### PR TITLE
Populate body parameter even if its name matches a url parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+CHANGELOG
+=========
+
+## HEAD (Unreleased)
+
+- Fix ManagedZoneRrset creation
+  [#61](https://github.com/pulumi/pulumi-google-native/issues/61)
+
+---
+
+## 0.1.0 (2021-04-19)
+
+The first beta release of the native Google Cloud Provider is out!

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -295,13 +295,8 @@ func (p *googleCloudProvider) Create(ctx context.Context, req *rpc.CreateRequest
 			key := resource.PropertyKey(param)
 			value := inputs[key].StringValue()
 			path = strings.Replace(path, fmt.Sprintf("{%s}", param), value, 1)
-			delete(inputs, key)
 		}
 		uri = res.RelativePath(path)
-		for _, param := range res.IdParams {
-			key := resource.PropertyKey(param)
-			delete(inputs, key)
-		}
 
 		inputsMap := inputs.Mappable()
 		body := map[string]interface{}{}


### PR DESCRIPTION
Removes a hack that is leftover from pre-metadata code. We don't need to remove ID parameters from the body anymore, as we have the full list of body parameters in the metadata.

It's a bit hard to create a test for DNS resources but I verified manually that the name is now being sent.

Fix https://github.com/pulumi/pulumi-google-native/issues/61