### PR TITLE
Store metadata for all types

### DIFF
--- a/provider/pkg/resources/convert.go
+++ b/provider/pkg/resources/convert.go
@@ -1,0 +1,90 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+package resources
+
+import (
+	"reflect"
+	"strings"
+)
+
+const body = "body"
+
+// SdkShapeConverter providers functions to convert between HTTP request/response shapes and
+// Pulumi SDK shapes (with flattening, renaming, etc.).
+type SdkShapeConverter struct {
+	Types map[string]CloudAPIType
+}
+
+type convertPropValues func(props map[string]CloudAPIProperty, values map[string]interface{}) map[string]interface{}
+
+func (k *SdkShapeConverter) convertPropValue(prop *CloudAPIProperty, value interface{}, convertMap convertPropValues) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	switch reflect.TypeOf(value).Kind() {
+	case reflect.Map:
+		valueMap, ok := value.(map[string]interface{})
+		if !ok {
+			return value
+		}
+
+		if strings.HasPrefix(prop.Ref, "#/types/") {
+			typeName := strings.TrimPrefix(prop.Ref, "#/types/")
+			typ, ok := k.Types[typeName]
+			if !ok {
+				return value
+			}
+			return convertMap(typ.Properties, valueMap)
+		}
+
+		if prop.AdditionalProperties != nil {
+			result := map[string]interface{}{}
+			for key, item := range valueMap {
+				result[key] = k.convertPropValue(prop.AdditionalProperties, item, convertMap)
+			}
+			return result
+		}
+
+		return value
+	case reflect.Slice, reflect.Array:
+		if prop.Items == nil {
+			return value
+		}
+
+		result := make([]interface{}, 0)
+		s := reflect.ValueOf(value)
+		for i := 0; i < s.Len(); i++ {
+			result = append(result, k.convertPropValue(prop.Items, s.Index(i).Interface(), convertMap))
+		}
+		return result
+	}
+	return value
+}
+
+// SdkPropertiesToRequestBody converts a map of SDK properties to JSON request body to be sent to an HTTP API.
+func (k *SdkShapeConverter) SdkPropertiesToRequestBody(props map[string]CloudAPIProperty,
+	values map[string]interface{}) map[string]interface{} {
+
+	body := map[string]interface{}{}
+	for name, prop := range props {
+		p := prop // https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable
+		parent := body
+		sdkName := name
+		if prop.SdkName != "" {
+			sdkName = prop.SdkName
+		}
+		if value, has := values[sdkName]; has {
+			if prop.Container != "" {
+				if v, has := body[prop.Container].(map[string]interface{}); has {
+					parent = v
+				} else {
+					parent = map[string]interface{}{}
+					body[prop.Container] = parent
+				}
+			}
+			parent[name] = k.convertPropValue(&p, value, k.SdkPropertiesToRequestBody)
+		}
+	}
+	return body
+}

