### PR TITLE
More nuanced type spec generation for object type

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -32,6 +32,19 @@ func TestFunctionsTs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestWebserverTs(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "webserver-ts"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				assertHTTPMatchesContent(t, stack.Outputs["instanceIP"].(string), "Hello, World!\n", nil)
+			},
+			SkipRefresh: true,
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestPubSubTs(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -150,7 +150,11 @@ func assertHTTPResultShapeWithRetry(t *testing.T, output interface{}, headers ma
 }
 
 func assertHTTPHelloWorld(t *testing.T, output interface{}, headers map[string]string) bool {
+	return assertHTTPMatchesContent(t, output, "Hello, World!", headers)
+}
+
+func assertHTTPMatchesContent(t *testing.T, output interface{}, content string, headers map[string]string) bool {
 	return assertHTTPResult(t, output, headers, func(s string) bool {
-		return assert.Equal(t, "Hello, World!", s)
+		return assert.Equal(t, content, s)
 	})
 }

--- a/examples/webserver-ts/Pulumi.yaml
+++ b/examples/webserver-ts/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: webserver-ts
+runtime: nodejs
+description: Basic example of an Google Cloud web server accessible over HTTP
+template:
+  config:
+    gcp-native:project:
+      description: The Google Cloud project to deploy into
+    gcp-native:zone:
+      description: The Google Cloud zone
+      default: us-central1-a

--- a/examples/webserver-ts/README.md
+++ b/examples/webserver-ts/README.md
@@ -1,0 +1,79 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new)
+
+# Web Server Using Compute Engine
+
+Starting point for building the Pulumi web server sample in Google Cloud.
+
+## Running the App
+
+1.  Create a new stack:
+
+    ```
+    $ pulumi stack init dev
+    ```
+
+1.  Configure the project:
+
+    ```
+    $ pulumi config set gcp-native:project YOURGOOGLECLOUDPROJECT
+    $ pulumi config set gcp-native:zone us-central1-a
+    ```
+
+1.  Restore NPM dependencies:
+
+    ```
+    $ npm install
+    ```
+
+1.  Run `pulumi up` to preview and deploy changes:
+
+    ``` 
+    $ pulumi up
+    Previewing changes:
+    ...
+
+    Performing changes:
+
+     Type                               Name                                       Status      
+ +   pulumi:pulumi:Stack                webserver-ts-dev                           created     
+ +   ├─ gcp-native:compute/v1:Network   network                                    created     
+ +   ├─ gcp-native:compute/v1:Firewall  firewall                                   created     
+ +   └─ gcp-native:compute/v1:Instance  instance                                   created 
+
+    ---outputs:---
+    instanceIP  : "35.224.37.178"
+    instanceLink: "....webserver-instance"
+
+    info: 4 changes performed:
+        + 4 resources created
+    Update duration: 57.918455655s
+    ```
+
+1.  Curl the HTTP server:
+
+    ```
+    $ curl $(pulumi stack output instanceIP)
+    Hello, World!
+    ```
+
+1.  SSH into the server:
+
+    ```
+    $ gcloud compute ssh $(pulumi stack output instanceName)
+    Warning: Permanently added 'compute.967481934451185713' (ECDSA) to the list of known hosts.
+
+    The programs included with the Debian GNU/Linux system are free software;
+    the exact distribution terms for each program are described in the
+    individual files in /usr/share/doc/*/copyright.
+
+    Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+    permitted by applicable law.
+    luke@instance-8ad9bd8:~$
+    ```
+
+1. Cleanup
+
+    ```
+    $ pulumi destroy
+    $ pulumi stack rm
+    ```

--- a/examples/webserver-ts/index.ts
+++ b/examples/webserver-ts/index.ts
@@ -1,0 +1,66 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as gcp from "@pulumi/gcp-native";
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config("gcp-native");
+const project = config.require("project");
+const zone = config.require("zone");
+
+const networkName = "webserver-net";
+const computeNetwork = new gcp.compute.v1.Network("network", {
+    autoCreateSubnetworks: true,
+    project: project,
+    network: networkName,
+    name: networkName,
+});
+
+const firewallName = "webserver-fw";
+const computeFirewall = new gcp.compute.v1.Firewall("firewall", {
+    network: computeNetwork.selfLink,
+    firewall: firewallName,
+    name: firewallName,
+    project: project,
+    allowed: [{
+        IPProtocol: "tcp",
+        ports: ["22", "80"],
+    }],
+});
+
+// (optional) create a simple web server using the startup script for the instance
+const startupScript = `#!/bin/bash
+echo "Hello, World!" > index.html
+nohup python -m SimpleHTTPServer 80 &`;
+
+const instanceName = "webserver-instance";
+const computeInstance = new gcp.compute.v1.Instance("instance", {
+    name: instanceName,
+    instance: instanceName,
+    project: project,
+    zone: zone,
+    machineType: `projects/${project}/zones/${zone}/machineTypes/f1-micro`,
+    metadata: {
+        items: [{
+            "key": "startup-script",
+            "value": startupScript,
+        }],
+    },
+    disks: [
+        {
+            boot: true,
+            initializeParams: {
+                sourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20181210",
+            },
+        },
+    ],
+    networkInterfaces: [{
+        network: computeNetwork.id,
+        accessConfigs: [{}], // must be empty to request an ephemeral IP
+    }],
+    serviceAccounts: [{
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+    }],
+}, { dependsOn: [computeFirewall] });
+
+exports.instanceLink = computeInstance.selfLink;
+exports.instanceIP = computeInstance.networkInterfaces[0].accessConfigs[0].natIP;

