### PR TITLE
Recalculate __inputs during refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-(None)
+- Fix refresh to re-populate inputs and provide accurate diff and drift detection
+  [#65](https://github.com/pulumi/pulumi-google-native/issues/65)
 
 ---
 

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+package provider
+
+import (
+	"github.com/pulumi/pulumi-google-native/provider/pkg/resources"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// getInputsFromState calculates the inputs map given resource state.
+func getInputsFromState(res resources.CloudAPIResource, state resource.PropertyMap) resource.PropertyMap {
+	inputsMap := map[string]interface{}{}
+	stateMap := state.Mappable()
+	for name, prop := range res.CreateProperties {
+		parent := stateMap
+		if prop.Container != "" {
+			container, ok := stateMap[prop.Container].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			parent = container
+		}
+
+		if value, has := parent[name]; has {
+			inputsMap[name] = value
+		}
+	}
+	return resource.NewPropertyMapFromMap(inputsMap)
+}
+
+// applyDiff produces a new map as a merge of a calculated diff into an existing map of values.
+func applyDiff(values resource.PropertyMap, diff *resource.ObjectDiff) resource.PropertyMap {
+	if diff == nil {
+		return values
+	}
+
+	result := resource.PropertyMap{}
+	for name, value := range values {
+		if !diff.Deleted(name) {
+			result[name] = value
+		}
+	}
+	for key, value := range diff.Adds {
+		result[key] = value
+	}
+	for key, value := range diff.Updates {
+		result[key] = value.New
+	}
+	return result
+}

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+package provider
+
+import (
+	"github.com/pulumi/pulumi-google-native/provider/pkg/resources"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetInputsFromState(t *testing.T) {
+	res := resources.CloudAPIResource{
+		CreateProperties: map[string]resources.CloudAPIProperty{
+			"p1": {},
+			"p2": {
+				Container: "c1",
+			},
+			"p3": {},
+		},
+	}
+	state := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"p1": "v1",
+		"c1": map[string]interface{}{
+			"p2": "v2",
+		},
+		"p3": 123.456,
+		"output1": "should-be-ignored",
+	})
+	actual := getInputsFromState(res, state).Mappable()
+	expected := map[string]interface{}{
+		"p1": "v1",
+		"p2": "v2",
+		"p3": 123.456,
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestApplyDiff(t *testing.T) {
+	state := resource.PropertyMap{
+		"p1": {V: "oldvalue"},
+		"p2": {V: "iamdeleted"},
+	}
+	diff := resource.ObjectDiff{
+		Adds: resource.PropertyMap{
+			"p3": {V: "newkey"},
+		},
+		Deletes: resource.PropertyMap{
+			"p2": {V: "iamdeleted"},
+		},
+		Updates: map[resource.PropertyKey]resource.ValueDiff{
+			"p1": {
+				Old: resource.PropertyValue{V: "oldvalue"},
+				New: resource.PropertyValue{V: "newvalue"},
+			},
+		},
+	}
+	actual := applyDiff(state, &diff)
+	expected := resource.PropertyMap{
+		"p1": {V: "newvalue"},
+		"p3": {V: "newkey"},
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Our special `__inputs` property is the basis for diff calculation, so we should refresh it when `Read()` method is invoked. The implementation is copied from Azure-Native and AWS-Native modulo `getInputsFromState` which is specific for each provider metadata.

Fix https://github.com/pulumi/pulumi-google-native/issues/65