--- a/provider/pkg/resources/convert_test.go
+++ b/provider/pkg/resources/convert_test.go
@@ -1,0 +1,201 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var resourceMap = &CloudAPIMetadata{
+	Types: map[string]CloudAPIType{
+		"google-native:testing:Structure": {
+			Properties: map[string]CloudAPIProperty{
+				"v1": {},
+				"v2": {},
+				"v3-odd": {
+					SdkName: "v3",
+				},
+				"v4-nested": {
+					SdkName:    "v4",
+					Container: "props",
+				},
+			},
+		},
+		"google-native:testing:More": {
+			Properties: map[string]CloudAPIProperty{
+				"items": {
+					Items: &CloudAPIProperty{
+						Ref: "#/types/google-native:testing:MoreItem",
+					},
+				},
+				"itemsMap": {
+					AdditionalProperties: &CloudAPIProperty{
+						Ref: "#/types/google-native:testing:MoreItem",
+					},
+				},
+			},
+		},
+		"google-native:testing:MoreItem": {
+			Properties: map[string]CloudAPIProperty{
+				"aaa": {
+					SdkName: "Aaa",
+				},
+				"bbb": {
+					Container: "ccc",
+				},
+			},
+		},
+	},
+	Resources: map[string]CloudAPIResource{
+		"r1": {
+			CreateProperties: map[string]CloudAPIProperty{
+				"name": {},
+				"x-threshold": {
+					SdkName: "threshold",
+				},
+				"structure": {
+					Ref: "#/types/google-native:testing:Structure",
+				},
+				"p1": {
+					Container: "properties",
+				},
+				"p2": {
+					Container: "properties",
+				},
+				"more": {
+					Container: "properties",
+					Ref:        "#/types/google-native:testing:More",
+				},
+				"tags":         {},
+				"untypedArray": {},
+				"untypedDict": {
+					Ref: "pulumi.json#/Any",
+				},
+			},
+		},
+	},
+}
+
+var c = SdkShapeConverter{Types: resourceMap.Types}
+
+var sampleAPIPackage = map[string]interface{}{
+	"name":        "MyResource",
+	"x-threshold": 123,
+	"structure": map[string]interface{}{
+		"v1":     "value1",
+		"v2":     2,
+		"v3-odd": "odd-value",
+		"props": map[string]interface{}{
+			"v4-nested": true,
+		},
+	},
+	"properties": map[string]interface{}{
+		"p1": "prop1",
+		"p2": "prop2",
+		"more": map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{"aaa": "111", "ccc": map[string]interface{}{"bbb": "333"}},
+				map[string]interface{}{"aaa": "222"},
+			},
+			"itemsMap": map[string]interface{}{
+				"key1": map[string]interface{}{"aaa": "444", "ccc": map[string]interface{}{"bbb": "555"}},
+				"key2": map[string]interface{}{"aaa": "666"},
+			},
+		},
+	},
+	"tags": map[string]interface{}{
+		"createdBy":   "admin",
+		"application": "dashboard",
+	},
+	"untypedArray": []interface{}{
+		map[string]interface{}{"key1": "value1"},
+		map[string]interface{}{"key1": "value2"},
+	},
+	"untypedDict": map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	},
+}
+var sampleSdkProps = map[string]interface{}{
+	"name":      "MyResource",
+	"threshold": 123,
+	"structure": map[string]interface{}{
+		"v1": "value1",
+		"v2": 2,
+		"v3": "odd-value",
+		"v4": true,
+	},
+	"p1": "prop1",
+	"p2": "prop2",
+	"p3": "prop3",
+	"more": map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"Aaa": "111", "bbb": "333"},
+			map[string]interface{}{"Aaa": "222"},
+		},
+		"itemsMap": map[string]interface{}{
+			"key1": map[string]interface{}{"Aaa": "444", "bbb": "555"},
+			"key2": map[string]interface{}{"Aaa": "666"},
+		},
+	},
+	"tags": map[string]interface{}{
+		"createdBy":   "admin",
+		"application": "dashboard",
+	},
+	"untypedArray": []interface{}{
+		map[string]interface{}{"key1": "value1"},
+		map[string]interface{}{"key1": "value2"},
+	},
+	"untypedDict": map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	},
+}
+
+func TestSdkPropertiesToRequestBody(t *testing.T) {
+	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	data := c.SdkPropertiesToRequestBody(bodyProperties, sampleSdkProps)
+	assert.Equal(t, sampleAPIPackage, data)
+}
+
+func TestSdkPropertiesToRequestBodyEmptyCollections(t *testing.T) {
+	var emptyCollectionData = map[string]interface{}{
+		"more": map[string]interface{}{
+			"items":    make([]interface{}, 0),
+			"itemsMap": make(map[string]interface{}),
+		},
+	}
+	var expectedBody = map[string]interface{}{
+		"properties": map[string]interface{}{
+			"more": map[string]interface{}{
+				"items":    make([]interface{}, 0),
+				"itemsMap": make(map[string]interface{}),
+			},
+		},
+	}
+	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	actualBody := c.SdkPropertiesToRequestBody(bodyProperties, emptyCollectionData)
+	assert.Equal(t, expectedBody, actualBody)
+}
+
+func TestSdkPropertiesToRequestBodyNilCollections(t *testing.T) {
+	var nilCollectionData = map[string]interface{}{
+		"more": map[string]interface{}{
+			"items":    nil,
+			"itemsMap": nil,
+		},
+	}
+	var expectedBody = map[string]interface{}{
+		"properties": map[string]interface{}{
+			"more": map[string]interface{}{
+				"items":    nil,
+				"itemsMap": nil,
+			},
+		},
+	}
+	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	actualBody := c.SdkPropertiesToRequestBody(bodyProperties, nilCollectionData)
+	assert.Equal(t, expectedBody, actualBody)
+}

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -69,7 +69,7 @@ type CloudAPIProperty struct {
 	SdkName   string `json:"sdkName,omitempty"`
 }
 
-// AzureAPIType represents the shape of an auxiliary type in the API.
+// CloudAPIType represents the shape of an auxiliary type in the API.
 type CloudAPIType struct {
 	Properties map[string]CloudAPIProperty `json:"properties,omitempty"`
 }

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -9,6 +9,7 @@ import (
 
 // CloudAPIMetadata is a collection of all resources and functions in the Google Cloud REST API.
 type CloudAPIMetadata struct {
+	Types     map[string]CloudAPIType     `json:"types"`
 	Resources map[string]CloudAPIResource `json:"resources"`
 	Functions map[string]CloudAPIFunction `json:"functions"`
 }
@@ -59,8 +60,16 @@ func CombineUrl(baseUrl, path string) string {
 
 // CloudAPIProperty is a property of a body of an API call payload.
 type CloudAPIProperty struct {
+	Ref                  string            `json:"$ref,omitempty"`
+	Items                *CloudAPIProperty `json:"items,omitempty"`
+	AdditionalProperties *CloudAPIProperty `json:"additionalProperties,omitempty"`
 	// The name of the container property that was "flattened" during SDK generation, i.e. extra layer that exists
 	// in the API payload but does not exist in the SDK.
 	Container string `json:"container,omitempty"`
 	SdkName   string `json:"sdkName,omitempty"`
+}
+
+// AzureAPIType represents the shape of an auxiliary type in the API.
+type CloudAPIType struct {
+	Properties map[string]CloudAPIProperty `json:"properties,omitempty"`
 }


### PR DESCRIPTION
I extended metadata to keep information about named types, maps, and arrays in addition to resource metadata that we have today. This is needed for the follow-up PR that tracks [fingerprint](https://github.com/pulumi/pulumi-google-native/issues/126) properties in the metadata. I expect we'll get more use cases in the future - basically every time the shape of SDK needs to differ from the wire format.

This is a technical change that shouldn't affect end users. The code is largely copied from azure-native.