--- a/examples/webserver-ts/package.json
+++ b/examples/webserver-ts/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "webserver-gcp",
+    "version": "0.1.0",
+    "main": "index.js",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0b"
+    }
+}

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -491,6 +491,13 @@ func (g *packageGenerator) genTypeSpec(prop *discovery.JsonSchema, isOutput bool
 	case prop.Type == "any":
 		return &schema.TypeSpec{Ref: "pulumi.json#/Any"}, nil
 	case prop.Type != "":
+		if prop.Type == "object" {
+			for _, p := range prop.Properties {
+				if p.Type != "" && p.Type != "string" {
+					return &schema.TypeSpec{Ref: "pulumi.json#/Any"}, nil
+				}
+			}
+		}
 		return &schema.TypeSpec{Type: prop.Type}, nil
 	case prop.Ref != "":
 		tok := fmt.Sprintf(`%s:%s:%s`, g.pkg.Name, g.mod, prop.Ref)

--- a/provider/pkg/provider/debug.go
+++ b/provider/pkg/provider/debug.go
@@ -1,0 +1,1 @@
+package provider

--- a/sdk/dotnet/BigQuery/V2/Inputs/BqmlTrainingRunArgs.cs
+++ b/sdk/dotnet/BigQuery/V2/Inputs/BqmlTrainingRunArgs.cs
@@ -36,17 +36,11 @@ namespace Pulumi.GcpNative.BigQuery.V2.Inputs
         [Input("state")]
         public Input<string>? State { get; set; }
 
-        [Input("trainingOptions")]
-        private InputMap<string>? _trainingOptions;
-
         /// <summary>
         /// [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
         /// </summary>
-        public InputMap<string> TrainingOptions
-        {
-            get => _trainingOptions ?? (_trainingOptions = new InputMap<string>());
-            set => _trainingOptions = value;
-        }
+        [Input("trainingOptions")]
+        public Input<object>? TrainingOptions { get; set; }
 
         public BqmlTrainingRunArgs()
         {

--- a/sdk/dotnet/BigQuery/V2/Inputs/ModelDefinitionArgs.cs
+++ b/sdk/dotnet/BigQuery/V2/Inputs/ModelDefinitionArgs.cs
@@ -12,17 +12,11 @@ namespace Pulumi.GcpNative.BigQuery.V2.Inputs
 
     public sealed class ModelDefinitionArgs : Pulumi.ResourceArgs
     {
-        [Input("modelOptions")]
-        private InputMap<string>? _modelOptions;
-
         /// <summary>
         /// [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
         /// </summary>
-        public InputMap<string> ModelOptions
-        {
-            get => _modelOptions ?? (_modelOptions = new InputMap<string>());
-            set => _modelOptions = value;
-        }
+        [Input("modelOptions")]
+        public Input<object>? ModelOptions { get; set; }
 
         [Input("trainingRuns")]
         private InputList<Inputs.BqmlTrainingRunArgs>? _trainingRuns;

--- a/sdk/dotnet/BigQuery/V2/Inputs/TableFieldSchemaArgs.cs
+++ b/sdk/dotnet/BigQuery/V2/Inputs/TableFieldSchemaArgs.cs
@@ -12,17 +12,11 @@ namespace Pulumi.GcpNative.BigQuery.V2.Inputs
 
     public sealed class TableFieldSchemaArgs : Pulumi.ResourceArgs
     {
-        [Input("categories")]
-        private InputMap<string>? _categories;
-
         /// <summary>
         /// [Optional] The categories attached to this field, used for field-level access control.
         /// </summary>
-        public InputMap<string> Categories
-        {
-            get => _categories ?? (_categories = new InputMap<string>());
-            set => _categories = value;
-        }
+        [Input("categories")]
+        public Input<object>? Categories { get; set; }
 
         /// <summary>
         /// [Optional] The field description. The maximum length is 1,024 characters.
@@ -61,12 +55,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Inputs
         public Input<string>? Name { get; set; }
 
         [Input("policyTags")]
-        private InputMap<string>? _policyTags;
-        public InputMap<string> PolicyTags
-        {
-            get => _policyTags ?? (_policyTags = new InputMap<string>());
-            set => _policyTags = value;
-        }
+        public Input<object>? PolicyTags { get; set; }
 
         /// <summary>
         /// [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.

--- a/sdk/dotnet/BigQuery/V2/Outputs/BqmlTrainingRunResponse.cs
+++ b/sdk/dotnet/BigQuery/V2/Outputs/BqmlTrainingRunResponse.cs
@@ -28,7 +28,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
         /// <summary>
         /// [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
         /// </summary>
-        public readonly ImmutableDictionary<string, string> TrainingOptions;
+        public readonly object TrainingOptions;
 
         [OutputConstructor]
         private BqmlTrainingRunResponse(
@@ -38,7 +38,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
 
             string state,
 
-            ImmutableDictionary<string, string> trainingOptions)
+            object trainingOptions)
         {
             IterationResults = iterationResults;
             StartTime = startTime;

--- a/sdk/dotnet/BigQuery/V2/Outputs/ModelDefinitionResponse.cs
+++ b/sdk/dotnet/BigQuery/V2/Outputs/ModelDefinitionResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
         /// <summary>
         /// [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
         /// </summary>
-        public readonly ImmutableDictionary<string, string> ModelOptions;
+        public readonly object ModelOptions;
         /// <summary>
         /// [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
         /// </summary>
@@ -24,7 +24,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
 
         [OutputConstructor]
         private ModelDefinitionResponse(
-            ImmutableDictionary<string, string> modelOptions,
+            object modelOptions,
 
             ImmutableArray<Outputs.BqmlTrainingRunResponse> trainingRuns)
         {

--- a/sdk/dotnet/BigQuery/V2/Outputs/TableFieldSchemaResponse.cs
+++ b/sdk/dotnet/BigQuery/V2/Outputs/TableFieldSchemaResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
         /// <summary>
         /// [Optional] The categories attached to this field, used for field-level access control.
         /// </summary>
-        public readonly ImmutableDictionary<string, string> Categories;
+        public readonly object Categories;
         /// <summary>
         /// [Optional] The field description. The maximum length is 1,024 characters.
         /// </summary>
@@ -37,7 +37,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
         /// [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
         /// </summary>
         public readonly string Name;
-        public readonly ImmutableDictionary<string, string> PolicyTags;
+        public readonly object PolicyTags;
         /// <summary>
         /// [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
         /// </summary>
@@ -53,7 +53,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
 
         [OutputConstructor]
         private TableFieldSchemaResponse(
-            ImmutableDictionary<string, string> categories,
+            object categories,
 
             string description,
 
@@ -65,7 +65,7 @@ namespace Pulumi.GcpNative.BigQuery.V2.Outputs
 
             string name,
 
-            ImmutableDictionary<string, string> policyTags,
+            object policyTags,
 
             string precision,
 

--- a/sdk/dotnet/Compute/Alpha/Firewall.cs
+++ b/sdk/dotnet/Compute/Alpha/Firewall.cs
@@ -19,7 +19,7 @@ namespace Pulumi.GcpNative.Compute.Alpha
         /// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         /// </summary>
         [Output("allowed")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Allowed { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Allowed { get; private set; } = null!;
 
         /// <summary>
         /// [Output Only] Creation timestamp in RFC3339 text format.
@@ -31,7 +31,7 @@ namespace Pulumi.GcpNative.Compute.Alpha
         /// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         /// </summary>
         [Output("denied")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Denied { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Denied { get; private set; } = null!;
 
         /// <summary>
         /// An optional description of this resource. Provide this field when you create the resource.
@@ -186,14 +186,14 @@ namespace Pulumi.GcpNative.Compute.Alpha
     public sealed class FirewallArgs : Pulumi.ResourceArgs
     {
         [Input("allowed")]
-        private InputList<ImmutableDictionary<string, string>>? _allowed;
+        private InputList<object>? _allowed;
 
         /// <summary>
         /// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Allowed
+        public InputList<object> Allowed
         {
-            get => _allowed ?? (_allowed = new InputList<ImmutableDictionary<string, string>>());
+            get => _allowed ?? (_allowed = new InputList<object>());
             set => _allowed = value;
         }
 
@@ -204,14 +204,14 @@ namespace Pulumi.GcpNative.Compute.Alpha
         public Input<string>? CreationTimestamp { get; set; }
 
         [Input("denied")]
-        private InputList<ImmutableDictionary<string, string>>? _denied;
+        private InputList<object>? _denied;
 
         /// <summary>
         /// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Denied
+        public InputList<object> Denied
         {
-            get => _denied ?? (_denied = new InputList<ImmutableDictionary<string, string>>());
+            get => _denied ?? (_denied = new InputList<object>());
             set => _denied = value;
         }
 

--- a/sdk/dotnet/Compute/Alpha/Route.cs
+++ b/sdk/dotnet/Compute/Alpha/Route.cs
@@ -137,7 +137,7 @@ namespace Pulumi.GcpNative.Compute.Alpha
         /// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         /// </summary>
         [Output("warnings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Warnings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Warnings { get; private set; } = null!;
 
 
         /// <summary>
@@ -321,14 +321,14 @@ namespace Pulumi.GcpNative.Compute.Alpha
         }
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/Compute/Alpha/SslPolicy.cs
+++ b/sdk/dotnet/Compute/Alpha/SslPolicy.cs
@@ -94,7 +94,7 @@ namespace Pulumi.GcpNative.Compute.Alpha
         /// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         /// </summary>
         [Output("warnings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Warnings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Warnings { get; private set; } = null!;
 
 
         /// <summary>
@@ -241,14 +241,14 @@ namespace Pulumi.GcpNative.Compute.Alpha
         public Input<Inputs.ServerTlsSettingsArgs>? TlsSettings { get; set; }
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/Compute/Beta/Firewall.cs
+++ b/sdk/dotnet/Compute/Beta/Firewall.cs
@@ -19,7 +19,7 @@ namespace Pulumi.GcpNative.Compute.Beta
         /// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         /// </summary>
         [Output("allowed")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Allowed { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Allowed { get; private set; } = null!;
 
         /// <summary>
         /// [Output Only] Creation timestamp in RFC3339 text format.
@@ -31,7 +31,7 @@ namespace Pulumi.GcpNative.Compute.Beta
         /// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         /// </summary>
         [Output("denied")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Denied { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Denied { get; private set; } = null!;
 
         /// <summary>
         /// An optional description of this resource. Provide this field when you create the resource.
@@ -180,14 +180,14 @@ namespace Pulumi.GcpNative.Compute.Beta
     public sealed class FirewallArgs : Pulumi.ResourceArgs
     {
         [Input("allowed")]
-        private InputList<ImmutableDictionary<string, string>>? _allowed;
+        private InputList<object>? _allowed;
 
         /// <summary>
         /// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Allowed
+        public InputList<object> Allowed
         {
-            get => _allowed ?? (_allowed = new InputList<ImmutableDictionary<string, string>>());
+            get => _allowed ?? (_allowed = new InputList<object>());
             set => _allowed = value;
         }
 
@@ -198,14 +198,14 @@ namespace Pulumi.GcpNative.Compute.Beta
         public Input<string>? CreationTimestamp { get; set; }
 
         [Input("denied")]
-        private InputList<ImmutableDictionary<string, string>>? _denied;
+        private InputList<object>? _denied;
 
         /// <summary>
         /// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Denied
+        public InputList<object> Denied
         {
-            get => _denied ?? (_denied = new InputList<ImmutableDictionary<string, string>>());
+            get => _denied ?? (_denied = new InputList<object>());
             set => _denied = value;
         }
 

--- a/sdk/dotnet/Compute/Beta/Route.cs
+++ b/sdk/dotnet/Compute/Beta/Route.cs
@@ -125,7 +125,7 @@ namespace Pulumi.GcpNative.Compute.Beta
         /// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         /// </summary>
         [Output("warnings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Warnings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Warnings { get; private set; } = null!;
 
 
         /// <summary>
@@ -297,14 +297,14 @@ namespace Pulumi.GcpNative.Compute.Beta
         }
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/Compute/Beta/SslPolicy.cs
+++ b/sdk/dotnet/Compute/Beta/SslPolicy.cs
@@ -82,7 +82,7 @@ namespace Pulumi.GcpNative.Compute.Beta
         /// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         /// </summary>
         [Output("warnings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Warnings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Warnings { get; private set; } = null!;
 
 
         /// <summary>
@@ -217,14 +217,14 @@ namespace Pulumi.GcpNative.Compute.Beta
         public Input<string> SslPolicy { get; set; } = null!;
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/Compute/V1/Firewall.cs
+++ b/sdk/dotnet/Compute/V1/Firewall.cs
@@ -19,7 +19,7 @@ namespace Pulumi.GcpNative.Compute.V1
         /// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         /// </summary>
         [Output("allowed")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Allowed { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Allowed { get; private set; } = null!;
 
         /// <summary>
         /// [Output Only] Creation timestamp in RFC3339 text format.
@@ -31,7 +31,7 @@ namespace Pulumi.GcpNative.Compute.V1
         /// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         /// </summary>
         [Output("denied")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Denied { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Denied { get; private set; } = null!;
 
         /// <summary>
         /// An optional description of this resource. Provide this field when you create the resource.
@@ -174,14 +174,14 @@ namespace Pulumi.GcpNative.Compute.V1
     public sealed class FirewallArgs : Pulumi.ResourceArgs
     {
         [Input("allowed")]
-        private InputList<ImmutableDictionary<string, string>>? _allowed;
+        private InputList<object>? _allowed;
 
         /// <summary>
         /// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Allowed
+        public InputList<object> Allowed
         {
-            get => _allowed ?? (_allowed = new InputList<ImmutableDictionary<string, string>>());
+            get => _allowed ?? (_allowed = new InputList<object>());
             set => _allowed = value;
         }
 
@@ -192,14 +192,14 @@ namespace Pulumi.GcpNative.Compute.V1
         public Input<string>? CreationTimestamp { get; set; }
 
         [Input("denied")]
-        private InputList<ImmutableDictionary<string, string>>? _denied;
+        private InputList<object>? _denied;
 
         /// <summary>
         /// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Denied
+        public InputList<object> Denied
         {
-            get => _denied ?? (_denied = new InputList<ImmutableDictionary<string, string>>());
+            get => _denied ?? (_denied = new InputList<object>());
             set => _denied = value;
         }
 

--- a/sdk/dotnet/Compute/V1/Route.cs
+++ b/sdk/dotnet/Compute/V1/Route.cs
@@ -119,7 +119,7 @@ namespace Pulumi.GcpNative.Compute.V1
         /// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         /// </summary>
         [Output("warnings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Warnings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Warnings { get; private set; } = null!;
 
 
         /// <summary>
@@ -285,14 +285,14 @@ namespace Pulumi.GcpNative.Compute.V1
         }
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/Compute/V1/SslPolicy.cs
+++ b/sdk/dotnet/Compute/V1/SslPolicy.cs
@@ -82,7 +82,7 @@ namespace Pulumi.GcpNative.Compute.V1
         /// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         /// </summary>
         [Output("warnings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Warnings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Warnings { get; private set; } = null!;
 
 
         /// <summary>
@@ -217,14 +217,14 @@ namespace Pulumi.GcpNative.Compute.V1
         public Input<string> SslPolicy { get; set; } = null!;
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/DeploymentManager/Alpha/Inputs/OperationArgs.cs
+++ b/sdk/dotnet/DeploymentManager/Alpha/Inputs/OperationArgs.cs
@@ -39,17 +39,11 @@ namespace Pulumi.GcpNative.DeploymentManager.Alpha.Inputs
         [Input("endTime")]
         public Input<string>? EndTime { get; set; }
 
-        [Input("error")]
-        private InputMap<string>? _error;
-
         /// <summary>
         /// [Output Only] If errors are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public InputMap<string> Error
-        {
-            get => _error ?? (_error = new InputMap<string>());
-            set => _error = value;
-        }
+        [Input("error")]
+        public Input<object>? Error { get; set; }
 
         /// <summary>
         /// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -154,14 +148,14 @@ namespace Pulumi.GcpNative.DeploymentManager.Alpha.Inputs
         public Input<string>? User { get; set; }
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/DeploymentManager/Alpha/Outputs/OperationResponse.cs
+++ b/sdk/dotnet/DeploymentManager/Alpha/Outputs/OperationResponse.cs
@@ -32,7 +32,7 @@ namespace Pulumi.GcpNative.DeploymentManager.Alpha.Outputs
         /// <summary>
         /// [Output Only] If errors are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public readonly ImmutableDictionary<string, string> Error;
+        public readonly object Error;
         /// <summary>
         /// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         /// </summary>
@@ -100,7 +100,7 @@ namespace Pulumi.GcpNative.DeploymentManager.Alpha.Outputs
         /// <summary>
         /// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public readonly ImmutableArray<ImmutableDictionary<string, string>> Warnings;
+        public readonly ImmutableArray<object> Warnings;
         /// <summary>
         /// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         /// </summary>
@@ -116,7 +116,7 @@ namespace Pulumi.GcpNative.DeploymentManager.Alpha.Outputs
 
             string endTime,
 
-            ImmutableDictionary<string, string> error,
+            object error,
 
             string httpErrorMessage,
 
@@ -150,7 +150,7 @@ namespace Pulumi.GcpNative.DeploymentManager.Alpha.Outputs
 
             string user,
 
-            ImmutableArray<ImmutableDictionary<string, string>> warnings,
+            ImmutableArray<object> warnings,
 
             string zone)
         {

--- a/sdk/dotnet/DeploymentManager/V2/Inputs/OperationArgs.cs
+++ b/sdk/dotnet/DeploymentManager/V2/Inputs/OperationArgs.cs
@@ -39,17 +39,11 @@ namespace Pulumi.GcpNative.DeploymentManager.V2.Inputs
         [Input("endTime")]
         public Input<string>? EndTime { get; set; }
 
-        [Input("error")]
-        private InputMap<string>? _error;
-
         /// <summary>
         /// [Output Only] If errors are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public InputMap<string> Error
-        {
-            get => _error ?? (_error = new InputMap<string>());
-            set => _error = value;
-        }
+        [Input("error")]
+        public Input<object>? Error { get; set; }
 
         /// <summary>
         /// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -154,14 +148,14 @@ namespace Pulumi.GcpNative.DeploymentManager.V2.Inputs
         public Input<string>? User { get; set; }
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/DeploymentManager/V2/Outputs/OperationResponse.cs
+++ b/sdk/dotnet/DeploymentManager/V2/Outputs/OperationResponse.cs
@@ -32,7 +32,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2.Outputs
         /// <summary>
         /// [Output Only] If errors are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public readonly ImmutableDictionary<string, string> Error;
+        public readonly object Error;
         /// <summary>
         /// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         /// </summary>
@@ -100,7 +100,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2.Outputs
         /// <summary>
         /// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public readonly ImmutableArray<ImmutableDictionary<string, string>> Warnings;
+        public readonly ImmutableArray<object> Warnings;
         /// <summary>
         /// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         /// </summary>
@@ -116,7 +116,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2.Outputs
 
             string endTime,
 
-            ImmutableDictionary<string, string> error,
+            object error,
 
             string httpErrorMessage,
 
@@ -150,7 +150,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2.Outputs
 
             string user,
 
-            ImmutableArray<ImmutableDictionary<string, string>> warnings,
+            ImmutableArray<object> warnings,
 
             string zone)
         {

--- a/sdk/dotnet/DeploymentManager/V2Beta/Inputs/OperationArgs.cs
+++ b/sdk/dotnet/DeploymentManager/V2Beta/Inputs/OperationArgs.cs
@@ -39,17 +39,11 @@ namespace Pulumi.GcpNative.DeploymentManager.V2Beta.Inputs
         [Input("endTime")]
         public Input<string>? EndTime { get; set; }
 
-        [Input("error")]
-        private InputMap<string>? _error;
-
         /// <summary>
         /// [Output Only] If errors are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public InputMap<string> Error
-        {
-            get => _error ?? (_error = new InputMap<string>());
-            set => _error = value;
-        }
+        [Input("error")]
+        public Input<object>? Error { get; set; }
 
         /// <summary>
         /// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -154,14 +148,14 @@ namespace Pulumi.GcpNative.DeploymentManager.V2Beta.Inputs
         public Input<string>? User { get; set; }
 
         [Input("warnings")]
-        private InputList<ImmutableDictionary<string, string>>? _warnings;
+        private InputList<object>? _warnings;
 
         /// <summary>
         /// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Warnings
+        public InputList<object> Warnings
         {
-            get => _warnings ?? (_warnings = new InputList<ImmutableDictionary<string, string>>());
+            get => _warnings ?? (_warnings = new InputList<object>());
             set => _warnings = value;
         }
 

--- a/sdk/dotnet/DeploymentManager/V2Beta/Outputs/OperationResponse.cs
+++ b/sdk/dotnet/DeploymentManager/V2Beta/Outputs/OperationResponse.cs
@@ -32,7 +32,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2Beta.Outputs
         /// <summary>
         /// [Output Only] If errors are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public readonly ImmutableDictionary<string, string> Error;
+        public readonly object Error;
         /// <summary>
         /// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         /// </summary>
@@ -100,7 +100,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2Beta.Outputs
         /// <summary>
         /// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         /// </summary>
-        public readonly ImmutableArray<ImmutableDictionary<string, string>> Warnings;
+        public readonly ImmutableArray<object> Warnings;
         /// <summary>
         /// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         /// </summary>
@@ -116,7 +116,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2Beta.Outputs
 
             string endTime,
 
-            ImmutableDictionary<string, string> error,
+            object error,
 
             string httpErrorMessage,
 
@@ -150,7 +150,7 @@ namespace Pulumi.GcpNative.DeploymentManager.V2Beta.Outputs
 
             string user,
 
-            ImmutableArray<ImmutableDictionary<string, string>> warnings,
+            ImmutableArray<object> warnings,
 
             string zone)
         {

--- a/sdk/dotnet/SQLAdmin/V1Beta4/Instance.cs
+++ b/sdk/dotnet/SQLAdmin/V1Beta4/Instance.cs
@@ -61,7 +61,7 @@ namespace Pulumi.GcpNative.SQLAdmin.V1Beta4
         /// The name and status of the failover replica. This property is applicable only to Second Generation instances.
         /// </summary>
         [Output("failoverReplica")]
-        public Output<ImmutableDictionary<string, string>> FailoverReplica { get; private set; } = null!;
+        public Output<object> FailoverReplica { get; private set; } = null!;
 
         /// <summary>
         /// The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
@@ -288,17 +288,11 @@ namespace Pulumi.GcpNative.SQLAdmin.V1Beta4
         [Input("etag")]
         public Input<string>? Etag { get; set; }
 
-        [Input("failoverReplica")]
-        private InputMap<string>? _failoverReplica;
-
         /// <summary>
         /// The name and status of the failover replica. This property is applicable only to Second Generation instances.
         /// </summary>
-        public InputMap<string> FailoverReplica
-        {
-            get => _failoverReplica ?? (_failoverReplica = new InputMap<string>());
-            set => _failoverReplica = value;
-        }
+        [Input("failoverReplica")]
+        public Input<object>? FailoverReplica { get; set; }
 
         /// <summary>
         /// The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.

--- a/sdk/dotnet/Storage/V1/Bucket.cs
+++ b/sdk/dotnet/Storage/V1/Bucket.cs
@@ -25,13 +25,13 @@ namespace Pulumi.GcpNative.Storage.V1
         /// The bucket's billing configuration.
         /// </summary>
         [Output("billing")]
-        public Output<ImmutableDictionary<string, string>> Billing { get; private set; } = null!;
+        public Output<object> Billing { get; private set; } = null!;
 
         /// <summary>
         /// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
         /// </summary>
         [Output("cors")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Cors { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Cors { get; private set; } = null!;
 
         /// <summary>
         /// The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
@@ -61,7 +61,7 @@ namespace Pulumi.GcpNative.Storage.V1
         /// The bucket's IAM configuration.
         /// </summary>
         [Output("iamConfiguration")]
-        public Output<ImmutableDictionary<string, string>> IamConfiguration { get; private set; } = null!;
+        public Output<object> IamConfiguration { get; private set; } = null!;
 
         /// <summary>
         /// The kind of item this is. For buckets, this is always storage#bucket.
@@ -79,7 +79,7 @@ namespace Pulumi.GcpNative.Storage.V1
         /// The bucket's lifecycle configuration. See lifecycle management for more information.
         /// </summary>
         [Output("lifecycle")]
-        public Output<ImmutableDictionary<string, string>> Lifecycle { get; private set; } = null!;
+        public Output<object> Lifecycle { get; private set; } = null!;
 
         /// <summary>
         /// The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
@@ -127,7 +127,7 @@ namespace Pulumi.GcpNative.Storage.V1
         /// The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
         /// </summary>
         [Output("retentionPolicy")]
-        public Output<ImmutableDictionary<string, string>> RetentionPolicy { get; private set; } = null!;
+        public Output<object> RetentionPolicy { get; private set; } = null!;
 
         /// <summary>
         /// Reserved for future use.
@@ -163,7 +163,7 @@ namespace Pulumi.GcpNative.Storage.V1
         /// The bucket's versioning configuration.
         /// </summary>
         [Output("versioning")]
-        public Output<ImmutableDictionary<string, string>> Versioning { get; private set; } = null!;
+        public Output<object> Versioning { get; private set; } = null!;
 
         /// <summary>
         /// The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
@@ -234,30 +234,24 @@ namespace Pulumi.GcpNative.Storage.V1
             set => _acl = value;
         }
 
-        [Input("billing")]
-        private InputMap<string>? _billing;
-
         /// <summary>
         /// The bucket's billing configuration.
         /// </summary>
-        public InputMap<string> Billing
-        {
-            get => _billing ?? (_billing = new InputMap<string>());
-            set => _billing = value;
-        }
+        [Input("billing")]
+        public Input<object>? Billing { get; set; }
 
         [Input("bucket", required: true)]
         public Input<string> Bucket { get; set; } = null!;
 
         [Input("cors")]
-        private InputList<ImmutableDictionary<string, string>>? _cors;
+        private InputList<object>? _cors;
 
         /// <summary>
         /// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Cors
+        public InputList<object> Cors
         {
-            get => _cors ?? (_cors = new InputList<ImmutableDictionary<string, string>>());
+            get => _cors ?? (_cors = new InputList<object>());
             set => _cors = value;
         }
 
@@ -297,17 +291,11 @@ namespace Pulumi.GcpNative.Storage.V1
         [Input("etag")]
         public Input<string>? Etag { get; set; }
 
-        [Input("iamConfiguration")]
-        private InputMap<string>? _iamConfiguration;
-
         /// <summary>
         /// The bucket's IAM configuration.
         /// </summary>
-        public InputMap<string> IamConfiguration
-        {
-            get => _iamConfiguration ?? (_iamConfiguration = new InputMap<string>());
-            set => _iamConfiguration = value;
-        }
+        [Input("iamConfiguration")]
+        public Input<object>? IamConfiguration { get; set; }
 
         /// <summary>
         /// The ID of the bucket. For buckets, the id and name properties are the same.
@@ -333,17 +321,11 @@ namespace Pulumi.GcpNative.Storage.V1
             set => _labels = value;
         }
 
-        [Input("lifecycle")]
-        private InputMap<string>? _lifecycle;
-
         /// <summary>
         /// The bucket's lifecycle configuration. See lifecycle management for more information.
         /// </summary>
-        public InputMap<string> Lifecycle
-        {
-            get => _lifecycle ?? (_lifecycle = new InputMap<string>());
-            set => _lifecycle = value;
-        }
+        [Input("lifecycle")]
+        public Input<object>? Lifecycle { get; set; }
 
         /// <summary>
         /// The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
@@ -402,17 +384,11 @@ namespace Pulumi.GcpNative.Storage.V1
         [Input("projectNumber")]
         public Input<string>? ProjectNumber { get; set; }
 
-        [Input("retentionPolicy")]
-        private InputMap<string>? _retentionPolicy;
-
         /// <summary>
         /// The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
         /// </summary>
-        public InputMap<string> RetentionPolicy
-        {
-            get => _retentionPolicy ?? (_retentionPolicy = new InputMap<string>());
-            set => _retentionPolicy = value;
-        }
+        [Input("retentionPolicy")]
+        public Input<object>? RetentionPolicy { get; set; }
 
         /// <summary>
         /// Reserved for future use.
@@ -444,17 +420,11 @@ namespace Pulumi.GcpNative.Storage.V1
         [Input("updated")]
         public Input<string>? Updated { get; set; }
 
-        [Input("versioning")]
-        private InputMap<string>? _versioning;
-
         /// <summary>
         /// The bucket's versioning configuration.
         /// </summary>
-        public InputMap<string> Versioning
-        {
-            get => _versioning ?? (_versioning = new InputMap<string>());
-            set => _versioning = value;
-        }
+        [Input("versioning")]
+        public Input<object>? Versioning { get; set; }
 
         [Input("website")]
         private InputMap<string>? _website;

--- a/sdk/dotnet/Storage/V1/BucketIamPolicy.cs
+++ b/sdk/dotnet/Storage/V1/BucketIamPolicy.cs
@@ -19,7 +19,7 @@ namespace Pulumi.GcpNative.Storage.V1
         /// An association between a role, which comes with a set of permissions, and members who may assume that role.
         /// </summary>
         [Output("bindings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Bindings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Bindings { get; private set; } = null!;
 
         /// <summary>
         /// HTTP 1.1  Entity tag for the policy.
@@ -91,14 +91,14 @@ namespace Pulumi.GcpNative.Storage.V1
     public sealed class BucketIamPolicyArgs : Pulumi.ResourceArgs
     {
         [Input("bindings")]
-        private InputList<ImmutableDictionary<string, string>>? _bindings;
+        private InputList<object>? _bindings;
 
         /// <summary>
         /// An association between a role, which comes with a set of permissions, and members who may assume that role.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Bindings
+        public InputList<object> Bindings
         {
-            get => _bindings ?? (_bindings = new InputList<ImmutableDictionary<string, string>>());
+            get => _bindings ?? (_bindings = new InputList<object>());
             set => _bindings = value;
         }
 

--- a/sdk/dotnet/Storage/V1/ObjectIamPolicy.cs
+++ b/sdk/dotnet/Storage/V1/ObjectIamPolicy.cs
@@ -19,7 +19,7 @@ namespace Pulumi.GcpNative.Storage.V1
         /// An association between a role, which comes with a set of permissions, and members who may assume that role.
         /// </summary>
         [Output("bindings")]
-        public Output<ImmutableArray<ImmutableDictionary<string, string>>> Bindings { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Bindings { get; private set; } = null!;
 
         /// <summary>
         /// HTTP 1.1  Entity tag for the policy.
@@ -91,14 +91,14 @@ namespace Pulumi.GcpNative.Storage.V1
     public sealed class ObjectIamPolicyArgs : Pulumi.ResourceArgs
     {
         [Input("bindings")]
-        private InputList<ImmutableDictionary<string, string>>? _bindings;
+        private InputList<object>? _bindings;
 
         /// <summary>
         /// An association between a role, which comes with a set of permissions, and members who may assume that role.
         /// </summary>
-        public InputList<ImmutableDictionary<string, string>> Bindings
+        public InputList<object> Bindings
         {
-            get => _bindings ?? (_bindings = new InputList<ImmutableDictionary<string, string>>());
+            get => _bindings ?? (_bindings = new InputList<object>());
             set => _bindings = value;
         }
 

--- a/sdk/go/gcp/bigquery/v2/pulumiTypes.go
+++ b/sdk/go/gcp/bigquery/v2/pulumiTypes.go
@@ -2392,7 +2392,7 @@ type BqmlTrainingRun struct {
 	// [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
 	State *string `pulumi:"state"`
 	// [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
-	TrainingOptions map[string]string `pulumi:"trainingOptions"`
+	TrainingOptions interface{} `pulumi:"trainingOptions"`
 }
 
 // BqmlTrainingRunInput is an input type that accepts BqmlTrainingRunArgs and BqmlTrainingRunOutput values.
@@ -2414,7 +2414,7 @@ type BqmlTrainingRunArgs struct {
 	// [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
 	State pulumi.StringPtrInput `pulumi:"state"`
 	// [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
-	TrainingOptions pulumi.StringMapInput `pulumi:"trainingOptions"`
+	TrainingOptions pulumi.Input `pulumi:"trainingOptions"`
 }
 
 func (BqmlTrainingRunArgs) ElementType() reflect.Type {
@@ -2484,8 +2484,8 @@ func (o BqmlTrainingRunOutput) State() pulumi.StringPtrOutput {
 }
 
 // [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
-func (o BqmlTrainingRunOutput) TrainingOptions() pulumi.StringMapOutput {
-	return o.ApplyT(func(v BqmlTrainingRun) map[string]string { return v.TrainingOptions }).(pulumi.StringMapOutput)
+func (o BqmlTrainingRunOutput) TrainingOptions() pulumi.AnyOutput {
+	return o.ApplyT(func(v BqmlTrainingRun) interface{} { return v.TrainingOptions }).(pulumi.AnyOutput)
 }
 
 type BqmlTrainingRunArrayOutput struct{ *pulumi.OutputState }
@@ -2516,7 +2516,7 @@ type BqmlTrainingRunResponse struct {
 	// [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
 	State string `pulumi:"state"`
 	// [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
-	TrainingOptions map[string]string `pulumi:"trainingOptions"`
+	TrainingOptions interface{} `pulumi:"trainingOptions"`
 }
 
 // BqmlTrainingRunResponseInput is an input type that accepts BqmlTrainingRunResponseArgs and BqmlTrainingRunResponseOutput values.
@@ -2538,7 +2538,7 @@ type BqmlTrainingRunResponseArgs struct {
 	// [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
 	State pulumi.StringInput `pulumi:"state"`
 	// [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
-	TrainingOptions pulumi.StringMapInput `pulumi:"trainingOptions"`
+	TrainingOptions pulumi.Input `pulumi:"trainingOptions"`
 }
 
 func (BqmlTrainingRunResponseArgs) ElementType() reflect.Type {
@@ -2608,8 +2608,8 @@ func (o BqmlTrainingRunResponseOutput) State() pulumi.StringOutput {
 }
 
 // [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
-func (o BqmlTrainingRunResponseOutput) TrainingOptions() pulumi.StringMapOutput {
-	return o.ApplyT(func(v BqmlTrainingRunResponse) map[string]string { return v.TrainingOptions }).(pulumi.StringMapOutput)
+func (o BqmlTrainingRunResponseOutput) TrainingOptions() pulumi.AnyOutput {
+	return o.ApplyT(func(v BqmlTrainingRunResponse) interface{} { return v.TrainingOptions }).(pulumi.AnyOutput)
 }
 
 type BqmlTrainingRunResponseArrayOutput struct{ *pulumi.OutputState }
@@ -15496,7 +15496,7 @@ func (o MaterializedViewDefinitionResponsePtrOutput) RefreshIntervalMs() pulumi.
 
 type ModelDefinition struct {
 	// [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-	ModelOptions map[string]string `pulumi:"modelOptions"`
+	ModelOptions interface{} `pulumi:"modelOptions"`
 	// [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
 	TrainingRuns []BqmlTrainingRun `pulumi:"trainingRuns"`
 }
@@ -15514,7 +15514,7 @@ type ModelDefinitionInput interface {
 
 type ModelDefinitionArgs struct {
 	// [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-	ModelOptions pulumi.StringMapInput `pulumi:"modelOptions"`
+	ModelOptions pulumi.Input `pulumi:"modelOptions"`
 	// [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
 	TrainingRuns BqmlTrainingRunArrayInput `pulumi:"trainingRuns"`
 }
@@ -15597,8 +15597,8 @@ func (o ModelDefinitionOutput) ToModelDefinitionPtrOutputWithContext(ctx context
 }
 
 // [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-func (o ModelDefinitionOutput) ModelOptions() pulumi.StringMapOutput {
-	return o.ApplyT(func(v ModelDefinition) map[string]string { return v.ModelOptions }).(pulumi.StringMapOutput)
+func (o ModelDefinitionOutput) ModelOptions() pulumi.AnyOutput {
+	return o.ApplyT(func(v ModelDefinition) interface{} { return v.ModelOptions }).(pulumi.AnyOutput)
 }
 
 // [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
@@ -15625,13 +15625,13 @@ func (o ModelDefinitionPtrOutput) Elem() ModelDefinitionOutput {
 }
 
 // [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-func (o ModelDefinitionPtrOutput) ModelOptions() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *ModelDefinition) map[string]string {
+func (o ModelDefinitionPtrOutput) ModelOptions() pulumi.AnyOutput {
+	return o.ApplyT(func(v *ModelDefinition) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.ModelOptions
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
@@ -15646,7 +15646,7 @@ func (o ModelDefinitionPtrOutput) TrainingRuns() BqmlTrainingRunArrayOutput {
 
 type ModelDefinitionResponse struct {
 	// [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-	ModelOptions map[string]string `pulumi:"modelOptions"`
+	ModelOptions interface{} `pulumi:"modelOptions"`
 	// [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
 	TrainingRuns []BqmlTrainingRunResponse `pulumi:"trainingRuns"`
 }
@@ -15664,7 +15664,7 @@ type ModelDefinitionResponseInput interface {
 
 type ModelDefinitionResponseArgs struct {
 	// [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-	ModelOptions pulumi.StringMapInput `pulumi:"modelOptions"`
+	ModelOptions pulumi.Input `pulumi:"modelOptions"`
 	// [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
 	TrainingRuns BqmlTrainingRunResponseArrayInput `pulumi:"trainingRuns"`
 }
@@ -15747,8 +15747,8 @@ func (o ModelDefinitionResponseOutput) ToModelDefinitionResponsePtrOutputWithCon
 }
 
 // [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-func (o ModelDefinitionResponseOutput) ModelOptions() pulumi.StringMapOutput {
-	return o.ApplyT(func(v ModelDefinitionResponse) map[string]string { return v.ModelOptions }).(pulumi.StringMapOutput)
+func (o ModelDefinitionResponseOutput) ModelOptions() pulumi.AnyOutput {
+	return o.ApplyT(func(v ModelDefinitionResponse) interface{} { return v.ModelOptions }).(pulumi.AnyOutput)
 }
 
 // [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
@@ -15775,13 +15775,13 @@ func (o ModelDefinitionResponsePtrOutput) Elem() ModelDefinitionResponseOutput {
 }
 
 // [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
-func (o ModelDefinitionResponsePtrOutput) ModelOptions() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *ModelDefinitionResponse) map[string]string {
+func (o ModelDefinitionResponsePtrOutput) ModelOptions() pulumi.AnyOutput {
+	return o.ApplyT(func(v *ModelDefinitionResponse) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.ModelOptions
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
@@ -21430,7 +21430,7 @@ func (o StreamingbufferResponsePtrOutput) OldestEntryTime() pulumi.StringPtrOutp
 
 type TableFieldSchema struct {
 	// [Optional] The categories attached to this field, used for field-level access control.
-	Categories map[string]string `pulumi:"categories"`
+	Categories interface{} `pulumi:"categories"`
 	// [Optional] The field description. The maximum length is 1,024 characters.
 	Description *string `pulumi:"description"`
 	// [Optional] Describes the nested schema fields if the type property is set to RECORD.
@@ -21440,8 +21440,8 @@ type TableFieldSchema struct {
 	// [Optional] The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE.
 	Mode *string `pulumi:"mode"`
 	// [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
-	Name       *string           `pulumi:"name"`
-	PolicyTags map[string]string `pulumi:"policyTags"`
+	Name       *string     `pulumi:"name"`
+	PolicyTags interface{} `pulumi:"policyTags"`
 	// [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
 	Precision *string `pulumi:"precision"`
 	// [Optional] See documentation for precision.
@@ -21463,7 +21463,7 @@ type TableFieldSchemaInput interface {
 
 type TableFieldSchemaArgs struct {
 	// [Optional] The categories attached to this field, used for field-level access control.
-	Categories pulumi.StringMapInput `pulumi:"categories"`
+	Categories pulumi.Input `pulumi:"categories"`
 	// [Optional] The field description. The maximum length is 1,024 characters.
 	Description pulumi.StringPtrInput `pulumi:"description"`
 	// [Optional] Describes the nested schema fields if the type property is set to RECORD.
@@ -21474,7 +21474,7 @@ type TableFieldSchemaArgs struct {
 	Mode pulumi.StringPtrInput `pulumi:"mode"`
 	// [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
 	Name       pulumi.StringPtrInput `pulumi:"name"`
-	PolicyTags pulumi.StringMapInput `pulumi:"policyTags"`
+	PolicyTags pulumi.Input          `pulumi:"policyTags"`
 	// [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
 	Precision pulumi.StringPtrInput `pulumi:"precision"`
 	// [Optional] See documentation for precision.
@@ -21535,8 +21535,8 @@ func (o TableFieldSchemaOutput) ToTableFieldSchemaOutputWithContext(ctx context.
 }
 
 // [Optional] The categories attached to this field, used for field-level access control.
-func (o TableFieldSchemaOutput) Categories() pulumi.StringMapOutput {
-	return o.ApplyT(func(v TableFieldSchema) map[string]string { return v.Categories }).(pulumi.StringMapOutput)
+func (o TableFieldSchemaOutput) Categories() pulumi.AnyOutput {
+	return o.ApplyT(func(v TableFieldSchema) interface{} { return v.Categories }).(pulumi.AnyOutput)
 }
 
 // [Optional] The field description. The maximum length is 1,024 characters.
@@ -21564,8 +21564,8 @@ func (o TableFieldSchemaOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v TableFieldSchema) *string { return v.Name }).(pulumi.StringPtrOutput)
 }
 
-func (o TableFieldSchemaOutput) PolicyTags() pulumi.StringMapOutput {
-	return o.ApplyT(func(v TableFieldSchema) map[string]string { return v.PolicyTags }).(pulumi.StringMapOutput)
+func (o TableFieldSchemaOutput) PolicyTags() pulumi.AnyOutput {
+	return o.ApplyT(func(v TableFieldSchema) interface{} { return v.PolicyTags }).(pulumi.AnyOutput)
 }
 
 // [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
@@ -21605,7 +21605,7 @@ func (o TableFieldSchemaArrayOutput) Index(i pulumi.IntInput) TableFieldSchemaOu
 
 type TableFieldSchemaResponse struct {
 	// [Optional] The categories attached to this field, used for field-level access control.
-	Categories map[string]string `pulumi:"categories"`
+	Categories interface{} `pulumi:"categories"`
 	// [Optional] The field description. The maximum length is 1,024 characters.
 	Description string `pulumi:"description"`
 	// [Optional] Describes the nested schema fields if the type property is set to RECORD.
@@ -21615,8 +21615,8 @@ type TableFieldSchemaResponse struct {
 	// [Optional] The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE.
 	Mode string `pulumi:"mode"`
 	// [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
-	Name       string            `pulumi:"name"`
-	PolicyTags map[string]string `pulumi:"policyTags"`
+	Name       string      `pulumi:"name"`
+	PolicyTags interface{} `pulumi:"policyTags"`
 	// [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
 	Precision string `pulumi:"precision"`
 	// [Optional] See documentation for precision.
@@ -21638,7 +21638,7 @@ type TableFieldSchemaResponseInput interface {
 
 type TableFieldSchemaResponseArgs struct {
 	// [Optional] The categories attached to this field, used for field-level access control.
-	Categories pulumi.StringMapInput `pulumi:"categories"`
+	Categories pulumi.Input `pulumi:"categories"`
 	// [Optional] The field description. The maximum length is 1,024 characters.
 	Description pulumi.StringInput `pulumi:"description"`
 	// [Optional] Describes the nested schema fields if the type property is set to RECORD.
@@ -21648,8 +21648,8 @@ type TableFieldSchemaResponseArgs struct {
 	// [Optional] The field mode. Possible values include NULLABLE, REQUIRED and REPEATED. The default value is NULLABLE.
 	Mode pulumi.StringInput `pulumi:"mode"`
 	// [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
-	Name       pulumi.StringInput    `pulumi:"name"`
-	PolicyTags pulumi.StringMapInput `pulumi:"policyTags"`
+	Name       pulumi.StringInput `pulumi:"name"`
+	PolicyTags pulumi.Input       `pulumi:"policyTags"`
 	// [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
 	Precision pulumi.StringInput `pulumi:"precision"`
 	// [Optional] See documentation for precision.
@@ -21710,8 +21710,8 @@ func (o TableFieldSchemaResponseOutput) ToTableFieldSchemaResponseOutputWithCont
 }
 
 // [Optional] The categories attached to this field, used for field-level access control.
-func (o TableFieldSchemaResponseOutput) Categories() pulumi.StringMapOutput {
-	return o.ApplyT(func(v TableFieldSchemaResponse) map[string]string { return v.Categories }).(pulumi.StringMapOutput)
+func (o TableFieldSchemaResponseOutput) Categories() pulumi.AnyOutput {
+	return o.ApplyT(func(v TableFieldSchemaResponse) interface{} { return v.Categories }).(pulumi.AnyOutput)
 }
 
 // [Optional] The field description. The maximum length is 1,024 characters.
@@ -21739,8 +21739,8 @@ func (o TableFieldSchemaResponseOutput) Name() pulumi.StringOutput {
 	return o.ApplyT(func(v TableFieldSchemaResponse) string { return v.Name }).(pulumi.StringOutput)
 }
 
-func (o TableFieldSchemaResponseOutput) PolicyTags() pulumi.StringMapOutput {
-	return o.ApplyT(func(v TableFieldSchemaResponse) map[string]string { return v.PolicyTags }).(pulumi.StringMapOutput)
+func (o TableFieldSchemaResponseOutput) PolicyTags() pulumi.AnyOutput {
+	return o.ApplyT(func(v TableFieldSchemaResponse) interface{} { return v.PolicyTags }).(pulumi.AnyOutput)
 }
 
 // [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.

--- a/sdk/go/gcp/compute/alpha/firewall.go
+++ b/sdk/go/gcp/compute/alpha/firewall.go
@@ -16,11 +16,11 @@ type Firewall struct {
 	pulumi.CustomResourceState
 
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayOutput `pulumi:"allowed"`
+	Allowed pulumi.ArrayOutput `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringOutput `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayOutput `pulumi:"denied"`
+	Denied pulumi.ArrayOutput `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringOutput `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -98,11 +98,11 @@ func GetFirewall(ctx *pulumi.Context,
 // Input properties used for looking up and filtering Firewall resources.
 type firewallState struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed []map[string]string `pulumi:"allowed"`
+	Allowed []interface{} `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp *string `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied []map[string]string `pulumi:"denied"`
+	Denied []interface{} `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description *string `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -146,11 +146,11 @@ type firewallState struct {
 
 type FirewallState struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayInput
+	Allowed pulumi.ArrayInput
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringPtrInput
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayInput
+	Denied pulumi.ArrayInput
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringPtrInput
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -198,11 +198,11 @@ func (FirewallState) ElementType() reflect.Type {
 
 type firewallArgs struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed []map[string]string `pulumi:"allowed"`
+	Allowed []interface{} `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp *string `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied []map[string]string `pulumi:"denied"`
+	Denied []interface{} `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description *string `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -251,11 +251,11 @@ type firewallArgs struct {
 // The set of arguments for constructing a Firewall resource.
 type FirewallArgs struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayInput
+	Allowed pulumi.ArrayInput
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringPtrInput
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayInput
+	Denied pulumi.ArrayInput
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringPtrInput
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.

--- a/sdk/go/gcp/compute/alpha/route.go
+++ b/sdk/go/gcp/compute/alpha/route.go
@@ -58,7 +58,7 @@ type Route struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayOutput `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayOutput `pulumi:"warnings"`
+	Warnings pulumi.ArrayOutput `pulumi:"warnings"`
 }
 
 // NewRoute registers a new resource with the given unique name, arguments, and options.
@@ -139,7 +139,7 @@ type routeState struct {
 	// A list of instance tags to which this route applies.
 	Tags []string `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 type RouteState struct {
@@ -186,7 +186,7 @@ type RouteState struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayInput
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (RouteState) ElementType() reflect.Type {
@@ -241,7 +241,7 @@ type routeArgs struct {
 	// A list of instance tags to which this route applies.
 	Tags []string `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 // The set of arguments for constructing a Route resource.
@@ -293,7 +293,7 @@ type RouteArgs struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayInput
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (RouteArgs) ElementType() reflect.Type {

--- a/sdk/go/gcp/compute/alpha/sslPolicy.go
+++ b/sdk/go/gcp/compute/alpha/sslPolicy.go
@@ -43,7 +43,7 @@ type SslPolicy struct {
 	// Security settings for the proxy. This field is only applicable to a global backend service with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
 	TlsSettings ServerTlsSettingsResponseOutput `pulumi:"tlsSettings"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayOutput `pulumi:"warnings"`
+	Warnings pulumi.ArrayOutput `pulumi:"warnings"`
 }
 
 // NewSslPolicy registers a new resource with the given unique name, arguments, and options.
@@ -109,7 +109,7 @@ type sslPolicyState struct {
 	// Security settings for the proxy. This field is only applicable to a global backend service with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
 	TlsSettings *ServerTlsSettingsResponse `pulumi:"tlsSettings"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 type SslPolicyState struct {
@@ -141,7 +141,7 @@ type SslPolicyState struct {
 	// Security settings for the proxy. This field is only applicable to a global backend service with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
 	TlsSettings ServerTlsSettingsResponsePtrInput
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (SslPolicyState) ElementType() reflect.Type {
@@ -181,7 +181,7 @@ type sslPolicyArgs struct {
 	// Security settings for the proxy. This field is only applicable to a global backend service with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
 	TlsSettings *ServerTlsSettings `pulumi:"tlsSettings"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 // The set of arguments for constructing a SslPolicy resource.
@@ -218,7 +218,7 @@ type SslPolicyArgs struct {
 	// Security settings for the proxy. This field is only applicable to a global backend service with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
 	TlsSettings ServerTlsSettingsPtrInput
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (SslPolicyArgs) ElementType() reflect.Type {

--- a/sdk/go/gcp/compute/beta/firewall.go
+++ b/sdk/go/gcp/compute/beta/firewall.go
@@ -16,11 +16,11 @@ type Firewall struct {
 	pulumi.CustomResourceState
 
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayOutput `pulumi:"allowed"`
+	Allowed pulumi.ArrayOutput `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringOutput `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayOutput `pulumi:"denied"`
+	Denied pulumi.ArrayOutput `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringOutput `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -96,11 +96,11 @@ func GetFirewall(ctx *pulumi.Context,
 // Input properties used for looking up and filtering Firewall resources.
 type firewallState struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed []map[string]string `pulumi:"allowed"`
+	Allowed []interface{} `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp *string `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied []map[string]string `pulumi:"denied"`
+	Denied []interface{} `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description *string `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -142,11 +142,11 @@ type firewallState struct {
 
 type FirewallState struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayInput
+	Allowed pulumi.ArrayInput
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringPtrInput
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayInput
+	Denied pulumi.ArrayInput
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringPtrInput
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -192,11 +192,11 @@ func (FirewallState) ElementType() reflect.Type {
 
 type firewallArgs struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed []map[string]string `pulumi:"allowed"`
+	Allowed []interface{} `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp *string `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied []map[string]string `pulumi:"denied"`
+	Denied []interface{} `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description *string `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -243,11 +243,11 @@ type firewallArgs struct {
 // The set of arguments for constructing a Firewall resource.
 type FirewallArgs struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayInput
+	Allowed pulumi.ArrayInput
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringPtrInput
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayInput
+	Denied pulumi.ArrayInput
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringPtrInput
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.

--- a/sdk/go/gcp/compute/beta/route.go
+++ b/sdk/go/gcp/compute/beta/route.go
@@ -54,7 +54,7 @@ type Route struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayOutput `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayOutput `pulumi:"warnings"`
+	Warnings pulumi.ArrayOutput `pulumi:"warnings"`
 }
 
 // NewRoute registers a new resource with the given unique name, arguments, and options.
@@ -131,7 +131,7 @@ type routeState struct {
 	// A list of instance tags to which this route applies.
 	Tags []string `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 type RouteState struct {
@@ -174,7 +174,7 @@ type RouteState struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayInput
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (RouteState) ElementType() reflect.Type {
@@ -225,7 +225,7 @@ type routeArgs struct {
 	// A list of instance tags to which this route applies.
 	Tags []string `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 // The set of arguments for constructing a Route resource.
@@ -273,7 +273,7 @@ type RouteArgs struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayInput
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (RouteArgs) ElementType() reflect.Type {

--- a/sdk/go/gcp/compute/beta/sslPolicy.go
+++ b/sdk/go/gcp/compute/beta/sslPolicy.go
@@ -39,7 +39,7 @@ type SslPolicy struct {
 	// [Output Only] Server-defined URL for the resource.
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayOutput `pulumi:"warnings"`
+	Warnings pulumi.ArrayOutput `pulumi:"warnings"`
 }
 
 // NewSslPolicy registers a new resource with the given unique name, arguments, and options.
@@ -101,7 +101,7 @@ type sslPolicyState struct {
 	// [Output Only] Server-defined URL for the resource.
 	SelfLink *string `pulumi:"selfLink"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 type SslPolicyState struct {
@@ -129,7 +129,7 @@ type SslPolicyState struct {
 	// [Output Only] Server-defined URL for the resource.
 	SelfLink pulumi.StringPtrInput
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (SslPolicyState) ElementType() reflect.Type {
@@ -165,7 +165,7 @@ type sslPolicyArgs struct {
 	SelfLink  *string `pulumi:"selfLink"`
 	SslPolicy string  `pulumi:"sslPolicy"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 // The set of arguments for constructing a SslPolicy resource.
@@ -198,7 +198,7 @@ type SslPolicyArgs struct {
 	SelfLink  pulumi.StringPtrInput
 	SslPolicy pulumi.StringInput
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (SslPolicyArgs) ElementType() reflect.Type {

--- a/sdk/go/gcp/compute/v1/firewall.go
+++ b/sdk/go/gcp/compute/v1/firewall.go
@@ -16,11 +16,11 @@ type Firewall struct {
 	pulumi.CustomResourceState
 
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayOutput `pulumi:"allowed"`
+	Allowed pulumi.ArrayOutput `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringOutput `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayOutput `pulumi:"denied"`
+	Denied pulumi.ArrayOutput `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringOutput `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -94,11 +94,11 @@ func GetFirewall(ctx *pulumi.Context,
 // Input properties used for looking up and filtering Firewall resources.
 type firewallState struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed []map[string]string `pulumi:"allowed"`
+	Allowed []interface{} `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp *string `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied []map[string]string `pulumi:"denied"`
+	Denied []interface{} `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description *string `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -138,11 +138,11 @@ type firewallState struct {
 
 type FirewallState struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayInput
+	Allowed pulumi.ArrayInput
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringPtrInput
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayInput
+	Denied pulumi.ArrayInput
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringPtrInput
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -186,11 +186,11 @@ func (FirewallState) ElementType() reflect.Type {
 
 type firewallArgs struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed []map[string]string `pulumi:"allowed"`
+	Allowed []interface{} `pulumi:"allowed"`
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp *string `pulumi:"creationTimestamp"`
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied []map[string]string `pulumi:"denied"`
+	Denied []interface{} `pulumi:"denied"`
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description *string `pulumi:"description"`
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
@@ -235,11 +235,11 @@ type firewallArgs struct {
 // The set of arguments for constructing a Firewall resource.
 type FirewallArgs struct {
 	// The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
-	Allowed pulumi.StringMapArrayInput
+	Allowed pulumi.ArrayInput
 	// [Output Only] Creation timestamp in RFC3339 text format.
 	CreationTimestamp pulumi.StringPtrInput
 	// The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-	Denied pulumi.StringMapArrayInput
+	Denied pulumi.ArrayInput
 	// An optional description of this resource. Provide this field when you create the resource.
 	Description pulumi.StringPtrInput
 	// If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.

--- a/sdk/go/gcp/compute/v1/route.go
+++ b/sdk/go/gcp/compute/v1/route.go
@@ -52,7 +52,7 @@ type Route struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayOutput `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayOutput `pulumi:"warnings"`
+	Warnings pulumi.ArrayOutput `pulumi:"warnings"`
 }
 
 // NewRoute registers a new resource with the given unique name, arguments, and options.
@@ -127,7 +127,7 @@ type routeState struct {
 	// A list of instance tags to which this route applies.
 	Tags []string `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 type RouteState struct {
@@ -168,7 +168,7 @@ type RouteState struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayInput
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (RouteState) ElementType() reflect.Type {
@@ -217,7 +217,7 @@ type routeArgs struct {
 	// A list of instance tags to which this route applies.
 	Tags []string `pulumi:"tags"`
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 // The set of arguments for constructing a Route resource.
@@ -263,7 +263,7 @@ type RouteArgs struct {
 	// A list of instance tags to which this route applies.
 	Tags pulumi.StringArrayInput
 	// [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (RouteArgs) ElementType() reflect.Type {

--- a/sdk/go/gcp/compute/v1/sslPolicy.go
+++ b/sdk/go/gcp/compute/v1/sslPolicy.go
@@ -39,7 +39,7 @@ type SslPolicy struct {
 	// [Output Only] Server-defined URL for the resource.
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayOutput `pulumi:"warnings"`
+	Warnings pulumi.ArrayOutput `pulumi:"warnings"`
 }
 
 // NewSslPolicy registers a new resource with the given unique name, arguments, and options.
@@ -101,7 +101,7 @@ type sslPolicyState struct {
 	// [Output Only] Server-defined URL for the resource.
 	SelfLink *string `pulumi:"selfLink"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 type SslPolicyState struct {
@@ -129,7 +129,7 @@ type SslPolicyState struct {
 	// [Output Only] Server-defined URL for the resource.
 	SelfLink pulumi.StringPtrInput
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (SslPolicyState) ElementType() reflect.Type {
@@ -165,7 +165,7 @@ type sslPolicyArgs struct {
 	SelfLink  *string `pulumi:"selfLink"`
 	SslPolicy string  `pulumi:"sslPolicy"`
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 }
 
 // The set of arguments for constructing a SslPolicy resource.
@@ -198,7 +198,7 @@ type SslPolicyArgs struct {
 	SelfLink  pulumi.StringPtrInput
 	SslPolicy pulumi.StringInput
 	// [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-	Warnings pulumi.StringMapArrayInput
+	Warnings pulumi.ArrayInput
 }
 
 func (SslPolicyArgs) ElementType() reflect.Type {

--- a/sdk/go/gcp/deploymentmanager/alpha/pulumiTypes.go
+++ b/sdk/go/gcp/deploymentmanager/alpha/pulumiTypes.go
@@ -4541,7 +4541,7 @@ type Operation struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime *string `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error map[string]string `pulumi:"error"`
+	Error interface{} `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage *string `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -4577,7 +4577,7 @@ type Operation struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User *string `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone *string `pulumi:"zone"`
 }
@@ -4604,7 +4604,7 @@ type OperationArgs struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime pulumi.StringPtrInput `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error pulumi.StringMapInput `pulumi:"error"`
+	Error pulumi.Input `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage pulumi.StringPtrInput `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -4640,7 +4640,7 @@ type OperationArgs struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User pulumi.StringPtrInput `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings pulumi.StringMapArrayInput `pulumi:"warnings"`
+	Warnings pulumi.ArrayInput `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone pulumi.StringPtrInput `pulumi:"zone"`
 }
@@ -4744,8 +4744,8 @@ func (o OperationOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v Operation) map[string]string { return v.Error }).(pulumi.StringMapOutput)
+func (o OperationOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v Operation) interface{} { return v.Error }).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -4834,8 +4834,8 @@ func (o OperationOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v Operation) []map[string]string { return v.Warnings }).(pulumi.StringMapArrayOutput)
+func (o OperationOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v Operation) []interface{} { return v.Warnings }).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -4902,13 +4902,13 @@ func (o OperationPtrOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationPtrOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *Operation) map[string]string {
+func (o OperationPtrOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v *Operation) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Error
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -5082,13 +5082,13 @@ func (o OperationPtrOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationPtrOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v *Operation) []map[string]string {
+func (o OperationPtrOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v *Operation) []interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Warnings
-	}).(pulumi.StringMapArrayOutput)
+	}).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -5112,7 +5112,7 @@ type OperationResponse struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime string `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error map[string]string `pulumi:"error"`
+	Error interface{} `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage string `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -5146,7 +5146,7 @@ type OperationResponse struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User string `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone string `pulumi:"zone"`
 }
@@ -5173,7 +5173,7 @@ type OperationResponseArgs struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime pulumi.StringInput `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error pulumi.StringMapInput `pulumi:"error"`
+	Error pulumi.Input `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage pulumi.StringInput `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -5207,7 +5207,7 @@ type OperationResponseArgs struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User pulumi.StringInput `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings pulumi.StringMapArrayInput `pulumi:"warnings"`
+	Warnings pulumi.ArrayInput `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone pulumi.StringInput `pulumi:"zone"`
 }
@@ -5311,8 +5311,8 @@ func (o OperationResponseOutput) EndTime() pulumi.StringOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationResponseOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v OperationResponse) map[string]string { return v.Error }).(pulumi.StringMapOutput)
+func (o OperationResponseOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v OperationResponse) interface{} { return v.Error }).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -5396,8 +5396,8 @@ func (o OperationResponseOutput) User() pulumi.StringOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationResponseOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v OperationResponse) []map[string]string { return v.Warnings }).(pulumi.StringMapArrayOutput)
+func (o OperationResponseOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v OperationResponse) []interface{} { return v.Warnings }).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -5464,13 +5464,13 @@ func (o OperationResponsePtrOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationResponsePtrOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *OperationResponse) map[string]string {
+func (o OperationResponsePtrOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v *OperationResponse) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Error
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -5634,13 +5634,13 @@ func (o OperationResponsePtrOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationResponsePtrOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v *OperationResponse) []map[string]string {
+func (o OperationResponsePtrOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v *OperationResponse) []interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Warnings
-	}).(pulumi.StringMapArrayOutput)
+	}).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.

--- a/sdk/go/gcp/deploymentmanager/v2/pulumiTypes.go
+++ b/sdk/go/gcp/deploymentmanager/v2/pulumiTypes.go
@@ -2214,7 +2214,7 @@ type Operation struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime *string `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error map[string]string `pulumi:"error"`
+	Error interface{} `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage *string `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -2250,7 +2250,7 @@ type Operation struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User *string `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone *string `pulumi:"zone"`
 }
@@ -2277,7 +2277,7 @@ type OperationArgs struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime pulumi.StringPtrInput `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error pulumi.StringMapInput `pulumi:"error"`
+	Error pulumi.Input `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage pulumi.StringPtrInput `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -2313,7 +2313,7 @@ type OperationArgs struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User pulumi.StringPtrInput `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings pulumi.StringMapArrayInput `pulumi:"warnings"`
+	Warnings pulumi.ArrayInput `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone pulumi.StringPtrInput `pulumi:"zone"`
 }
@@ -2417,8 +2417,8 @@ func (o OperationOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v Operation) map[string]string { return v.Error }).(pulumi.StringMapOutput)
+func (o OperationOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v Operation) interface{} { return v.Error }).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -2507,8 +2507,8 @@ func (o OperationOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v Operation) []map[string]string { return v.Warnings }).(pulumi.StringMapArrayOutput)
+func (o OperationOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v Operation) []interface{} { return v.Warnings }).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -2575,13 +2575,13 @@ func (o OperationPtrOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationPtrOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *Operation) map[string]string {
+func (o OperationPtrOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v *Operation) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Error
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -2755,13 +2755,13 @@ func (o OperationPtrOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationPtrOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v *Operation) []map[string]string {
+func (o OperationPtrOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v *Operation) []interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Warnings
-	}).(pulumi.StringMapArrayOutput)
+	}).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -2785,7 +2785,7 @@ type OperationResponse struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime string `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error map[string]string `pulumi:"error"`
+	Error interface{} `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage string `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -2819,7 +2819,7 @@ type OperationResponse struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User string `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone string `pulumi:"zone"`
 }
@@ -2846,7 +2846,7 @@ type OperationResponseArgs struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime pulumi.StringInput `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error pulumi.StringMapInput `pulumi:"error"`
+	Error pulumi.Input `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage pulumi.StringInput `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -2880,7 +2880,7 @@ type OperationResponseArgs struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User pulumi.StringInput `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings pulumi.StringMapArrayInput `pulumi:"warnings"`
+	Warnings pulumi.ArrayInput `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone pulumi.StringInput `pulumi:"zone"`
 }
@@ -2984,8 +2984,8 @@ func (o OperationResponseOutput) EndTime() pulumi.StringOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationResponseOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v OperationResponse) map[string]string { return v.Error }).(pulumi.StringMapOutput)
+func (o OperationResponseOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v OperationResponse) interface{} { return v.Error }).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -3069,8 +3069,8 @@ func (o OperationResponseOutput) User() pulumi.StringOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationResponseOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v OperationResponse) []map[string]string { return v.Warnings }).(pulumi.StringMapArrayOutput)
+func (o OperationResponseOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v OperationResponse) []interface{} { return v.Warnings }).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -3137,13 +3137,13 @@ func (o OperationResponsePtrOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationResponsePtrOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *OperationResponse) map[string]string {
+func (o OperationResponsePtrOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v *OperationResponse) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Error
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -3307,13 +3307,13 @@ func (o OperationResponsePtrOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationResponsePtrOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v *OperationResponse) []map[string]string {
+func (o OperationResponsePtrOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v *OperationResponse) []interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Warnings
-	}).(pulumi.StringMapArrayOutput)
+	}).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.

--- a/sdk/go/gcp/deploymentmanager/v2beta/pulumiTypes.go
+++ b/sdk/go/gcp/deploymentmanager/v2beta/pulumiTypes.go
@@ -3966,7 +3966,7 @@ type Operation struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime *string `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error map[string]string `pulumi:"error"`
+	Error interface{} `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage *string `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -4002,7 +4002,7 @@ type Operation struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User *string `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone *string `pulumi:"zone"`
 }
@@ -4029,7 +4029,7 @@ type OperationArgs struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime pulumi.StringPtrInput `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error pulumi.StringMapInput `pulumi:"error"`
+	Error pulumi.Input `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage pulumi.StringPtrInput `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -4065,7 +4065,7 @@ type OperationArgs struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User pulumi.StringPtrInput `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings pulumi.StringMapArrayInput `pulumi:"warnings"`
+	Warnings pulumi.ArrayInput `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone pulumi.StringPtrInput `pulumi:"zone"`
 }
@@ -4169,8 +4169,8 @@ func (o OperationOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v Operation) map[string]string { return v.Error }).(pulumi.StringMapOutput)
+func (o OperationOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v Operation) interface{} { return v.Error }).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -4259,8 +4259,8 @@ func (o OperationOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v Operation) []map[string]string { return v.Warnings }).(pulumi.StringMapArrayOutput)
+func (o OperationOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v Operation) []interface{} { return v.Warnings }).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -4327,13 +4327,13 @@ func (o OperationPtrOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationPtrOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *Operation) map[string]string {
+func (o OperationPtrOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v *Operation) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Error
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -4507,13 +4507,13 @@ func (o OperationPtrOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationPtrOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v *Operation) []map[string]string {
+func (o OperationPtrOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v *Operation) []interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Warnings
-	}).(pulumi.StringMapArrayOutput)
+	}).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -4537,7 +4537,7 @@ type OperationResponse struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime string `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error map[string]string `pulumi:"error"`
+	Error interface{} `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage string `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -4571,7 +4571,7 @@ type OperationResponse struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User string `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings []map[string]string `pulumi:"warnings"`
+	Warnings []interface{} `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone string `pulumi:"zone"`
 }
@@ -4598,7 +4598,7 @@ type OperationResponseArgs struct {
 	// [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
 	EndTime pulumi.StringInput `pulumi:"endTime"`
 	// [Output Only] If errors are generated during processing of the operation, this field will be populated.
-	Error pulumi.StringMapInput `pulumi:"error"`
+	Error pulumi.Input `pulumi:"error"`
 	// [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
 	HttpErrorMessage pulumi.StringInput `pulumi:"httpErrorMessage"`
 	// [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
@@ -4632,7 +4632,7 @@ type OperationResponseArgs struct {
 	// [Output Only] User who requested the operation, for example: `user@example.com`.
 	User pulumi.StringInput `pulumi:"user"`
 	// [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-	Warnings pulumi.StringMapArrayInput `pulumi:"warnings"`
+	Warnings pulumi.ArrayInput `pulumi:"warnings"`
 	// [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
 	Zone pulumi.StringInput `pulumi:"zone"`
 }
@@ -4736,8 +4736,8 @@ func (o OperationResponseOutput) EndTime() pulumi.StringOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationResponseOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v OperationResponse) map[string]string { return v.Error }).(pulumi.StringMapOutput)
+func (o OperationResponseOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v OperationResponse) interface{} { return v.Error }).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -4821,8 +4821,8 @@ func (o OperationResponseOutput) User() pulumi.StringOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationResponseOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v OperationResponse) []map[string]string { return v.Warnings }).(pulumi.StringMapArrayOutput)
+func (o OperationResponseOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v OperationResponse) []interface{} { return v.Warnings }).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
@@ -4889,13 +4889,13 @@ func (o OperationResponsePtrOutput) EndTime() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-func (o OperationResponsePtrOutput) Error() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *OperationResponse) map[string]string {
+func (o OperationResponsePtrOutput) Error() pulumi.AnyOutput {
+	return o.ApplyT(func(v *OperationResponse) interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Error
-	}).(pulumi.StringMapOutput)
+	}).(pulumi.AnyOutput)
 }
 
 // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
@@ -5059,13 +5059,13 @@ func (o OperationResponsePtrOutput) User() pulumi.StringPtrOutput {
 }
 
 // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-func (o OperationResponsePtrOutput) Warnings() pulumi.StringMapArrayOutput {
-	return o.ApplyT(func(v *OperationResponse) []map[string]string {
+func (o OperationResponsePtrOutput) Warnings() pulumi.ArrayOutput {
+	return o.ApplyT(func(v *OperationResponse) []interface{} {
 		if v == nil {
 			return nil
 		}
 		return v.Warnings
-	}).(pulumi.StringMapArrayOutput)
+	}).(pulumi.ArrayOutput)
 }
 
 // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.

--- a/sdk/go/gcp/sqladmin/v1beta4/instance.go
+++ b/sdk/go/gcp/sqladmin/v1beta4/instance.go
@@ -30,7 +30,7 @@ type Instance struct {
 	// This field is deprecated and will be removed from a future version of the API. Use the *settings.settingsVersion* field instead.
 	Etag pulumi.StringOutput `pulumi:"etag"`
 	// The name and status of the failover replica. This property is applicable only to Second Generation instances.
-	FailoverReplica pulumi.StringMapOutput `pulumi:"failoverReplica"`
+	FailoverReplica pulumi.AnyOutput `pulumi:"failoverReplica"`
 	// The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
 	GceZone pulumi.StringOutput `pulumi:"gceZone"`
 	// The instance type. This can be one of the following. *CLOUD_SQL_INSTANCE*: A Cloud SQL instance that is not replicating from a primary instance. *ON_PREMISES_INSTANCE*: An instance running on the customer's premises. *READ_REPLICA_INSTANCE*: A Cloud SQL instance configured as a read-replica.
@@ -129,7 +129,7 @@ type instanceState struct {
 	// This field is deprecated and will be removed from a future version of the API. Use the *settings.settingsVersion* field instead.
 	Etag *string `pulumi:"etag"`
 	// The name and status of the failover replica. This property is applicable only to Second Generation instances.
-	FailoverReplica map[string]string `pulumi:"failoverReplica"`
+	FailoverReplica interface{} `pulumi:"failoverReplica"`
 	// The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
 	GceZone *string `pulumi:"gceZone"`
 	// The instance type. This can be one of the following. *CLOUD_SQL_INSTANCE*: A Cloud SQL instance that is not replicating from a primary instance. *ON_PREMISES_INSTANCE*: An instance running on the customer's premises. *READ_REPLICA_INSTANCE*: A Cloud SQL instance configured as a read-replica.
@@ -194,7 +194,7 @@ type InstanceState struct {
 	// This field is deprecated and will be removed from a future version of the API. Use the *settings.settingsVersion* field instead.
 	Etag pulumi.StringPtrInput
 	// The name and status of the failover replica. This property is applicable only to Second Generation instances.
-	FailoverReplica pulumi.StringMapInput
+	FailoverReplica pulumi.Input
 	// The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
 	GceZone pulumi.StringPtrInput
 	// The instance type. This can be one of the following. *CLOUD_SQL_INSTANCE*: A Cloud SQL instance that is not replicating from a primary instance. *ON_PREMISES_INSTANCE*: An instance running on the customer's premises. *READ_REPLICA_INSTANCE*: A Cloud SQL instance configured as a read-replica.
@@ -263,7 +263,7 @@ type instanceArgs struct {
 	// This field is deprecated and will be removed from a future version of the API. Use the *settings.settingsVersion* field instead.
 	Etag *string `pulumi:"etag"`
 	// The name and status of the failover replica. This property is applicable only to Second Generation instances.
-	FailoverReplica map[string]string `pulumi:"failoverReplica"`
+	FailoverReplica interface{} `pulumi:"failoverReplica"`
 	// The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
 	GceZone  *string `pulumi:"gceZone"`
 	Instance string  `pulumi:"instance"`
@@ -330,7 +330,7 @@ type InstanceArgs struct {
 	// This field is deprecated and will be removed from a future version of the API. Use the *settings.settingsVersion* field instead.
 	Etag pulumi.StringPtrInput
 	// The name and status of the failover replica. This property is applicable only to Second Generation instances.
-	FailoverReplica pulumi.StringMapInput
+	FailoverReplica pulumi.Input
 	// The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
 	GceZone  pulumi.StringPtrInput
 	Instance pulumi.StringInput

--- a/sdk/go/gcp/storage/v1/bucket.go
+++ b/sdk/go/gcp/storage/v1/bucket.go
@@ -18,9 +18,9 @@ type Bucket struct {
 	// Access controls on the bucket.
 	Acl BucketAccessControlResponseArrayOutput `pulumi:"acl"`
 	// The bucket's billing configuration.
-	Billing pulumi.StringMapOutput `pulumi:"billing"`
+	Billing pulumi.AnyOutput `pulumi:"billing"`
 	// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
-	Cors pulumi.StringMapArrayOutput `pulumi:"cors"`
+	Cors pulumi.ArrayOutput `pulumi:"cors"`
 	// The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
 	DefaultEventBasedHold pulumi.BoolOutput `pulumi:"defaultEventBasedHold"`
 	// Default access controls to apply to new objects when no ACL is provided.
@@ -30,13 +30,13 @@ type Bucket struct {
 	// HTTP 1.1 Entity tag for the bucket.
 	Etag pulumi.StringOutput `pulumi:"etag"`
 	// The bucket's IAM configuration.
-	IamConfiguration pulumi.StringMapOutput `pulumi:"iamConfiguration"`
+	IamConfiguration pulumi.AnyOutput `pulumi:"iamConfiguration"`
 	// The kind of item this is. For buckets, this is always storage#bucket.
 	Kind pulumi.StringOutput `pulumi:"kind"`
 	// User-provided labels, in key/value pairs.
 	Labels pulumi.StringMapOutput `pulumi:"labels"`
 	// The bucket's lifecycle configuration. See lifecycle management for more information.
-	Lifecycle pulumi.StringMapOutput `pulumi:"lifecycle"`
+	Lifecycle pulumi.AnyOutput `pulumi:"lifecycle"`
 	// The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
 	Location pulumi.StringOutput `pulumi:"location"`
 	// The type of the bucket location.
@@ -52,7 +52,7 @@ type Bucket struct {
 	// The project number of the project the bucket belongs to.
 	ProjectNumber pulumi.StringOutput `pulumi:"projectNumber"`
 	// The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
-	RetentionPolicy pulumi.StringMapOutput `pulumi:"retentionPolicy"`
+	RetentionPolicy pulumi.AnyOutput `pulumi:"retentionPolicy"`
 	// Reserved for future use.
 	SatisfiesPZS pulumi.BoolOutput `pulumi:"satisfiesPZS"`
 	// The URI of this bucket.
@@ -64,7 +64,7 @@ type Bucket struct {
 	// The modification time of the bucket in RFC 3339 format.
 	Updated pulumi.StringOutput `pulumi:"updated"`
 	// The bucket's versioning configuration.
-	Versioning pulumi.StringMapOutput `pulumi:"versioning"`
+	Versioning pulumi.AnyOutput `pulumi:"versioning"`
 	// The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
 	Website pulumi.StringMapOutput `pulumi:"website"`
 	// The zone or zones from which the bucket is intended to use zonal quota. Requests for data from outside the specified affinities are still allowed but won't be able to use zonal quota. The zone or zones need to be within the bucket location otherwise the requests will fail with a 400 Bad Request response.
@@ -109,9 +109,9 @@ type bucketState struct {
 	// Access controls on the bucket.
 	Acl []BucketAccessControlResponse `pulumi:"acl"`
 	// The bucket's billing configuration.
-	Billing map[string]string `pulumi:"billing"`
+	Billing interface{} `pulumi:"billing"`
 	// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
-	Cors []map[string]string `pulumi:"cors"`
+	Cors []interface{} `pulumi:"cors"`
 	// The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
 	DefaultEventBasedHold *bool `pulumi:"defaultEventBasedHold"`
 	// Default access controls to apply to new objects when no ACL is provided.
@@ -121,13 +121,13 @@ type bucketState struct {
 	// HTTP 1.1 Entity tag for the bucket.
 	Etag *string `pulumi:"etag"`
 	// The bucket's IAM configuration.
-	IamConfiguration map[string]string `pulumi:"iamConfiguration"`
+	IamConfiguration interface{} `pulumi:"iamConfiguration"`
 	// The kind of item this is. For buckets, this is always storage#bucket.
 	Kind *string `pulumi:"kind"`
 	// User-provided labels, in key/value pairs.
 	Labels map[string]string `pulumi:"labels"`
 	// The bucket's lifecycle configuration. See lifecycle management for more information.
-	Lifecycle map[string]string `pulumi:"lifecycle"`
+	Lifecycle interface{} `pulumi:"lifecycle"`
 	// The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
 	Location *string `pulumi:"location"`
 	// The type of the bucket location.
@@ -143,7 +143,7 @@ type bucketState struct {
 	// The project number of the project the bucket belongs to.
 	ProjectNumber *string `pulumi:"projectNumber"`
 	// The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
-	RetentionPolicy map[string]string `pulumi:"retentionPolicy"`
+	RetentionPolicy interface{} `pulumi:"retentionPolicy"`
 	// Reserved for future use.
 	SatisfiesPZS *bool `pulumi:"satisfiesPZS"`
 	// The URI of this bucket.
@@ -155,7 +155,7 @@ type bucketState struct {
 	// The modification time of the bucket in RFC 3339 format.
 	Updated *string `pulumi:"updated"`
 	// The bucket's versioning configuration.
-	Versioning map[string]string `pulumi:"versioning"`
+	Versioning interface{} `pulumi:"versioning"`
 	// The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
 	Website map[string]string `pulumi:"website"`
 	// The zone or zones from which the bucket is intended to use zonal quota. Requests for data from outside the specified affinities are still allowed but won't be able to use zonal quota. The zone or zones need to be within the bucket location otherwise the requests will fail with a 400 Bad Request response.
@@ -166,9 +166,9 @@ type BucketState struct {
 	// Access controls on the bucket.
 	Acl BucketAccessControlResponseArrayInput
 	// The bucket's billing configuration.
-	Billing pulumi.StringMapInput
+	Billing pulumi.Input
 	// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
-	Cors pulumi.StringMapArrayInput
+	Cors pulumi.ArrayInput
 	// The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
 	DefaultEventBasedHold pulumi.BoolPtrInput
 	// Default access controls to apply to new objects when no ACL is provided.
@@ -178,13 +178,13 @@ type BucketState struct {
 	// HTTP 1.1 Entity tag for the bucket.
 	Etag pulumi.StringPtrInput
 	// The bucket's IAM configuration.
-	IamConfiguration pulumi.StringMapInput
+	IamConfiguration pulumi.Input
 	// The kind of item this is. For buckets, this is always storage#bucket.
 	Kind pulumi.StringPtrInput
 	// User-provided labels, in key/value pairs.
 	Labels pulumi.StringMapInput
 	// The bucket's lifecycle configuration. See lifecycle management for more information.
-	Lifecycle pulumi.StringMapInput
+	Lifecycle pulumi.Input
 	// The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
 	Location pulumi.StringPtrInput
 	// The type of the bucket location.
@@ -200,7 +200,7 @@ type BucketState struct {
 	// The project number of the project the bucket belongs to.
 	ProjectNumber pulumi.StringPtrInput
 	// The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
-	RetentionPolicy pulumi.StringMapInput
+	RetentionPolicy pulumi.Input
 	// Reserved for future use.
 	SatisfiesPZS pulumi.BoolPtrInput
 	// The URI of this bucket.
@@ -212,7 +212,7 @@ type BucketState struct {
 	// The modification time of the bucket in RFC 3339 format.
 	Updated pulumi.StringPtrInput
 	// The bucket's versioning configuration.
-	Versioning pulumi.StringMapInput
+	Versioning pulumi.Input
 	// The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
 	Website pulumi.StringMapInput
 	// The zone or zones from which the bucket is intended to use zonal quota. Requests for data from outside the specified affinities are still allowed but won't be able to use zonal quota. The zone or zones need to be within the bucket location otherwise the requests will fail with a 400 Bad Request response.
@@ -227,10 +227,10 @@ type bucketArgs struct {
 	// Access controls on the bucket.
 	Acl []BucketAccessControlType `pulumi:"acl"`
 	// The bucket's billing configuration.
-	Billing map[string]string `pulumi:"billing"`
-	Bucket  string            `pulumi:"bucket"`
+	Billing interface{} `pulumi:"billing"`
+	Bucket  string      `pulumi:"bucket"`
 	// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
-	Cors []map[string]string `pulumi:"cors"`
+	Cors []interface{} `pulumi:"cors"`
 	// The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
 	DefaultEventBasedHold *bool `pulumi:"defaultEventBasedHold"`
 	// Default access controls to apply to new objects when no ACL is provided.
@@ -240,7 +240,7 @@ type bucketArgs struct {
 	// HTTP 1.1 Entity tag for the bucket.
 	Etag *string `pulumi:"etag"`
 	// The bucket's IAM configuration.
-	IamConfiguration map[string]string `pulumi:"iamConfiguration"`
+	IamConfiguration interface{} `pulumi:"iamConfiguration"`
 	// The ID of the bucket. For buckets, the id and name properties are the same.
 	Id *string `pulumi:"id"`
 	// The kind of item this is. For buckets, this is always storage#bucket.
@@ -248,7 +248,7 @@ type bucketArgs struct {
 	// User-provided labels, in key/value pairs.
 	Labels map[string]string `pulumi:"labels"`
 	// The bucket's lifecycle configuration. See lifecycle management for more information.
-	Lifecycle map[string]string `pulumi:"lifecycle"`
+	Lifecycle interface{} `pulumi:"lifecycle"`
 	// The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
 	Location *string `pulumi:"location"`
 	// The type of the bucket location.
@@ -265,7 +265,7 @@ type bucketArgs struct {
 	// The project number of the project the bucket belongs to.
 	ProjectNumber *string `pulumi:"projectNumber"`
 	// The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
-	RetentionPolicy map[string]string `pulumi:"retentionPolicy"`
+	RetentionPolicy interface{} `pulumi:"retentionPolicy"`
 	// Reserved for future use.
 	SatisfiesPZS *bool `pulumi:"satisfiesPZS"`
 	// The URI of this bucket.
@@ -277,7 +277,7 @@ type bucketArgs struct {
 	// The modification time of the bucket in RFC 3339 format.
 	Updated *string `pulumi:"updated"`
 	// The bucket's versioning configuration.
-	Versioning map[string]string `pulumi:"versioning"`
+	Versioning interface{} `pulumi:"versioning"`
 	// The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
 	Website map[string]string `pulumi:"website"`
 	// The zone or zones from which the bucket is intended to use zonal quota. Requests for data from outside the specified affinities are still allowed but won't be able to use zonal quota. The zone or zones need to be within the bucket location otherwise the requests will fail with a 400 Bad Request response.
@@ -289,10 +289,10 @@ type BucketArgs struct {
 	// Access controls on the bucket.
 	Acl BucketAccessControlTypeArrayInput
 	// The bucket's billing configuration.
-	Billing pulumi.StringMapInput
+	Billing pulumi.Input
 	Bucket  pulumi.StringInput
 	// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
-	Cors pulumi.StringMapArrayInput
+	Cors pulumi.ArrayInput
 	// The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
 	DefaultEventBasedHold pulumi.BoolPtrInput
 	// Default access controls to apply to new objects when no ACL is provided.
@@ -302,7 +302,7 @@ type BucketArgs struct {
 	// HTTP 1.1 Entity tag for the bucket.
 	Etag pulumi.StringPtrInput
 	// The bucket's IAM configuration.
-	IamConfiguration pulumi.StringMapInput
+	IamConfiguration pulumi.Input
 	// The ID of the bucket. For buckets, the id and name properties are the same.
 	Id pulumi.StringPtrInput
 	// The kind of item this is. For buckets, this is always storage#bucket.
@@ -310,7 +310,7 @@ type BucketArgs struct {
 	// User-provided labels, in key/value pairs.
 	Labels pulumi.StringMapInput
 	// The bucket's lifecycle configuration. See lifecycle management for more information.
-	Lifecycle pulumi.StringMapInput
+	Lifecycle pulumi.Input
 	// The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
 	Location pulumi.StringPtrInput
 	// The type of the bucket location.
@@ -327,7 +327,7 @@ type BucketArgs struct {
 	// The project number of the project the bucket belongs to.
 	ProjectNumber pulumi.StringPtrInput
 	// The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
-	RetentionPolicy pulumi.StringMapInput
+	RetentionPolicy pulumi.Input
 	// Reserved for future use.
 	SatisfiesPZS pulumi.BoolPtrInput
 	// The URI of this bucket.
@@ -339,7 +339,7 @@ type BucketArgs struct {
 	// The modification time of the bucket in RFC 3339 format.
 	Updated pulumi.StringPtrInput
 	// The bucket's versioning configuration.
-	Versioning pulumi.StringMapInput
+	Versioning pulumi.Input
 	// The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
 	Website pulumi.StringMapInput
 	// The zone or zones from which the bucket is intended to use zonal quota. Requests for data from outside the specified affinities are still allowed but won't be able to use zonal quota. The zone or zones need to be within the bucket location otherwise the requests will fail with a 400 Bad Request response.

--- a/sdk/go/gcp/storage/v1/bucketIamPolicy.go
+++ b/sdk/go/gcp/storage/v1/bucketIamPolicy.go
@@ -16,7 +16,7 @@ type BucketIamPolicy struct {
 	pulumi.CustomResourceState
 
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings pulumi.StringMapArrayOutput `pulumi:"bindings"`
+	Bindings pulumi.ArrayOutput `pulumi:"bindings"`
 	// HTTP 1.1  Entity tag for the policy.
 	Etag pulumi.StringOutput `pulumi:"etag"`
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -60,7 +60,7 @@ func GetBucketIamPolicy(ctx *pulumi.Context,
 // Input properties used for looking up and filtering BucketIamPolicy resources.
 type bucketIamPolicyState struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings []map[string]string `pulumi:"bindings"`
+	Bindings []interface{} `pulumi:"bindings"`
 	// HTTP 1.1  Entity tag for the policy.
 	Etag *string `pulumi:"etag"`
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -73,7 +73,7 @@ type bucketIamPolicyState struct {
 
 type BucketIamPolicyState struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings pulumi.StringMapArrayInput
+	Bindings pulumi.ArrayInput
 	// HTTP 1.1  Entity tag for the policy.
 	Etag pulumi.StringPtrInput
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -90,8 +90,8 @@ func (BucketIamPolicyState) ElementType() reflect.Type {
 
 type bucketIamPolicyArgs struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings []map[string]string `pulumi:"bindings"`
-	Bucket   string              `pulumi:"bucket"`
+	Bindings []interface{} `pulumi:"bindings"`
+	Bucket   string        `pulumi:"bucket"`
 	// HTTP 1.1  Entity tag for the policy.
 	Etag *string `pulumi:"etag"`
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -105,7 +105,7 @@ type bucketIamPolicyArgs struct {
 // The set of arguments for constructing a BucketIamPolicy resource.
 type BucketIamPolicyArgs struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings pulumi.StringMapArrayInput
+	Bindings pulumi.ArrayInput
 	Bucket   pulumi.StringInput
 	// HTTP 1.1  Entity tag for the policy.
 	Etag pulumi.StringPtrInput

--- a/sdk/go/gcp/storage/v1/objectIamPolicy.go
+++ b/sdk/go/gcp/storage/v1/objectIamPolicy.go
@@ -16,7 +16,7 @@ type ObjectIamPolicy struct {
 	pulumi.CustomResourceState
 
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings pulumi.StringMapArrayOutput `pulumi:"bindings"`
+	Bindings pulumi.ArrayOutput `pulumi:"bindings"`
 	// HTTP 1.1  Entity tag for the policy.
 	Etag pulumi.StringOutput `pulumi:"etag"`
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -63,7 +63,7 @@ func GetObjectIamPolicy(ctx *pulumi.Context,
 // Input properties used for looking up and filtering ObjectIamPolicy resources.
 type objectIamPolicyState struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings []map[string]string `pulumi:"bindings"`
+	Bindings []interface{} `pulumi:"bindings"`
 	// HTTP 1.1  Entity tag for the policy.
 	Etag *string `pulumi:"etag"`
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -76,7 +76,7 @@ type objectIamPolicyState struct {
 
 type ObjectIamPolicyState struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings pulumi.StringMapArrayInput
+	Bindings pulumi.ArrayInput
 	// HTTP 1.1  Entity tag for the policy.
 	Etag pulumi.StringPtrInput
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -93,8 +93,8 @@ func (ObjectIamPolicyState) ElementType() reflect.Type {
 
 type objectIamPolicyArgs struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings []map[string]string `pulumi:"bindings"`
-	Bucket   string              `pulumi:"bucket"`
+	Bindings []interface{} `pulumi:"bindings"`
+	Bucket   string        `pulumi:"bucket"`
 	// HTTP 1.1  Entity tag for the policy.
 	Etag *string `pulumi:"etag"`
 	// The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
@@ -109,7 +109,7 @@ type objectIamPolicyArgs struct {
 // The set of arguments for constructing a ObjectIamPolicy resource.
 type ObjectIamPolicyArgs struct {
 	// An association between a role, which comes with a set of permissions, and members who may assume that role.
-	Bindings pulumi.StringMapArrayInput
+	Bindings pulumi.ArrayInput
 	Bucket   pulumi.StringInput
 	// HTTP 1.1  Entity tag for the policy.
 	Etag pulumi.StringPtrInput

--- a/sdk/nodejs/compute/alpha/firewall.ts
+++ b/sdk/nodejs/compute/alpha/firewall.ts
@@ -38,7 +38,7 @@ export class Firewall extends pulumi.CustomResource {
     /**
      * The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
      */
-    public readonly allowed!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly allowed!: pulumi.Output<any[]>;
     /**
      * [Output Only] Creation timestamp in RFC3339 text format.
      */
@@ -46,7 +46,7 @@ export class Firewall extends pulumi.CustomResource {
     /**
      * The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
      */
-    public readonly denied!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly denied!: pulumi.Output<any[]>;
     /**
      * An optional description of this resource. Provide this field when you create the resource.
      */
@@ -197,7 +197,7 @@ export interface FirewallArgs {
     /**
      * The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
      */
-    readonly allowed?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly allowed?: pulumi.Input<any[]>;
     /**
      * [Output Only] Creation timestamp in RFC3339 text format.
      */
@@ -205,7 +205,7 @@ export interface FirewallArgs {
     /**
      * The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
      */
-    readonly denied?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly denied?: pulumi.Input<any[]>;
     /**
      * An optional description of this resource. Provide this field when you create the resource.
      */

--- a/sdk/nodejs/compute/alpha/route.ts
+++ b/sdk/nodejs/compute/alpha/route.ts
@@ -117,7 +117,7 @@ export class Route extends pulumi.CustomResource {
     /**
      * [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
      */
-    public readonly warnings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly warnings!: pulumi.Output<any[]>;
 
     /**
      * Create a Route resource with the given unique name, arguments, and options.
@@ -281,5 +281,5 @@ export interface RouteArgs {
     /**
      * [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
      */
-    readonly warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly warnings?: pulumi.Input<any[]>;
 }

--- a/sdk/nodejs/compute/alpha/sslPolicy.ts
+++ b/sdk/nodejs/compute/alpha/sslPolicy.ts
@@ -89,7 +89,7 @@ export class SslPolicy extends pulumi.CustomResource {
     /**
      * [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
      */
-    public readonly warnings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly warnings!: pulumi.Output<any[]>;
 
     /**
      * Create a SslPolicy resource with the given unique name, arguments, and options.
@@ -210,5 +210,5 @@ export interface SslPolicyArgs {
     /**
      * [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
      */
-    readonly warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly warnings?: pulumi.Input<any[]>;
 }

--- a/sdk/nodejs/compute/beta/firewall.ts
+++ b/sdk/nodejs/compute/beta/firewall.ts
@@ -38,7 +38,7 @@ export class Firewall extends pulumi.CustomResource {
     /**
      * The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
      */
-    public readonly allowed!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly allowed!: pulumi.Output<any[]>;
     /**
      * [Output Only] Creation timestamp in RFC3339 text format.
      */
@@ -46,7 +46,7 @@ export class Firewall extends pulumi.CustomResource {
     /**
      * The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
      */
-    public readonly denied!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly denied!: pulumi.Output<any[]>;
     /**
      * An optional description of this resource. Provide this field when you create the resource.
      */
@@ -191,7 +191,7 @@ export interface FirewallArgs {
     /**
      * The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
      */
-    readonly allowed?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly allowed?: pulumi.Input<any[]>;
     /**
      * [Output Only] Creation timestamp in RFC3339 text format.
      */
@@ -199,7 +199,7 @@ export interface FirewallArgs {
     /**
      * The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
      */
-    readonly denied?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly denied?: pulumi.Input<any[]>;
     /**
      * An optional description of this resource. Provide this field when you create the resource.
      */

--- a/sdk/nodejs/compute/beta/route.ts
+++ b/sdk/nodejs/compute/beta/route.ts
@@ -109,7 +109,7 @@ export class Route extends pulumi.CustomResource {
     /**
      * [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
      */
-    public readonly warnings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly warnings!: pulumi.Output<any[]>;
 
     /**
      * Create a Route resource with the given unique name, arguments, and options.
@@ -261,5 +261,5 @@ export interface RouteArgs {
     /**
      * [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
      */
-    readonly warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly warnings?: pulumi.Input<any[]>;
 }

--- a/sdk/nodejs/compute/beta/sslPolicy.ts
+++ b/sdk/nodejs/compute/beta/sslPolicy.ts
@@ -80,7 +80,7 @@ export class SslPolicy extends pulumi.CustomResource {
     /**
      * [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
      */
-    public readonly warnings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly warnings!: pulumi.Output<any[]>;
 
     /**
      * Create a SslPolicy resource with the given unique name, arguments, and options.
@@ -189,5 +189,5 @@ export interface SslPolicyArgs {
     /**
      * [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
      */
-    readonly warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly warnings?: pulumi.Input<any[]>;
 }

--- a/sdk/nodejs/compute/v1/firewall.ts
+++ b/sdk/nodejs/compute/v1/firewall.ts
@@ -38,7 +38,7 @@ export class Firewall extends pulumi.CustomResource {
     /**
      * The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
      */
-    public readonly allowed!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly allowed!: pulumi.Output<any[]>;
     /**
      * [Output Only] Creation timestamp in RFC3339 text format.
      */
@@ -46,7 +46,7 @@ export class Firewall extends pulumi.CustomResource {
     /**
      * The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
      */
-    public readonly denied!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly denied!: pulumi.Output<any[]>;
     /**
      * An optional description of this resource. Provide this field when you create the resource.
      */
@@ -185,7 +185,7 @@ export interface FirewallArgs {
     /**
      * The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
      */
-    readonly allowed?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly allowed?: pulumi.Input<any[]>;
     /**
      * [Output Only] Creation timestamp in RFC3339 text format.
      */
@@ -193,7 +193,7 @@ export interface FirewallArgs {
     /**
      * The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
      */
-    readonly denied?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly denied?: pulumi.Input<any[]>;
     /**
      * An optional description of this resource. Provide this field when you create the resource.
      */

--- a/sdk/nodejs/compute/v1/route.ts
+++ b/sdk/nodejs/compute/v1/route.ts
@@ -105,7 +105,7 @@ export class Route extends pulumi.CustomResource {
     /**
      * [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
      */
-    public readonly warnings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly warnings!: pulumi.Output<any[]>;
 
     /**
      * Create a Route resource with the given unique name, arguments, and options.
@@ -251,5 +251,5 @@ export interface RouteArgs {
     /**
      * [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
      */
-    readonly warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly warnings?: pulumi.Input<any[]>;
 }

--- a/sdk/nodejs/compute/v1/sslPolicy.ts
+++ b/sdk/nodejs/compute/v1/sslPolicy.ts
@@ -80,7 +80,7 @@ export class SslPolicy extends pulumi.CustomResource {
     /**
      * [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
      */
-    public readonly warnings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly warnings!: pulumi.Output<any[]>;
 
     /**
      * Create a SslPolicy resource with the given unique name, arguments, and options.
@@ -189,5 +189,5 @@ export interface SslPolicyArgs {
     /**
      * [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
      */
-    readonly warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly warnings?: pulumi.Input<any[]>;
 }

--- a/sdk/nodejs/sqladmin/v1beta4/instance.ts
+++ b/sdk/nodejs/sqladmin/v1beta4/instance.ts
@@ -66,7 +66,7 @@ export class Instance extends pulumi.CustomResource {
     /**
      * The name and status of the failover replica. This property is applicable only to Second Generation instances.
      */
-    public readonly failoverReplica!: pulumi.Output<{[key: string]: string}>;
+    public readonly failoverReplica!: pulumi.Output<any>;
     /**
      * The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
      */
@@ -284,7 +284,7 @@ export interface InstanceArgs {
     /**
      * The name and status of the failover replica. This property is applicable only to Second Generation instances.
      */
-    readonly failoverReplica?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    readonly failoverReplica?: any;
     /**
      * The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
      */

--- a/sdk/nodejs/storage/v1/bucket.ts
+++ b/sdk/nodejs/storage/v1/bucket.ts
@@ -42,11 +42,11 @@ export class Bucket extends pulumi.CustomResource {
     /**
      * The bucket's billing configuration.
      */
-    public readonly billing!: pulumi.Output<{[key: string]: string}>;
+    public readonly billing!: pulumi.Output<any>;
     /**
      * The bucket's Cross-Origin Resource Sharing (CORS) configuration.
      */
-    public readonly cors!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly cors!: pulumi.Output<any[]>;
     /**
      * The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
      */
@@ -66,7 +66,7 @@ export class Bucket extends pulumi.CustomResource {
     /**
      * The bucket's IAM configuration.
      */
-    public readonly iamConfiguration!: pulumi.Output<{[key: string]: string}>;
+    public readonly iamConfiguration!: pulumi.Output<any>;
     /**
      * The kind of item this is. For buckets, this is always storage#bucket.
      */
@@ -78,7 +78,7 @@ export class Bucket extends pulumi.CustomResource {
     /**
      * The bucket's lifecycle configuration. See lifecycle management for more information.
      */
-    public readonly lifecycle!: pulumi.Output<{[key: string]: string}>;
+    public readonly lifecycle!: pulumi.Output<any>;
     /**
      * The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
      */
@@ -110,7 +110,7 @@ export class Bucket extends pulumi.CustomResource {
     /**
      * The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
      */
-    public readonly retentionPolicy!: pulumi.Output<{[key: string]: string}>;
+    public readonly retentionPolicy!: pulumi.Output<any>;
     /**
      * Reserved for future use.
      */
@@ -134,7 +134,7 @@ export class Bucket extends pulumi.CustomResource {
     /**
      * The bucket's versioning configuration.
      */
-    public readonly versioning!: pulumi.Output<{[key: string]: string}>;
+    public readonly versioning!: pulumi.Output<any>;
     /**
      * The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
      */
@@ -238,12 +238,12 @@ export interface BucketArgs {
     /**
      * The bucket's billing configuration.
      */
-    readonly billing?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    readonly billing?: any;
     readonly bucket: pulumi.Input<string>;
     /**
      * The bucket's Cross-Origin Resource Sharing (CORS) configuration.
      */
-    readonly cors?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly cors?: pulumi.Input<any[]>;
     /**
      * The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
      */
@@ -263,7 +263,7 @@ export interface BucketArgs {
     /**
      * The bucket's IAM configuration.
      */
-    readonly iamConfiguration?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    readonly iamConfiguration?: any;
     /**
      * The ID of the bucket. For buckets, the id and name properties are the same.
      */
@@ -279,7 +279,7 @@ export interface BucketArgs {
     /**
      * The bucket's lifecycle configuration. See lifecycle management for more information.
      */
-    readonly lifecycle?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    readonly lifecycle?: any;
     /**
      * The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
      */
@@ -312,7 +312,7 @@ export interface BucketArgs {
     /**
      * The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
      */
-    readonly retentionPolicy?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    readonly retentionPolicy?: any;
     /**
      * Reserved for future use.
      */
@@ -336,7 +336,7 @@ export interface BucketArgs {
     /**
      * The bucket's versioning configuration.
      */
-    readonly versioning?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    readonly versioning?: any;
     /**
      * The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
      */

--- a/sdk/nodejs/storage/v1/bucketIamPolicy.ts
+++ b/sdk/nodejs/storage/v1/bucketIamPolicy.ts
@@ -37,7 +37,7 @@ export class BucketIamPolicy extends pulumi.CustomResource {
     /**
      * An association between a role, which comes with a set of permissions, and members who may assume that role.
      */
-    public readonly bindings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly bindings!: pulumi.Output<any[]>;
     /**
      * HTTP 1.1  Entity tag for the policy.
      */
@@ -96,7 +96,7 @@ export interface BucketIamPolicyArgs {
     /**
      * An association between a role, which comes with a set of permissions, and members who may assume that role.
      */
-    readonly bindings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly bindings?: pulumi.Input<any[]>;
     readonly bucket: pulumi.Input<string>;
     /**
      * HTTP 1.1  Entity tag for the policy.

--- a/sdk/nodejs/storage/v1/objectIamPolicy.ts
+++ b/sdk/nodejs/storage/v1/objectIamPolicy.ts
@@ -37,7 +37,7 @@ export class ObjectIamPolicy extends pulumi.CustomResource {
     /**
      * An association between a role, which comes with a set of permissions, and members who may assume that role.
      */
-    public readonly bindings!: pulumi.Output<{[key: string]: string}[]>;
+    public readonly bindings!: pulumi.Output<any[]>;
     /**
      * HTTP 1.1  Entity tag for the policy.
      */
@@ -100,7 +100,7 @@ export interface ObjectIamPolicyArgs {
     /**
      * An association between a role, which comes with a set of permissions, and members who may assume that role.
      */
-    readonly bindings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+    readonly bindings?: pulumi.Input<any[]>;
     readonly bucket: pulumi.Input<string>;
     /**
      * HTTP 1.1  Entity tag for the policy.

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -2955,7 +2955,7 @@ export namespace bigquery {
             /**
              * [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
              */
-            trainingOptions?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+            trainingOptions?: any;
         }
 
         export interface Clustering {
@@ -3892,7 +3892,7 @@ export namespace bigquery {
             /**
              * [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
              */
-            modelOptions?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+            modelOptions?: any;
             /**
              * [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
              */
@@ -4166,7 +4166,7 @@ export namespace bigquery {
             /**
              * [Optional] The categories attached to this field, used for field-level access control.
              */
-            categories?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+            categories?: any;
             /**
              * [Optional] The field description. The maximum length is 1,024 characters.
              */
@@ -4187,7 +4187,7 @@ export namespace bigquery {
              * [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
              */
             name?: pulumi.Input<string>;
-            policyTags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+            policyTags?: any;
             /**
              * [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
              */
@@ -31408,7 +31408,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If errors are generated during processing of the operation, this field will be populated.
              */
-            error?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+            error?: any;
             /**
              * [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
              */
@@ -31480,7 +31480,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
              */
-            warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+            warnings?: pulumi.Input<any[]>;
             /**
              * [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
              */
@@ -31762,7 +31762,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If errors are generated during processing of the operation, this field will be populated.
              */
-            error?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+            error?: any;
             /**
              * [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
              */
@@ -31834,7 +31834,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
              */
-            warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+            warnings?: pulumi.Input<any[]>;
             /**
              * [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
              */
@@ -32108,7 +32108,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If errors are generated during processing of the operation, this field will be populated.
              */
-            error?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+            error?: any;
             /**
              * [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
              */
@@ -32180,7 +32180,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
              */
-            warnings?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
+            warnings?: pulumi.Input<any[]>;
             /**
              * [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
              */

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -3095,7 +3095,7 @@ export namespace bigquery {
             /**
              * [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
              */
-            trainingOptions: {[key: string]: string};
+            trainingOptions: any;
         }
 
         export interface ClusteringResponse {
@@ -4028,7 +4028,7 @@ export namespace bigquery {
             /**
              * [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
              */
-            modelOptions: {[key: string]: string};
+            modelOptions: any;
             /**
              * [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
              */
@@ -4302,7 +4302,7 @@ export namespace bigquery {
             /**
              * [Optional] The categories attached to this field, used for field-level access control.
              */
-            categories: {[key: string]: string};
+            categories: any;
             /**
              * [Optional] The field description. The maximum length is 1,024 characters.
              */
@@ -4323,7 +4323,7 @@ export namespace bigquery {
              * [Required] The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
              */
             name: string;
-            policyTags: {[key: string]: string};
+            policyTags: any;
             /**
              * [Optional] Precision (maximum number of total digits in base 10) and scale (maximum number of digits in the fractional part in base 10) constraints for values of this field for NUMERIC or BIGNUMERIC. It is invalid to set precision or scale if type ≠ "NUMERIC" and ≠ "BIGNUMERIC". If precision and scale are not specified, no value range constraint is imposed on this field insofar as values are permitted by the type. Values of this NUMERIC or BIGNUMERIC field must be in this range when: - Precision (P) and scale (S) are specified: [-10P-S + 10-S, 10P-S - 10-S] - Precision (P) is specified but not scale (and thus scale is interpreted to be equal to zero): [-10P + 1, 10P - 1]. Acceptable values for precision and scale if both are specified: - If type = "NUMERIC": 1 ≤ precision - scale ≤ 29 and 0 ≤ scale ≤ 9. - If type = "BIGNUMERIC": 1 ≤ precision - scale ≤ 38 and 0 ≤ scale ≤ 38. Acceptable values for precision if only precision is specified but not scale (and thus scale is interpreted to be equal to zero): - If type = "NUMERIC": 1 ≤ precision ≤ 29. - If type = "BIGNUMERIC": 1 ≤ precision ≤ 38. If scale is specified but not precision, then it is invalid.
              */
@@ -32485,7 +32485,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If errors are generated during processing of the operation, this field will be populated.
              */
-            error: {[key: string]: string};
+            error: any;
             /**
              * [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
              */
@@ -32553,7 +32553,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
              */
-            warnings: {[key: string]: string}[];
+            warnings: any[];
             /**
              * [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
              */
@@ -32834,7 +32834,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If errors are generated during processing of the operation, this field will be populated.
              */
-            error: {[key: string]: string};
+            error: any;
             /**
              * [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
              */
@@ -32902,7 +32902,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
              */
-            warnings: {[key: string]: string}[];
+            warnings: any[];
             /**
              * [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
              */
@@ -33175,7 +33175,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If errors are generated during processing of the operation, this field will be populated.
              */
-            error: {[key: string]: string};
+            error: any;
             /**
              * [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
              */
@@ -33243,7 +33243,7 @@ export namespace deploymentmanager {
             /**
              * [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
              */
-            warnings: {[key: string]: string}[];
+            warnings: any[];
             /**
              * [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
              */

--- a/sdk/python/pulumi_gcp_native/bigquery/v2/_inputs.py
+++ b/sdk/python/pulumi_gcp_native/bigquery/v2/_inputs.py
@@ -654,12 +654,12 @@ class BqmlTrainingRunArgs:
                  iteration_results: Optional[pulumi.Input[Sequence[pulumi.Input['BqmlIterationResultArgs']]]] = None,
                  start_time: Optional[pulumi.Input[str]] = None,
                  state: Optional[pulumi.Input[str]] = None,
-                 training_options: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
+                 training_options: Optional[Any] = None):
         """
         :param pulumi.Input[Sequence[pulumi.Input['BqmlIterationResultArgs']]] iteration_results: [Output-only, Beta] List of each iteration results.
         :param pulumi.Input[str] start_time: [Output-only, Beta] Training run start time in milliseconds since the epoch.
         :param pulumi.Input[str] state: [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] training_options: [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
+        :param Any training_options: [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
         """
         if iteration_results is not None:
             pulumi.set(__self__, "iteration_results", iteration_results)
@@ -708,14 +708,14 @@ class BqmlTrainingRunArgs:
 
     @property
     @pulumi.getter(name="trainingOptions")
-    def training_options(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def training_options(self) -> Optional[Any]:
         """
         [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
         """
         return pulumi.get(self, "training_options")
 
     @training_options.setter
-    def training_options(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def training_options(self, value: Optional[Any]):
         pulumi.set(self, "training_options", value)
 
 
@@ -4306,10 +4306,10 @@ class MaterializedViewDefinitionArgs:
 @pulumi.input_type
 class ModelDefinitionArgs:
     def __init__(__self__, *,
-                 model_options: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 model_options: Optional[Any] = None,
                  training_runs: Optional[pulumi.Input[Sequence[pulumi.Input['BqmlTrainingRunArgs']]]] = None):
         """
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] model_options: [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
+        :param Any model_options: [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
         :param pulumi.Input[Sequence[pulumi.Input['BqmlTrainingRunArgs']]] training_runs: [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
         """
         if model_options is not None:
@@ -4319,14 +4319,14 @@ class ModelDefinitionArgs:
 
     @property
     @pulumi.getter(name="modelOptions")
-    def model_options(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def model_options(self) -> Optional[Any]:
         """
         [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
         """
         return pulumi.get(self, "model_options")
 
     @model_options.setter
-    def model_options(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def model_options(self, value: Optional[Any]):
         pulumi.set(self, "model_options", value)
 
     @property
@@ -5275,18 +5275,18 @@ class StreamingbufferArgs:
 @pulumi.input_type
 class TableFieldSchemaArgs:
     def __init__(__self__, *,
-                 categories: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 categories: Optional[Any] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  fields: Optional[pulumi.Input[Sequence[pulumi.Input['TableFieldSchemaArgs']]]] = None,
                  max_length: Optional[pulumi.Input[str]] = None,
                  mode: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
-                 policy_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 policy_tags: Optional[Any] = None,
                  precision: Optional[pulumi.Input[str]] = None,
                  scale: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] categories: [Optional] The categories attached to this field, used for field-level access control.
+        :param Any categories: [Optional] The categories attached to this field, used for field-level access control.
         :param pulumi.Input[str] description: [Optional] The field description. The maximum length is 1,024 characters.
         :param pulumi.Input[Sequence[pulumi.Input['TableFieldSchemaArgs']]] fields: [Optional] Describes the nested schema fields if the type property is set to RECORD.
         :param pulumi.Input[str] max_length: [Optional] Maximum length of values of this field for STRINGS or BYTES. If max_length is not specified, no maximum length constraint is imposed on this field. If type = "STRING", then max_length represents the maximum UTF-8 length of strings in this field. If type = "BYTES", then max_length represents the maximum number of bytes in this field. It is invalid to set this field if type ≠ "STRING" and ≠ "BYTES".
@@ -5319,14 +5319,14 @@ class TableFieldSchemaArgs:
 
     @property
     @pulumi.getter
-    def categories(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def categories(self) -> Optional[Any]:
         """
         [Optional] The categories attached to this field, used for field-level access control.
         """
         return pulumi.get(self, "categories")
 
     @categories.setter
-    def categories(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def categories(self, value: Optional[Any]):
         pulumi.set(self, "categories", value)
 
     @property
@@ -5391,11 +5391,11 @@ class TableFieldSchemaArgs:
 
     @property
     @pulumi.getter(name="policyTags")
-    def policy_tags(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def policy_tags(self) -> Optional[Any]:
         return pulumi.get(self, "policy_tags")
 
     @policy_tags.setter
-    def policy_tags(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def policy_tags(self, value: Optional[Any]):
         pulumi.set(self, "policy_tags", value)
 
     @property

--- a/sdk/python/pulumi_gcp_native/bigquery/v2/outputs.py
+++ b/sdk/python/pulumi_gcp_native/bigquery/v2/outputs.py
@@ -534,12 +534,12 @@ class BqmlTrainingRunResponse(dict):
                  iteration_results: Sequence['outputs.BqmlIterationResultResponse'],
                  start_time: str,
                  state: str,
-                 training_options: Mapping[str, str]):
+                 training_options: Any):
         """
         :param Sequence['BqmlIterationResultResponseArgs'] iteration_results: [Output-only, Beta] List of each iteration results.
         :param str start_time: [Output-only, Beta] Training run start time in milliseconds since the epoch.
         :param str state: [Output-only, Beta] Different state applicable for a training run. IN PROGRESS: Training run is in progress. FAILED: Training run ended due to a non-retryable failure. SUCCEEDED: Training run successfully completed. CANCELLED: Training run cancelled by the user.
-        :param Mapping[str, str] training_options: [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
+        :param Any training_options: [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
         """
         pulumi.set(__self__, "iteration_results", iteration_results)
         pulumi.set(__self__, "start_time", start_time)
@@ -572,7 +572,7 @@ class BqmlTrainingRunResponse(dict):
 
     @property
     @pulumi.getter(name="trainingOptions")
-    def training_options(self) -> Mapping[str, str]:
+    def training_options(self) -> Any:
         """
         [Output-only, Beta] Training options used by this training run. These options are mutable for subsequent training runs. Default values are explicitly stored for options not specified in the input query of the first training run. For subsequent training runs, any option not explicitly specified in the input query will be copied from the previous training run.
         """
@@ -3171,10 +3171,10 @@ class MaterializedViewDefinitionResponse(dict):
 @pulumi.output_type
 class ModelDefinitionResponse(dict):
     def __init__(__self__, *,
-                 model_options: Mapping[str, str],
+                 model_options: Any,
                  training_runs: Sequence['outputs.BqmlTrainingRunResponse']):
         """
-        :param Mapping[str, str] model_options: [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
+        :param Any model_options: [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
         :param Sequence['BqmlTrainingRunResponseArgs'] training_runs: [Output-only, Beta] Information about ml training runs, each training run comprises of multiple iterations and there may be multiple training runs for the model if warm start is used or if a user decides to continue a previously cancelled query.
         """
         pulumi.set(__self__, "model_options", model_options)
@@ -3182,7 +3182,7 @@ class ModelDefinitionResponse(dict):
 
     @property
     @pulumi.getter(name="modelOptions")
-    def model_options(self) -> Mapping[str, str]:
+    def model_options(self) -> Any:
         """
         [Output-only, Beta] Model options used for the first training run. These options are immutable for subsequent training runs. Default values are used for any options not specified in the input query.
         """
@@ -3949,18 +3949,18 @@ class StreamingbufferResponse(dict):
 @pulumi.output_type
 class TableFieldSchemaResponse(dict):
     def __init__(__self__, *,
-                 categories: Mapping[str, str],
+                 categories: Any,
                  description: str,
                  fields: Sequence['outputs.TableFieldSchemaResponse'],
                  max_length: str,
                  mode: str,
                  name: str,
-                 policy_tags: Mapping[str, str],
+                 policy_tags: Any,
                  precision: str,
                  scale: str,
                  type: str):
         """
-        :param Mapping[str, str] categories: [Optional] The categories attached to this field, used for field-level access control.
+        :param Any categories: [Optional] The categories attached to this field, used for field-level access control.
         :param str description: [Optional] The field description. The maximum length is 1,024 characters.
         :param Sequence['TableFieldSchemaResponseArgs'] fields: [Optional] Describes the nested schema fields if the type property is set to RECORD.
         :param str max_length: [Optional] Maximum length of values of this field for STRINGS or BYTES. If max_length is not specified, no maximum length constraint is imposed on this field. If type = "STRING", then max_length represents the maximum UTF-8 length of strings in this field. If type = "BYTES", then max_length represents the maximum number of bytes in this field. It is invalid to set this field if type ≠ "STRING" and ≠ "BYTES".
@@ -3983,7 +3983,7 @@ class TableFieldSchemaResponse(dict):
 
     @property
     @pulumi.getter
-    def categories(self) -> Mapping[str, str]:
+    def categories(self) -> Any:
         """
         [Optional] The categories attached to this field, used for field-level access control.
         """
@@ -4031,7 +4031,7 @@ class TableFieldSchemaResponse(dict):
 
     @property
     @pulumi.getter(name="policyTags")
-    def policy_tags(self) -> Mapping[str, str]:
+    def policy_tags(self) -> Any:
         return pulumi.get(self, "policy_tags")
 
     @property

--- a/sdk/python/pulumi_gcp_native/compute/alpha/firewall.py
+++ b/sdk/python/pulumi_gcp_native/compute/alpha/firewall.py
@@ -17,9 +17,9 @@ class Firewall(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 allowed: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 allowed: Optional[pulumi.Input[Sequence[Any]]] = None,
                  creation_timestamp: Optional[pulumi.Input[str]] = None,
-                 denied: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 denied: Optional[pulumi.Input[Sequence[Any]]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  destination_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  direction: Optional[pulumi.Input[str]] = None,
@@ -48,9 +48,9 @@ class Firewall(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] allowed: The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
+        :param pulumi.Input[Sequence[Any]] allowed: The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         :param pulumi.Input[str] creation_timestamp: [Output Only] Creation timestamp in RFC3339 text format.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] denied: The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
+        :param pulumi.Input[Sequence[Any]] denied: The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this field when you create the resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] destination_ranges: If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
         :param pulumi.Input[str] direction: Direction of traffic to which this firewall applies, either `INGRESS` or `EGRESS`. The default is `INGRESS`. For `INGRESS` traffic, you cannot specify the destinationRanges field, and for `EGRESS` traffic, you cannot specify the sourceRanges or sourceTags fields.
@@ -165,7 +165,7 @@ class Firewall(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def allowed(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def allowed(self) -> pulumi.Output[Sequence[Any]]:
         """
         The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         """
@@ -181,7 +181,7 @@ class Firewall(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def denied(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def denied(self) -> pulumi.Output[Sequence[Any]]:
         """
         The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         """

--- a/sdk/python/pulumi_gcp_native/compute/alpha/route.py
+++ b/sdk/python/pulumi_gcp_native/compute/alpha/route.py
@@ -37,7 +37,7 @@ class Route(pulumi.CustomResource):
                  self_link: Optional[pulumi.Input[str]] = None,
                  self_link_with_id: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  __props__=None,
                  __name__=None,
                  __opts__=None):
@@ -70,7 +70,7 @@ class Route(pulumi.CustomResource):
         :param pulumi.Input[str] self_link: [Output Only] Server-defined fully-qualified URL for this resource.
         :param pulumi.Input[str] self_link_with_id: [Output Only] Server-defined URL for this resource with the resource id.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tags: A list of instance tags to which this route applies.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
@@ -318,7 +318,7 @@ class Route(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def warnings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def warnings(self) -> pulumi.Output[Sequence[Any]]:
         """
         [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         """

--- a/sdk/python/pulumi_gcp_native/compute/alpha/ssl_policy.py
+++ b/sdk/python/pulumi_gcp_native/compute/alpha/ssl_policy.py
@@ -32,7 +32,7 @@ class SslPolicy(pulumi.CustomResource):
                  self_link_with_id: Optional[pulumi.Input[str]] = None,
                  ssl_policy: Optional[pulumi.Input[str]] = None,
                  tls_settings: Optional[pulumi.Input[pulumi.InputType['ServerTlsSettingsArgs']]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  __props__=None,
                  __name__=None,
                  __opts__=None):
@@ -57,7 +57,7 @@ class SslPolicy(pulumi.CustomResource):
         :param pulumi.Input[str] self_link: [Output Only] Server-defined URL for the resource.
         :param pulumi.Input[str] self_link_with_id: [Output Only] Server-defined URL for this resource with the resource id.
         :param pulumi.Input[pulumi.InputType['ServerTlsSettingsArgs']] tls_settings: Security settings for the proxy. This field is only applicable to a global backend service with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
@@ -234,7 +234,7 @@ class SslPolicy(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def warnings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def warnings(self) -> pulumi.Output[Sequence[Any]]:
         """
         [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         """

--- a/sdk/python/pulumi_gcp_native/compute/beta/firewall.py
+++ b/sdk/python/pulumi_gcp_native/compute/beta/firewall.py
@@ -17,9 +17,9 @@ class Firewall(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 allowed: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 allowed: Optional[pulumi.Input[Sequence[Any]]] = None,
                  creation_timestamp: Optional[pulumi.Input[str]] = None,
-                 denied: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 denied: Optional[pulumi.Input[Sequence[Any]]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  destination_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  direction: Optional[pulumi.Input[str]] = None,
@@ -47,9 +47,9 @@ class Firewall(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] allowed: The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
+        :param pulumi.Input[Sequence[Any]] allowed: The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         :param pulumi.Input[str] creation_timestamp: [Output Only] Creation timestamp in RFC3339 text format.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] denied: The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
+        :param pulumi.Input[Sequence[Any]] denied: The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this field when you create the resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] destination_ranges: If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
         :param pulumi.Input[str] direction: Direction of traffic to which this firewall applies, either `INGRESS` or `EGRESS`. The default is `INGRESS`. For `INGRESS` traffic, you cannot specify the destinationRanges field, and for `EGRESS` traffic, you cannot specify the sourceRanges or sourceTags fields.
@@ -161,7 +161,7 @@ class Firewall(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def allowed(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def allowed(self) -> pulumi.Output[Sequence[Any]]:
         """
         The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         """
@@ -177,7 +177,7 @@ class Firewall(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def denied(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def denied(self) -> pulumi.Output[Sequence[Any]]:
         """
         The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         """

--- a/sdk/python/pulumi_gcp_native/compute/beta/route.py
+++ b/sdk/python/pulumi_gcp_native/compute/beta/route.py
@@ -35,7 +35,7 @@ class Route(pulumi.CustomResource):
                  route: Optional[pulumi.Input[str]] = None,
                  self_link: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  __props__=None,
                  __name__=None,
                  __opts__=None):
@@ -66,7 +66,7 @@ class Route(pulumi.CustomResource):
         :param pulumi.Input[int] priority: The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In cases where multiple routes have equal prefix length, the one with the lowest-numbered priority value wins. The default value is `1000`. The priority value must be from `0` to `65535`, inclusive.
         :param pulumi.Input[str] self_link: [Output Only] Server-defined fully-qualified URL for this resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tags: A list of instance tags to which this route applies.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
@@ -294,7 +294,7 @@ class Route(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def warnings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def warnings(self) -> pulumi.Output[Sequence[Any]]:
         """
         [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         """

--- a/sdk/python/pulumi_gcp_native/compute/beta/ssl_policy.py
+++ b/sdk/python/pulumi_gcp_native/compute/beta/ssl_policy.py
@@ -28,7 +28,7 @@ class SslPolicy(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  self_link: Optional[pulumi.Input[str]] = None,
                  ssl_policy: Optional[pulumi.Input[str]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  __props__=None,
                  __name__=None,
                  __opts__=None):
@@ -51,7 +51,7 @@ class SslPolicy(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the resource. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] profile: Profile specifies the set of SSL features that can be used by the load balancer when negotiating SSL with clients. This can be one of COMPATIBLE, MODERN, RESTRICTED, or CUSTOM. If using CUSTOM, the set of SSL features to enable must be specified in the customFeatures field.
         :param pulumi.Input[str] self_link: [Output Only] Server-defined URL for the resource.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
@@ -208,7 +208,7 @@ class SslPolicy(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def warnings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def warnings(self) -> pulumi.Output[Sequence[Any]]:
         """
         [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         """

--- a/sdk/python/pulumi_gcp_native/compute/v1/firewall.py
+++ b/sdk/python/pulumi_gcp_native/compute/v1/firewall.py
@@ -17,9 +17,9 @@ class Firewall(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 allowed: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 allowed: Optional[pulumi.Input[Sequence[Any]]] = None,
                  creation_timestamp: Optional[pulumi.Input[str]] = None,
-                 denied: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 denied: Optional[pulumi.Input[Sequence[Any]]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  destination_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  direction: Optional[pulumi.Input[str]] = None,
@@ -46,9 +46,9 @@ class Firewall(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] allowed: The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
+        :param pulumi.Input[Sequence[Any]] allowed: The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         :param pulumi.Input[str] creation_timestamp: [Output Only] Creation timestamp in RFC3339 text format.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] denied: The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
+        :param pulumi.Input[Sequence[Any]] denied: The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this field when you create the resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] destination_ranges: If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
         :param pulumi.Input[str] direction: Direction of traffic to which this firewall applies, either `INGRESS` or `EGRESS`. The default is `INGRESS`. For `INGRESS` traffic, you cannot specify the destinationRanges field, and for `EGRESS` traffic, you cannot specify the sourceRanges or sourceTags fields.
@@ -157,7 +157,7 @@ class Firewall(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def allowed(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def allowed(self) -> pulumi.Output[Sequence[Any]]:
         """
         The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a permitted connection.
         """
@@ -173,7 +173,7 @@ class Firewall(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def denied(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def denied(self) -> pulumi.Output[Sequence[Any]]:
         """
         The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
         """

--- a/sdk/python/pulumi_gcp_native/compute/v1/route.py
+++ b/sdk/python/pulumi_gcp_native/compute/v1/route.py
@@ -34,7 +34,7 @@ class Route(pulumi.CustomResource):
                  route: Optional[pulumi.Input[str]] = None,
                  self_link: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  __props__=None,
                  __name__=None,
                  __opts__=None):
@@ -64,7 +64,7 @@ class Route(pulumi.CustomResource):
         :param pulumi.Input[int] priority: The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In cases where multiple routes have equal prefix length, the one with the lowest-numbered priority value wins. The default value is `1000`. The priority value must be from `0` to `65535`, inclusive.
         :param pulumi.Input[str] self_link: [Output Only] Server-defined fully-qualified URL for this resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] tags: A list of instance tags to which this route applies.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
@@ -282,7 +282,7 @@ class Route(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def warnings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def warnings(self) -> pulumi.Output[Sequence[Any]]:
         """
         [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
         """

--- a/sdk/python/pulumi_gcp_native/compute/v1/ssl_policy.py
+++ b/sdk/python/pulumi_gcp_native/compute/v1/ssl_policy.py
@@ -28,7 +28,7 @@ class SslPolicy(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  self_link: Optional[pulumi.Input[str]] = None,
                  ssl_policy: Optional[pulumi.Input[str]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  __props__=None,
                  __name__=None,
                  __opts__=None):
@@ -51,7 +51,7 @@ class SslPolicy(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the resource. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] profile: Profile specifies the set of SSL features that can be used by the load balancer when negotiating SSL with clients. This can be one of COMPATIBLE, MODERN, RESTRICTED, or CUSTOM. If using CUSTOM, the set of SSL features to enable must be specified in the customFeatures field.
         :param pulumi.Input[str] self_link: [Output Only] Server-defined URL for the resource.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
@@ -208,7 +208,7 @@ class SslPolicy(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def warnings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def warnings(self) -> pulumi.Output[Sequence[Any]]:
         """
         [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
         """

--- a/sdk/python/pulumi_gcp_native/deploymentmanager/alpha/_inputs.py
+++ b/sdk/python/pulumi_gcp_native/deploymentmanager/alpha/_inputs.py
@@ -928,7 +928,7 @@ class OperationArgs:
                  creation_timestamp: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  end_time: Optional[pulumi.Input[str]] = None,
-                 error: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 error: Optional[Any] = None,
                  http_error_message: Optional[pulumi.Input[str]] = None,
                  http_error_status_code: Optional[pulumi.Input[int]] = None,
                  id: Optional[pulumi.Input[str]] = None,
@@ -946,7 +946,7 @@ class OperationArgs:
                  target_id: Optional[pulumi.Input[str]] = None,
                  target_link: Optional[pulumi.Input[str]] = None,
                  user: Optional[pulumi.Input[str]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  zone: Optional[pulumi.Input[str]] = None):
         """
         Represents an Operation resource. Google Compute Engine has three Operation resources: * [Global](/compute/docs/reference/rest/{$api_version}/globalOperations) * [Regional](/compute/docs/reference/rest/{$api_version}/regionOperations) * [Zonal](/compute/docs/reference/rest/{$api_version}/zoneOperations) You can use an operation resource to manage asynchronous API requests. For more information, read Handling API responses. Operations can be global, regional or zonal. - For global operations, use the `globalOperations` resource. - For regional operations, use the `regionOperations` resource. - For zonal operations, use the `zonalOperations` resource. For more information, read Global, Regional, and Zonal Resources.
@@ -954,7 +954,7 @@ class OperationArgs:
         :param pulumi.Input[str] creation_timestamp: [Deprecated] This field is deprecated.
         :param pulumi.Input[str] description: [Output Only] A textual description of the operation, which is set when the operation is created.
         :param pulumi.Input[str] end_time: [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
+        :param Any error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
         :param pulumi.Input[str] http_error_message: [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         :param pulumi.Input[int] http_error_status_code: [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
         :param pulumi.Input[str] id: [Output Only] The unique identifier for the operation. This identifier is defined by the server.
@@ -972,7 +972,7 @@ class OperationArgs:
         :param pulumi.Input[str] target_id: [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
         :param pulumi.Input[str] target_link: [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
         :param pulumi.Input[str] user: [Output Only] User who requested the operation, for example: `user@example.com`.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         :param pulumi.Input[str] zone: [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         """
         if client_operation_id is not None:
@@ -1074,14 +1074,14 @@ class OperationArgs:
 
     @property
     @pulumi.getter
-    def error(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def error(self) -> Optional[Any]:
         """
         [Output Only] If errors are generated during processing of the operation, this field will be populated.
         """
         return pulumi.get(self, "error")
 
     @error.setter
-    def error(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def error(self, value: Optional[Any]):
         pulumi.set(self, "error", value)
 
     @property
@@ -1290,14 +1290,14 @@ class OperationArgs:
 
     @property
     @pulumi.getter
-    def warnings(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def warnings(self) -> Optional[pulumi.Input[Sequence[Any]]]:
         """
         [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         """
         return pulumi.get(self, "warnings")
 
     @warnings.setter
-    def warnings(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def warnings(self, value: Optional[pulumi.Input[Sequence[Any]]]):
         pulumi.set(self, "warnings", value)
 
     @property

--- a/sdk/python/pulumi_gcp_native/deploymentmanager/alpha/outputs.py
+++ b/sdk/python/pulumi_gcp_native/deploymentmanager/alpha/outputs.py
@@ -793,7 +793,7 @@ class OperationResponse(dict):
                  creation_timestamp: str,
                  description: str,
                  end_time: str,
-                 error: Mapping[str, str],
+                 error: Any,
                  http_error_message: str,
                  http_error_status_code: int,
                  insert_time: str,
@@ -810,7 +810,7 @@ class OperationResponse(dict):
                  target_id: str,
                  target_link: str,
                  user: str,
-                 warnings: Sequence[Mapping[str, str]],
+                 warnings: Sequence[Any],
                  zone: str):
         """
         Represents an Operation resource. Google Compute Engine has three Operation resources: * [Global](/compute/docs/reference/rest/{$api_version}/globalOperations) * [Regional](/compute/docs/reference/rest/{$api_version}/regionOperations) * [Zonal](/compute/docs/reference/rest/{$api_version}/zoneOperations) You can use an operation resource to manage asynchronous API requests. For more information, read Handling API responses. Operations can be global, regional or zonal. - For global operations, use the `globalOperations` resource. - For regional operations, use the `regionOperations` resource. - For zonal operations, use the `zonalOperations` resource. For more information, read Global, Regional, and Zonal Resources.
@@ -818,7 +818,7 @@ class OperationResponse(dict):
         :param str creation_timestamp: [Deprecated] This field is deprecated.
         :param str description: [Output Only] A textual description of the operation, which is set when the operation is created.
         :param str end_time: [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-        :param Mapping[str, str] error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
+        :param Any error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
         :param str http_error_message: [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         :param int http_error_status_code: [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
         :param str insert_time: [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
@@ -835,7 +835,7 @@ class OperationResponse(dict):
         :param str target_id: [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
         :param str target_link: [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
         :param str user: [Output Only] User who requested the operation, for example: `user@example.com`.
-        :param Sequence[Mapping[str, str]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
+        :param Sequence[Any] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         :param str zone: [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         """
         pulumi.set(__self__, "client_operation_id", client_operation_id)
@@ -896,7 +896,7 @@ class OperationResponse(dict):
 
     @property
     @pulumi.getter
-    def error(self) -> Mapping[str, str]:
+    def error(self) -> Any:
         """
         [Output Only] If errors are generated during processing of the operation, this field will be populated.
         """
@@ -1032,7 +1032,7 @@ class OperationResponse(dict):
 
     @property
     @pulumi.getter
-    def warnings(self) -> Sequence[Mapping[str, str]]:
+    def warnings(self) -> Sequence[Any]:
         """
         [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         """

--- a/sdk/python/pulumi_gcp_native/deploymentmanager/v2/_inputs.py
+++ b/sdk/python/pulumi_gcp_native/deploymentmanager/v2/_inputs.py
@@ -434,7 +434,7 @@ class OperationArgs:
                  creation_timestamp: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  end_time: Optional[pulumi.Input[str]] = None,
-                 error: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 error: Optional[Any] = None,
                  http_error_message: Optional[pulumi.Input[str]] = None,
                  http_error_status_code: Optional[pulumi.Input[int]] = None,
                  id: Optional[pulumi.Input[str]] = None,
@@ -452,7 +452,7 @@ class OperationArgs:
                  target_id: Optional[pulumi.Input[str]] = None,
                  target_link: Optional[pulumi.Input[str]] = None,
                  user: Optional[pulumi.Input[str]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  zone: Optional[pulumi.Input[str]] = None):
         """
         Represents an Operation resource. Google Compute Engine has three Operation resources: * [Global](/compute/docs/reference/rest/{$api_version}/globalOperations) * [Regional](/compute/docs/reference/rest/{$api_version}/regionOperations) * [Zonal](/compute/docs/reference/rest/{$api_version}/zoneOperations) You can use an operation resource to manage asynchronous API requests. For more information, read Handling API responses. Operations can be global, regional or zonal. - For global operations, use the `globalOperations` resource. - For regional operations, use the `regionOperations` resource. - For zonal operations, use the `zonalOperations` resource. For more information, read Global, Regional, and Zonal Resources.
@@ -460,7 +460,7 @@ class OperationArgs:
         :param pulumi.Input[str] creation_timestamp: [Deprecated] This field is deprecated.
         :param pulumi.Input[str] description: [Output Only] A textual description of the operation, which is set when the operation is created.
         :param pulumi.Input[str] end_time: [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
+        :param Any error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
         :param pulumi.Input[str] http_error_message: [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         :param pulumi.Input[int] http_error_status_code: [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
         :param pulumi.Input[str] id: [Output Only] The unique identifier for the operation. This identifier is defined by the server.
@@ -478,7 +478,7 @@ class OperationArgs:
         :param pulumi.Input[str] target_id: [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
         :param pulumi.Input[str] target_link: [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
         :param pulumi.Input[str] user: [Output Only] User who requested the operation, for example: `user@example.com`.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         :param pulumi.Input[str] zone: [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         """
         if client_operation_id is not None:
@@ -580,14 +580,14 @@ class OperationArgs:
 
     @property
     @pulumi.getter
-    def error(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def error(self) -> Optional[Any]:
         """
         [Output Only] If errors are generated during processing of the operation, this field will be populated.
         """
         return pulumi.get(self, "error")
 
     @error.setter
-    def error(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def error(self, value: Optional[Any]):
         pulumi.set(self, "error", value)
 
     @property
@@ -796,14 +796,14 @@ class OperationArgs:
 
     @property
     @pulumi.getter
-    def warnings(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def warnings(self) -> Optional[pulumi.Input[Sequence[Any]]]:
         """
         [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         """
         return pulumi.get(self, "warnings")
 
     @warnings.setter
-    def warnings(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def warnings(self, value: Optional[pulumi.Input[Sequence[Any]]]):
         pulumi.set(self, "warnings", value)
 
     @property

--- a/sdk/python/pulumi_gcp_native/deploymentmanager/v2/outputs.py
+++ b/sdk/python/pulumi_gcp_native/deploymentmanager/v2/outputs.py
@@ -378,7 +378,7 @@ class OperationResponse(dict):
                  creation_timestamp: str,
                  description: str,
                  end_time: str,
-                 error: Mapping[str, str],
+                 error: Any,
                  http_error_message: str,
                  http_error_status_code: int,
                  insert_time: str,
@@ -395,7 +395,7 @@ class OperationResponse(dict):
                  target_id: str,
                  target_link: str,
                  user: str,
-                 warnings: Sequence[Mapping[str, str]],
+                 warnings: Sequence[Any],
                  zone: str):
         """
         Represents an Operation resource. Google Compute Engine has three Operation resources: * [Global](/compute/docs/reference/rest/{$api_version}/globalOperations) * [Regional](/compute/docs/reference/rest/{$api_version}/regionOperations) * [Zonal](/compute/docs/reference/rest/{$api_version}/zoneOperations) You can use an operation resource to manage asynchronous API requests. For more information, read Handling API responses. Operations can be global, regional or zonal. - For global operations, use the `globalOperations` resource. - For regional operations, use the `regionOperations` resource. - For zonal operations, use the `zonalOperations` resource. For more information, read Global, Regional, and Zonal Resources.
@@ -403,7 +403,7 @@ class OperationResponse(dict):
         :param str creation_timestamp: [Deprecated] This field is deprecated.
         :param str description: [Output Only] A textual description of the operation, which is set when the operation is created.
         :param str end_time: [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-        :param Mapping[str, str] error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
+        :param Any error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
         :param str http_error_message: [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         :param int http_error_status_code: [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
         :param str insert_time: [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
@@ -420,7 +420,7 @@ class OperationResponse(dict):
         :param str target_id: [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
         :param str target_link: [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
         :param str user: [Output Only] User who requested the operation, for example: `user@example.com`.
-        :param Sequence[Mapping[str, str]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
+        :param Sequence[Any] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         :param str zone: [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         """
         pulumi.set(__self__, "client_operation_id", client_operation_id)
@@ -481,7 +481,7 @@ class OperationResponse(dict):
 
     @property
     @pulumi.getter
-    def error(self) -> Mapping[str, str]:
+    def error(self) -> Any:
         """
         [Output Only] If errors are generated during processing of the operation, this field will be populated.
         """
@@ -617,7 +617,7 @@ class OperationResponse(dict):
 
     @property
     @pulumi.getter
-    def warnings(self) -> Sequence[Mapping[str, str]]:
+    def warnings(self) -> Sequence[Any]:
         """
         [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         """

--- a/sdk/python/pulumi_gcp_native/deploymentmanager/v2beta/_inputs.py
+++ b/sdk/python/pulumi_gcp_native/deploymentmanager/v2beta/_inputs.py
@@ -766,7 +766,7 @@ class OperationArgs:
                  creation_timestamp: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  end_time: Optional[pulumi.Input[str]] = None,
-                 error: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 error: Optional[Any] = None,
                  http_error_message: Optional[pulumi.Input[str]] = None,
                  http_error_status_code: Optional[pulumi.Input[int]] = None,
                  id: Optional[pulumi.Input[str]] = None,
@@ -784,7 +784,7 @@ class OperationArgs:
                  target_id: Optional[pulumi.Input[str]] = None,
                  target_link: Optional[pulumi.Input[str]] = None,
                  user: Optional[pulumi.Input[str]] = None,
-                 warnings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 warnings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  zone: Optional[pulumi.Input[str]] = None):
         """
         Represents an Operation resource. Google Compute Engine has three Operation resources: * [Global](/compute/docs/reference/rest/{$api_version}/globalOperations) * [Regional](/compute/docs/reference/rest/{$api_version}/regionOperations) * [Zonal](/compute/docs/reference/rest/{$api_version}/zoneOperations) You can use an operation resource to manage asynchronous API requests. For more information, read Handling API responses. Operations can be global, regional or zonal. - For global operations, use the `globalOperations` resource. - For regional operations, use the `regionOperations` resource. - For zonal operations, use the `zonalOperations` resource. For more information, read Global, Regional, and Zonal Resources.
@@ -792,7 +792,7 @@ class OperationArgs:
         :param pulumi.Input[str] creation_timestamp: [Deprecated] This field is deprecated.
         :param pulumi.Input[str] description: [Output Only] A textual description of the operation, which is set when the operation is created.
         :param pulumi.Input[str] end_time: [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
+        :param Any error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
         :param pulumi.Input[str] http_error_message: [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         :param pulumi.Input[int] http_error_status_code: [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
         :param pulumi.Input[str] id: [Output Only] The unique identifier for the operation. This identifier is defined by the server.
@@ -810,7 +810,7 @@ class OperationArgs:
         :param pulumi.Input[str] target_id: [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
         :param pulumi.Input[str] target_link: [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
         :param pulumi.Input[str] user: [Output Only] User who requested the operation, for example: `user@example.com`.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
+        :param pulumi.Input[Sequence[Any]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         :param pulumi.Input[str] zone: [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         """
         if client_operation_id is not None:
@@ -912,14 +912,14 @@ class OperationArgs:
 
     @property
     @pulumi.getter
-    def error(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def error(self) -> Optional[Any]:
         """
         [Output Only] If errors are generated during processing of the operation, this field will be populated.
         """
         return pulumi.get(self, "error")
 
     @error.setter
-    def error(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def error(self, value: Optional[Any]):
         pulumi.set(self, "error", value)
 
     @property
@@ -1128,14 +1128,14 @@ class OperationArgs:
 
     @property
     @pulumi.getter
-    def warnings(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def warnings(self) -> Optional[pulumi.Input[Sequence[Any]]]:
         """
         [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         """
         return pulumi.get(self, "warnings")
 
     @warnings.setter
-    def warnings(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def warnings(self, value: Optional[pulumi.Input[Sequence[Any]]]):
         pulumi.set(self, "warnings", value)
 
     @property

--- a/sdk/python/pulumi_gcp_native/deploymentmanager/v2beta/outputs.py
+++ b/sdk/python/pulumi_gcp_native/deploymentmanager/v2beta/outputs.py
@@ -664,7 +664,7 @@ class OperationResponse(dict):
                  creation_timestamp: str,
                  description: str,
                  end_time: str,
-                 error: Mapping[str, str],
+                 error: Any,
                  http_error_message: str,
                  http_error_status_code: int,
                  insert_time: str,
@@ -681,7 +681,7 @@ class OperationResponse(dict):
                  target_id: str,
                  target_link: str,
                  user: str,
-                 warnings: Sequence[Mapping[str, str]],
+                 warnings: Sequence[Any],
                  zone: str):
         """
         Represents an Operation resource. Google Compute Engine has three Operation resources: * [Global](/compute/docs/reference/rest/{$api_version}/globalOperations) * [Regional](/compute/docs/reference/rest/{$api_version}/regionOperations) * [Zonal](/compute/docs/reference/rest/{$api_version}/zoneOperations) You can use an operation resource to manage asynchronous API requests. For more information, read Handling API responses. Operations can be global, regional or zonal. - For global operations, use the `globalOperations` resource. - For regional operations, use the `regionOperations` resource. - For zonal operations, use the `zonalOperations` resource. For more information, read Global, Regional, and Zonal Resources.
@@ -689,7 +689,7 @@ class OperationResponse(dict):
         :param str creation_timestamp: [Deprecated] This field is deprecated.
         :param str description: [Output Only] A textual description of the operation, which is set when the operation is created.
         :param str end_time: [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-        :param Mapping[str, str] error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
+        :param Any error: [Output Only] If errors are generated during processing of the operation, this field will be populated.
         :param str http_error_message: [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as `NOT FOUND`.
         :param int http_error_status_code: [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
         :param str insert_time: [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
@@ -706,7 +706,7 @@ class OperationResponse(dict):
         :param str target_id: [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
         :param str target_link: [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
         :param str user: [Output Only] User who requested the operation, for example: `user@example.com`.
-        :param Sequence[Mapping[str, str]] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
+        :param Sequence[Any] warnings: [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         :param str zone: [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
         """
         pulumi.set(__self__, "client_operation_id", client_operation_id)
@@ -767,7 +767,7 @@ class OperationResponse(dict):
 
     @property
     @pulumi.getter
-    def error(self) -> Mapping[str, str]:
+    def error(self) -> Any:
         """
         [Output Only] If errors are generated during processing of the operation, this field will be populated.
         """
@@ -903,7 +903,7 @@ class OperationResponse(dict):
 
     @property
     @pulumi.getter
-    def warnings(self) -> Sequence[Mapping[str, str]]:
+    def warnings(self) -> Sequence[Any]:
         """
         [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
         """

--- a/sdk/python/pulumi_gcp_native/sqladmin/v1beta4/instance.py
+++ b/sdk/python/pulumi_gcp_native/sqladmin/v1beta4/instance.py
@@ -24,7 +24,7 @@ class Instance(pulumi.CustomResource):
                  disk_encryption_configuration: Optional[pulumi.Input[pulumi.InputType['DiskEncryptionConfigurationArgs']]] = None,
                  disk_encryption_status: Optional[pulumi.Input[pulumi.InputType['DiskEncryptionStatusArgs']]] = None,
                  etag: Optional[pulumi.Input[str]] = None,
-                 failover_replica: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 failover_replica: Optional[Any] = None,
                  gce_zone: Optional[pulumi.Input[str]] = None,
                  instance: Optional[pulumi.Input[str]] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -64,7 +64,7 @@ class Instance(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['DiskEncryptionConfigurationArgs']] disk_encryption_configuration: Disk encryption configuration specific to an instance. Applies only to Second Generation instances.
         :param pulumi.Input[pulumi.InputType['DiskEncryptionStatusArgs']] disk_encryption_status: Disk encryption status specific to an instance. Applies only to Second Generation instances.
         :param pulumi.Input[str] etag: This field is deprecated and will be removed from a future version of the API. Use the *settings.settingsVersion* field instead.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] failover_replica: The name and status of the failover replica. This property is applicable only to Second Generation instances.
+        :param Any failover_replica: The name and status of the failover replica. This property is applicable only to Second Generation instances.
         :param pulumi.Input[str] gce_zone: The Compute Engine zone that the instance is currently serving from. This value could be different from the zone that was specified when the instance was created if the instance has failed over to its secondary zone.
         :param pulumi.Input[str] instance_type: The instance type. This can be one of the following. *CLOUD_SQL_INSTANCE*: A Cloud SQL instance that is not replicating from a primary instance. *ON_PREMISES_INSTANCE*: An instance running on the customer's premises. *READ_REPLICA_INSTANCE*: A Cloud SQL instance configured as a read-replica.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IpMappingArgs']]]] ip_addresses: The assigned IP addresses for the instance.
@@ -255,7 +255,7 @@ class Instance(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="failoverReplica")
-    def failover_replica(self) -> pulumi.Output[Mapping[str, str]]:
+    def failover_replica(self) -> pulumi.Output[Any]:
         """
         The name and status of the failover replica. This property is applicable only to Second Generation instances.
         """

--- a/sdk/python/pulumi_gcp_native/storage/v1/bucket.py
+++ b/sdk/python/pulumi_gcp_native/storage/v1/bucket.py
@@ -18,18 +18,18 @@ class Bucket(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  acl: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['BucketAccessControlArgs']]]]] = None,
-                 billing: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 billing: Optional[Any] = None,
                  bucket: Optional[pulumi.Input[str]] = None,
-                 cors: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 cors: Optional[pulumi.Input[Sequence[Any]]] = None,
                  default_event_based_hold: Optional[pulumi.Input[bool]] = None,
                  default_object_acl: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectAccessControlArgs']]]]] = None,
                  encryption: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  etag: Optional[pulumi.Input[str]] = None,
-                 iam_configuration: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 iam_configuration: Optional[Any] = None,
                  id: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 lifecycle: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 lifecycle: Optional[Any] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  location_type: Optional[pulumi.Input[str]] = None,
                  logging: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -38,13 +38,13 @@ class Bucket(pulumi.CustomResource):
                  owner: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  project_number: Optional[pulumi.Input[str]] = None,
-                 retention_policy: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 retention_policy: Optional[Any] = None,
                  satisfies_pzs: Optional[pulumi.Input[bool]] = None,
                  self_link: Optional[pulumi.Input[str]] = None,
                  storage_class: Optional[pulumi.Input[str]] = None,
                  time_created: Optional[pulumi.Input[str]] = None,
                  updated: Optional[pulumi.Input[str]] = None,
-                 versioning: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 versioning: Optional[Any] = None,
                  website: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  zone_affinity: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  __props__=None,
@@ -56,17 +56,17 @@ class Bucket(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['BucketAccessControlArgs']]]] acl: Access controls on the bucket.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] billing: The bucket's billing configuration.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] cors: The bucket's Cross-Origin Resource Sharing (CORS) configuration.
+        :param Any billing: The bucket's billing configuration.
+        :param pulumi.Input[Sequence[Any]] cors: The bucket's Cross-Origin Resource Sharing (CORS) configuration.
         :param pulumi.Input[bool] default_event_based_hold: The default value for event-based hold on newly created objects in this bucket. Event-based hold is a way to retain objects indefinitely until an event occurs, signified by the hold's release. After being released, such objects will be subject to bucket-level retention (if any). One sample use case of this flag is for banks to hold loan documents for at least 3 years after loan is paid in full. Here, bucket-level retention is 3 years and the event is loan being paid in full. In this example, these objects will be held intact for any number of years until the event has occurred (event-based hold on the object is released) and then 3 more years after that. That means retention duration of the objects begins from the moment event-based hold transitioned from true to false. Objects under event-based hold cannot be deleted, overwritten or archived until the hold is removed.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectAccessControlArgs']]]] default_object_acl: Default access controls to apply to new objects when no ACL is provided.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] encryption: Encryption configuration for a bucket.
         :param pulumi.Input[str] etag: HTTP 1.1 Entity tag for the bucket.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] iam_configuration: The bucket's IAM configuration.
+        :param Any iam_configuration: The bucket's IAM configuration.
         :param pulumi.Input[str] id: The ID of the bucket. For buckets, the id and name properties are the same.
         :param pulumi.Input[str] kind: The kind of item this is. For buckets, this is always storage#bucket.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: User-provided labels, in key/value pairs.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] lifecycle: The bucket's lifecycle configuration. See lifecycle management for more information.
+        :param Any lifecycle: The bucket's lifecycle configuration. See lifecycle management for more information.
         :param pulumi.Input[str] location: The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list.
         :param pulumi.Input[str] location_type: The type of the bucket location.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] logging: The bucket's logging configuration, which defines the destination bucket and optional name prefix for the current bucket's logs.
@@ -74,13 +74,13 @@ class Bucket(pulumi.CustomResource):
         :param pulumi.Input[str] name: The name of the bucket.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] owner: The owner of the bucket. This is always the project team's owner group.
         :param pulumi.Input[str] project_number: The project number of the project the bucket belongs to.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] retention_policy: The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
+        :param Any retention_policy: The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
         :param pulumi.Input[bool] satisfies_pzs: Reserved for future use.
         :param pulumi.Input[str] self_link: The URI of this bucket.
         :param pulumi.Input[str] storage_class: The bucket's default storage class, used whenever no storageClass is specified for a newly-created object. This defines how objects in the bucket are stored and determines the SLA and the cost of storage. Values include MULTI_REGIONAL, REGIONAL, STANDARD, NEARLINE, COLDLINE, ARCHIVE, and DURABLE_REDUCED_AVAILABILITY. If this value is not specified when the bucket is created, it will default to STANDARD. For more information, see storage classes.
         :param pulumi.Input[str] time_created: The creation time of the bucket in RFC 3339 format.
         :param pulumi.Input[str] updated: The modification time of the bucket in RFC 3339 format.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] versioning: The bucket's versioning configuration.
+        :param Any versioning: The bucket's versioning configuration.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] website: The bucket's website configuration, controlling how the service behaves when accessing bucket contents as a web site. See the Static Website Examples for more information.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] zone_affinity: The zone or zones from which the bucket is intended to use zonal quota. Requests for data from outside the specified affinities are still allowed but won't be able to use zonal quota. The zone or zones need to be within the bucket location otherwise the requests will fail with a 400 Bad Request response.
         """
@@ -196,7 +196,7 @@ class Bucket(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def billing(self) -> pulumi.Output[Mapping[str, str]]:
+    def billing(self) -> pulumi.Output[Any]:
         """
         The bucket's billing configuration.
         """
@@ -204,7 +204,7 @@ class Bucket(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def cors(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def cors(self) -> pulumi.Output[Sequence[Any]]:
         """
         The bucket's Cross-Origin Resource Sharing (CORS) configuration.
         """
@@ -244,7 +244,7 @@ class Bucket(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="iamConfiguration")
-    def iam_configuration(self) -> pulumi.Output[Mapping[str, str]]:
+    def iam_configuration(self) -> pulumi.Output[Any]:
         """
         The bucket's IAM configuration.
         """
@@ -268,7 +268,7 @@ class Bucket(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def lifecycle(self) -> pulumi.Output[Mapping[str, str]]:
+    def lifecycle(self) -> pulumi.Output[Any]:
         """
         The bucket's lifecycle configuration. See lifecycle management for more information.
         """
@@ -332,7 +332,7 @@ class Bucket(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="retentionPolicy")
-    def retention_policy(self) -> pulumi.Output[Mapping[str, str]]:
+    def retention_policy(self) -> pulumi.Output[Any]:
         """
         The bucket's retention policy. The retention policy enforces a minimum retention time for all objects contained in the bucket, based on their creation time. Any attempt to overwrite or delete objects younger than the retention period will result in a PERMISSION_DENIED error. An unlocked retention policy can be modified or removed from the bucket via a storage.buckets.update operation. A locked retention policy cannot be removed or shortened in duration for the lifetime of the bucket. Attempting to remove or decrease period of a locked retention policy will result in a PERMISSION_DENIED error.
         """
@@ -380,7 +380,7 @@ class Bucket(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def versioning(self) -> pulumi.Output[Mapping[str, str]]:
+    def versioning(self) -> pulumi.Output[Any]:
         """
         The bucket's versioning configuration.
         """

--- a/sdk/python/pulumi_gcp_native/storage/v1/bucket_iam_policy.py
+++ b/sdk/python/pulumi_gcp_native/storage/v1/bucket_iam_policy.py
@@ -15,7 +15,7 @@ class BucketIamPolicy(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bindings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 bindings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  bucket: Optional[pulumi.Input[str]] = None,
                  etag: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
@@ -29,7 +29,7 @@ class BucketIamPolicy(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] bindings: An association between a role, which comes with a set of permissions, and members who may assume that role.
+        :param pulumi.Input[Sequence[Any]] bindings: An association between a role, which comes with a set of permissions, and members who may assume that role.
         :param pulumi.Input[str] etag: HTTP 1.1  Entity tag for the policy.
         :param pulumi.Input[str] kind: The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
         :param pulumi.Input[str] resource_id: The ID of the resource to which this policy belongs. Will be of the form projects/_/buckets/bucket for buckets, and projects/_/buckets/bucket/objects/object for objects. A specific generation may be specified by appending #generationNumber to the end of the object name, e.g. projects/_/buckets/my-bucket/objects/data.txt#17. The current generation can be denoted with #0. This field is ignored on input.
@@ -91,7 +91,7 @@ class BucketIamPolicy(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def bindings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def bindings(self) -> pulumi.Output[Sequence[Any]]:
         """
         An association between a role, which comes with a set of permissions, and members who may assume that role.
         """

--- a/sdk/python/pulumi_gcp_native/storage/v1/object_iam_policy.py
+++ b/sdk/python/pulumi_gcp_native/storage/v1/object_iam_policy.py
@@ -15,7 +15,7 @@ class ObjectIamPolicy(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bindings: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 bindings: Optional[pulumi.Input[Sequence[Any]]] = None,
                  bucket: Optional[pulumi.Input[str]] = None,
                  etag: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
@@ -30,7 +30,7 @@ class ObjectIamPolicy(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] bindings: An association between a role, which comes with a set of permissions, and members who may assume that role.
+        :param pulumi.Input[Sequence[Any]] bindings: An association between a role, which comes with a set of permissions, and members who may assume that role.
         :param pulumi.Input[str] etag: HTTP 1.1  Entity tag for the policy.
         :param pulumi.Input[str] kind: The kind of item this is. For policies, this is always storage#policy. This field is ignored on input.
         :param pulumi.Input[str] resource_id: The ID of the resource to which this policy belongs. Will be of the form projects/_/buckets/bucket for buckets, and projects/_/buckets/bucket/objects/object for objects. A specific generation may be specified by appending #generationNumber to the end of the object name, e.g. projects/_/buckets/my-bucket/objects/data.txt#17. The current generation can be denoted with #0. This field is ignored on input.
@@ -95,7 +95,7 @@ class ObjectIamPolicy(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def bindings(self) -> pulumi.Output[Sequence[Mapping[str, str]]]:
+    def bindings(self) -> pulumi.Output[Sequence[Any]]:
         """
         An association between a role, which comes with a set of permissions, and members who may assume that role.
         """


### PR DESCRIPTION
Currently any type where the discovery doc labels the nested type in a list as `object` we emit an object type in schema which results in `map[string]string` or similar generated code. However, it seems fairly common for discovery docs to include inline types which easily break the `string->string` requirement. This change attempts to detect this and replace such types with `any` type instead.

I also included an example which demonstrates the problem. Without the change, the `allowed` block in the firewall would not compile – since the properties `IPProtocols` and `ports` expect different types.

Fixes: https://github.com/pulumi/pulumi-gcp-native/issues/18