### PR TITLE
Normalize remaining properties to camel case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Bug fixes:
 - Fix the representation of properties marked as `[Output only]`
   [#134](https://github.com/pulumi/pulumi-google-native/issues/134),
   [#135](https://github.com/pulumi/pulumi-google-native/issues/135)
+- Normalize property naming to lowerCamelCase
+  [#146](https://github.com/pulumi/pulumi-google-native/pull/146)
 
 ---
 

--- a/examples/webserver-ts/index.ts
+++ b/examples/webserver-ts/index.ts
@@ -26,7 +26,7 @@ const computeFirewall = new google.compute.v1.Firewall("firewall", {
     name: pulumi.interpolate`${randomString.result}-fw`,
     project: project,
     allowed: [{
-        IPProtocol: "tcp",
+        ipProtocol: "tcp",
         ports: ["22", "80"],
     }],
 });

--- a/provider/pkg/gen/discovery.go
+++ b/provider/pkg/gen/discovery.go
@@ -200,7 +200,7 @@ func findApiParams(dd discoveryDocumentResource) codegen.StringSet {
 	params := findParams(path)
 	result := codegen.NewStringSet()
 	for _, param := range params {
-		result.Add(apiNameToSdkName(param))
+		result.Add(apiParamNameToSdkName(param))
 	}
 	return result
 }

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -299,7 +299,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		}
 
 		name := names[1]
-		sdkName := apiNameToSdkName(name)
+		sdkName := apiParamNameToSdkName(name)
 		inputProperties[sdkName] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{Type: "string"},
 		}
@@ -495,7 +495,7 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 		}
 
 		name := names[1]
-		sdkName := apiNameToSdkName(name)
+		sdkName := apiParamNameToSdkName(name)
 		inputProperties[sdkName] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{Type: "string"},
 		}
@@ -560,7 +560,7 @@ func (g *packageGenerator) buildIdParams(typeName string, idPath string, inputPr
 		name := names[1]
 
 		// If the property is already defined in the input args, add its SDK name.
-		sdkName := apiNameToSdkName(name)
+		sdkName := apiParamNameToSdkName(name)
 		if _, has := inputProperties[sdkName]; has {
 			result[name] = sdkName
 			continue
@@ -612,7 +612,7 @@ func (g *packageGenerator) buildIdParams(typeName string, idPath string, inputPr
 		name := names[1]
 
 		// If the property is already defined in the input args, add its SDK name.
-		sdkName := apiNameToSdkName(name)
+		sdkName := apiParamNameToSdkName(name)
 		if _, has := inputProperties[sdkName]; has {
 			result[name] = sdkName
 			continue
@@ -656,7 +656,7 @@ func (g *packageGenerator) genProperties(typeName string, typeSchema *discovery.
 	}
 	for _, name := range codegen.SortedKeys(typeSchema.Properties) {
 		value := typeSchema.Properties[name]
-		sdkName := apiNameToSdkName(name)
+		sdkName := apiPropNameToSdkName(name)
 
 		if isDeprecated(value.Description) {
 			continue

--- a/provider/pkg/gen/utilities.go
+++ b/provider/pkg/gen/utilities.go
@@ -10,9 +10,9 @@ import (
 
 var s = codegen.NewStringSet()
 
-// apiNameToSdkName returns an SDK name for a given API parameter or property name.
+// apiParamNameToSdkName returns an SDK name for a given API parameter name.
 // In particular, it converts pluralized ID names to singular ID names.
-func apiNameToSdkName(name string) string {
+func apiParamNameToSdkName(name string) string {
 	if strings.HasSuffix(name, "Id") {
 		name = inflector.Singularize(name[:len(name)-2])
 		switch name {
@@ -27,6 +27,17 @@ func apiNameToSdkName(name string) string {
 	return name
 }
 
+// apiPropNameToSdkName returns an SDK name for a given API property name.
+// In particular, it converts pluralized ID names to singular ID names.
+func apiPropNameToSdkName(name string) string {
+	switch name {
+	case "projectId", "locationId", "managedZoneId":
+		return name[:len(name)-2]
+	default:
+		return ToLowerCamel(name)
+	}
+}
+
 // ToLowerCamel converts a string to lowerCamelCase.
 // The code is adopted from https://github.com/iancoleman/strcase but changed in several ways to handle
 // all the cases that are found in API specs in a most user-friendly way.
@@ -34,11 +45,13 @@ func ToLowerCamel(s string) string {
 	if s == "" {
 		return s
 	}
-	if uppercaseAcronym[s] {
-		s = strings.ToLower(s)
-	}
 	if r := rune(s[0]); r == '_' {
 		s = s[1:]
+	}
+	for _, acronym := range uppercaseAcronyms {
+		if strings.HasPrefix(s, acronym) {
+			s = strings.ToLower(acronym) + strings.TrimPrefix(s, acronym)
+		}
 	}
 	if r := rune(s[0]); r >= 'A' && r <= 'Z' {
 		s = strings.ToLower(string(r)) + s[1:]
@@ -83,7 +96,6 @@ func toCamelInitCase(s string, initCase bool) string {
 	return n
 }
 
-var uppercaseAcronym = map[string]bool{
-	"ID":  true,
-	"TTL": true,
+var uppercaseAcronyms = []string{
+	"IP",
 }

--- a/provider/pkg/gen/utilities_test.go
+++ b/provider/pkg/gen/utilities_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-var apiToSdkNames = map[string]string{
+var apiParamToSdkNames = map[string]string{
 	"projectsId":               "project",
 	"locationId":               "location",
 	"managedZonesId":           "managedZone",
@@ -18,9 +18,25 @@ var apiToSdkNames = map[string]string{
 	"dataId":                   "dataId",
 }
 
-func TestApiNameToSdkName(t *testing.T) {
-	for name, expected := range apiToSdkNames {
-		actual := apiNameToSdkName(name)
+func TestApiParamNameToSdkName(t *testing.T) {
+	for name, expected := range apiParamToSdkNames {
+		actual := apiParamNameToSdkName(name)
+		assert.Equal(t, expected, actual)
+	}
+}
+
+var apiPropToSdkNames = map[string]string{
+	"projectId":         "project",
+	"locationId":        "location",
+	"managedZoneId":     "managedZone",
+	"ApiName":           "apiName",
+	"IPAddress":         "ipAddress",
+	"custom_attributes": "customAttributes",
+}
+
+func TestApiPropNameToSdkName(t *testing.T) {
+	for name, expected := range apiPropToSdkNames {
+		actual := apiPropNameToSdkName(name)
 		assert.Equal(t, expected, actual)
 	}
 }

--- a/sdk/dotnet/Apigee/V1/Inputs/GoogleCloudApigeeV1CanaryEvaluationMetricLabelsArgs.cs
+++ b/sdk/dotnet/Apigee/V1/Inputs/GoogleCloudApigeeV1CanaryEvaluationMetricLabelsArgs.cs
@@ -24,8 +24,8 @@ namespace Pulumi.GoogleNative.Apigee.V1.Inputs
         /// <summary>
         /// Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
         /// </summary>
-        [Input("instance_id")]
-        public Input<string>? Instance_id { get; set; }
+        [Input("instanceId")]
+        public Input<string>? InstanceId { get; set; }
 
         /// <summary>
         /// Required. The location associated with the metrics.

--- a/sdk/dotnet/Apigee/V1/Outputs/GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse.cs
+++ b/sdk/dotnet/Apigee/V1/Outputs/GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse.cs
@@ -20,7 +20,7 @@ namespace Pulumi.GoogleNative.Apigee.V1.Outputs
         /// <summary>
         /// Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
         /// </summary>
-        public readonly string Instance_id;
+        public readonly string InstanceId;
         /// <summary>
         /// Required. The location associated with the metrics.
         /// </summary>
@@ -30,12 +30,12 @@ namespace Pulumi.GoogleNative.Apigee.V1.Outputs
         private GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse(
             string env,
 
-            string instance_id,
+            string instanceId,
 
             string location)
         {
             Env = env;
-            Instance_id = instance_id;
+            InstanceId = instanceId;
             Location = location;
         }
     }

--- a/sdk/dotnet/BigQuery/V2/GetJob.cs
+++ b/sdk/dotnet/BigQuery/V2/GetJob.cs
@@ -70,7 +70,7 @@ namespace Pulumi.GoogleNative.BigQuery.V2
         /// <summary>
         /// Email address of the user who ran the job.
         /// </summary>
-        public readonly string User_email;
+        public readonly string UserEmail;
 
         [OutputConstructor]
         private GetJobResult(
@@ -88,7 +88,7 @@ namespace Pulumi.GoogleNative.BigQuery.V2
 
             Outputs.JobStatusResponse status,
 
-            string user_email)
+            string userEmail)
         {
             Configuration = configuration;
             Etag = etag;
@@ -97,7 +97,7 @@ namespace Pulumi.GoogleNative.BigQuery.V2
             SelfLink = selfLink;
             Statistics = statistics;
             Status = status;
-            User_email = user_email;
+            UserEmail = userEmail;
         }
     }
 }

--- a/sdk/dotnet/BigQuery/V2/Inputs/DatasetAccessEntryArgs.cs
+++ b/sdk/dotnet/BigQuery/V2/Inputs/DatasetAccessEntryArgs.cs
@@ -18,12 +18,12 @@ namespace Pulumi.GoogleNative.BigQuery.V2.Inputs
         [Input("dataset")]
         public Input<Inputs.DatasetReferenceArgs>? Dataset { get; set; }
 
-        [Input("target_types")]
-        private InputList<Inputs.DatasetAccessEntryTarget_typesItemArgs>? _target_types;
-        public InputList<Inputs.DatasetAccessEntryTarget_typesItemArgs> Target_types
+        [Input("targetTypes")]
+        private InputList<Inputs.DatasetAccessEntryTargetTypesItemArgs>? _targetTypes;
+        public InputList<Inputs.DatasetAccessEntryTargetTypesItemArgs> TargetTypes
         {
-            get => _target_types ?? (_target_types = new InputList<Inputs.DatasetAccessEntryTarget_typesItemArgs>());
-            set => _target_types = value;
+            get => _targetTypes ?? (_targetTypes = new InputList<Inputs.DatasetAccessEntryTargetTypesItemArgs>());
+            set => _targetTypes = value;
         }
 
         public DatasetAccessEntryArgs()

--- a/sdk/dotnet/BigQuery/V2/Inputs/DatasetAccessEntryTargetTypesItemArgs.cs
+++ b/sdk/dotnet/BigQuery/V2/Inputs/DatasetAccessEntryTargetTypesItemArgs.cs
@@ -7,21 +7,19 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Pulumi.Serialization;
 
-namespace Pulumi.GoogleNative.BigQuery.V2.Outputs
+namespace Pulumi.GoogleNative.BigQuery.V2.Inputs
 {
 
-    [OutputType]
-    public sealed class DatasetAccessEntryTarget_typesItemResponse
+    public sealed class DatasetAccessEntryTargetTypesItemArgs : Pulumi.ResourceArgs
     {
         /// <summary>
         /// [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
         /// </summary>
-        public readonly string TargetType;
+        [Input("targetType")]
+        public Input<string>? TargetType { get; set; }
 
-        [OutputConstructor]
-        private DatasetAccessEntryTarget_typesItemResponse(string targetType)
+        public DatasetAccessEntryTargetTypesItemArgs()
         {
-            TargetType = targetType;
         }
     }
 }

--- a/sdk/dotnet/BigQuery/V2/Job.cs
+++ b/sdk/dotnet/BigQuery/V2/Job.cs
@@ -60,8 +60,8 @@ namespace Pulumi.GoogleNative.BigQuery.V2
         /// <summary>
         /// Email address of the user who ran the job.
         /// </summary>
-        [Output("user_email")]
-        public Output<string> User_email { get; private set; } = null!;
+        [Output("userEmail")]
+        public Output<string> UserEmail { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/BigQuery/V2/Outputs/DatasetAccessEntryResponse.cs
+++ b/sdk/dotnet/BigQuery/V2/Outputs/DatasetAccessEntryResponse.cs
@@ -17,16 +17,16 @@ namespace Pulumi.GoogleNative.BigQuery.V2.Outputs
         /// [Required] The dataset this entry applies to.
         /// </summary>
         public readonly Outputs.DatasetReferenceResponse Dataset;
-        public readonly ImmutableArray<Outputs.DatasetAccessEntryTarget_typesItemResponse> Target_types;
+        public readonly ImmutableArray<Outputs.DatasetAccessEntryTargetTypesItemResponse> TargetTypes;
 
         [OutputConstructor]
         private DatasetAccessEntryResponse(
             Outputs.DatasetReferenceResponse dataset,
 
-            ImmutableArray<Outputs.DatasetAccessEntryTarget_typesItemResponse> target_types)
+            ImmutableArray<Outputs.DatasetAccessEntryTargetTypesItemResponse> targetTypes)
         {
             Dataset = dataset;
-            Target_types = target_types;
+            TargetTypes = targetTypes;
         }
     }
 }

--- a/sdk/dotnet/BigQuery/V2/Outputs/DatasetAccessEntryTargetTypesItemResponse.cs
+++ b/sdk/dotnet/BigQuery/V2/Outputs/DatasetAccessEntryTargetTypesItemResponse.cs
@@ -7,19 +7,21 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Pulumi.Serialization;
 
-namespace Pulumi.GoogleNative.BigQuery.V2.Inputs
+namespace Pulumi.GoogleNative.BigQuery.V2.Outputs
 {
 
-    public sealed class DatasetAccessEntryTarget_typesItemArgs : Pulumi.ResourceArgs
+    [OutputType]
+    public sealed class DatasetAccessEntryTargetTypesItemResponse
     {
         /// <summary>
         /// [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
         /// </summary>
-        [Input("targetType")]
-        public Input<string>? TargetType { get; set; }
+        public readonly string TargetType;
 
-        public DatasetAccessEntryTarget_typesItemArgs()
+        [OutputConstructor]
+        private DatasetAccessEntryTargetTypesItemResponse(string targetType)
         {
+            TargetType = targetType;
         }
     }
 }

--- a/sdk/dotnet/BigQuery/V2/Outputs/JobStatisticsResponse.cs
+++ b/sdk/dotnet/BigQuery/V2/Outputs/JobStatisticsResponse.cs
@@ -50,13 +50,13 @@ namespace Pulumi.GoogleNative.BigQuery.V2.Outputs
         /// </summary>
         public readonly ImmutableArray<string> QuotaDeferments;
         /// <summary>
+        /// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+        /// </summary>
+        public readonly string ReservationId;
+        /// <summary>
         /// Job resource usage breakdown by reservation.
         /// </summary>
         public readonly ImmutableArray<Outputs.JobStatisticsReservationUsageItemResponse> ReservationUsage;
-        /// <summary>
-        /// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
-        /// </summary>
-        public readonly string Reservation_id;
         /// <summary>
         /// [Preview] Statistics for row-level security. Present only for query and extract jobs.
         /// </summary>
@@ -102,9 +102,9 @@ namespace Pulumi.GoogleNative.BigQuery.V2.Outputs
 
             ImmutableArray<string> quotaDeferments,
 
-            ImmutableArray<Outputs.JobStatisticsReservationUsageItemResponse> reservationUsage,
+            string reservationId,
 
-            string reservation_id,
+            ImmutableArray<Outputs.JobStatisticsReservationUsageItemResponse> reservationUsage,
 
             Outputs.RowLevelSecurityStatisticsResponse rowLevelSecurityStatistics,
 
@@ -127,8 +127,8 @@ namespace Pulumi.GoogleNative.BigQuery.V2.Outputs
             ParentJobId = parentJobId;
             Query = query;
             QuotaDeferments = quotaDeferments;
+            ReservationId = reservationId;
             ReservationUsage = reservationUsage;
-            Reservation_id = reservation_id;
             RowLevelSecurityStatistics = rowLevelSecurityStatistics;
             ScriptStatistics = scriptStatistics;
             SessionInfoTemplate = sessionInfoTemplate;

--- a/sdk/dotnet/Compute/Alpha/Enums.cs
+++ b/sdk/dotnet/Compute/Alpha/Enums.cs
@@ -1474,31 +1474,31 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
     /// </summary>
     [EnumType]
-    public readonly struct ForwardingRuleIPProtocol : IEquatable<ForwardingRuleIPProtocol>
+    public readonly struct ForwardingRuleIpProtocol : IEquatable<ForwardingRuleIpProtocol>
     {
         private readonly string _value;
 
-        private ForwardingRuleIPProtocol(string value)
+        private ForwardingRuleIpProtocol(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        public static ForwardingRuleIPProtocol Ah { get; } = new ForwardingRuleIPProtocol("AH");
-        public static ForwardingRuleIPProtocol All { get; } = new ForwardingRuleIPProtocol("ALL");
-        public static ForwardingRuleIPProtocol Esp { get; } = new ForwardingRuleIPProtocol("ESP");
-        public static ForwardingRuleIPProtocol Icmp { get; } = new ForwardingRuleIPProtocol("ICMP");
-        public static ForwardingRuleIPProtocol Sctp { get; } = new ForwardingRuleIPProtocol("SCTP");
-        public static ForwardingRuleIPProtocol Tcp { get; } = new ForwardingRuleIPProtocol("TCP");
-        public static ForwardingRuleIPProtocol Udp { get; } = new ForwardingRuleIPProtocol("UDP");
+        public static ForwardingRuleIpProtocol Ah { get; } = new ForwardingRuleIpProtocol("AH");
+        public static ForwardingRuleIpProtocol All { get; } = new ForwardingRuleIpProtocol("ALL");
+        public static ForwardingRuleIpProtocol Esp { get; } = new ForwardingRuleIpProtocol("ESP");
+        public static ForwardingRuleIpProtocol Icmp { get; } = new ForwardingRuleIpProtocol("ICMP");
+        public static ForwardingRuleIpProtocol Sctp { get; } = new ForwardingRuleIpProtocol("SCTP");
+        public static ForwardingRuleIpProtocol Tcp { get; } = new ForwardingRuleIpProtocol("TCP");
+        public static ForwardingRuleIpProtocol Udp { get; } = new ForwardingRuleIpProtocol("UDP");
 
-        public static bool operator ==(ForwardingRuleIPProtocol left, ForwardingRuleIPProtocol right) => left.Equals(right);
-        public static bool operator !=(ForwardingRuleIPProtocol left, ForwardingRuleIPProtocol right) => !left.Equals(right);
+        public static bool operator ==(ForwardingRuleIpProtocol left, ForwardingRuleIpProtocol right) => left.Equals(right);
+        public static bool operator !=(ForwardingRuleIpProtocol left, ForwardingRuleIpProtocol right) => !left.Equals(right);
 
-        public static explicit operator string(ForwardingRuleIPProtocol value) => value._value;
+        public static explicit operator string(ForwardingRuleIpProtocol value) => value._value;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object? obj) => obj is ForwardingRuleIPProtocol other && Equals(other);
-        public bool Equals(ForwardingRuleIPProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => obj is ForwardingRuleIpProtocol other && Equals(other);
+        public bool Equals(ForwardingRuleIpProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;
@@ -1851,31 +1851,31 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
     /// </summary>
     [EnumType]
-    public readonly struct GlobalForwardingRuleIPProtocol : IEquatable<GlobalForwardingRuleIPProtocol>
+    public readonly struct GlobalForwardingRuleIpProtocol : IEquatable<GlobalForwardingRuleIpProtocol>
     {
         private readonly string _value;
 
-        private GlobalForwardingRuleIPProtocol(string value)
+        private GlobalForwardingRuleIpProtocol(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        public static GlobalForwardingRuleIPProtocol Ah { get; } = new GlobalForwardingRuleIPProtocol("AH");
-        public static GlobalForwardingRuleIPProtocol All { get; } = new GlobalForwardingRuleIPProtocol("ALL");
-        public static GlobalForwardingRuleIPProtocol Esp { get; } = new GlobalForwardingRuleIPProtocol("ESP");
-        public static GlobalForwardingRuleIPProtocol Icmp { get; } = new GlobalForwardingRuleIPProtocol("ICMP");
-        public static GlobalForwardingRuleIPProtocol Sctp { get; } = new GlobalForwardingRuleIPProtocol("SCTP");
-        public static GlobalForwardingRuleIPProtocol Tcp { get; } = new GlobalForwardingRuleIPProtocol("TCP");
-        public static GlobalForwardingRuleIPProtocol Udp { get; } = new GlobalForwardingRuleIPProtocol("UDP");
+        public static GlobalForwardingRuleIpProtocol Ah { get; } = new GlobalForwardingRuleIpProtocol("AH");
+        public static GlobalForwardingRuleIpProtocol All { get; } = new GlobalForwardingRuleIpProtocol("ALL");
+        public static GlobalForwardingRuleIpProtocol Esp { get; } = new GlobalForwardingRuleIpProtocol("ESP");
+        public static GlobalForwardingRuleIpProtocol Icmp { get; } = new GlobalForwardingRuleIpProtocol("ICMP");
+        public static GlobalForwardingRuleIpProtocol Sctp { get; } = new GlobalForwardingRuleIpProtocol("SCTP");
+        public static GlobalForwardingRuleIpProtocol Tcp { get; } = new GlobalForwardingRuleIpProtocol("TCP");
+        public static GlobalForwardingRuleIpProtocol Udp { get; } = new GlobalForwardingRuleIpProtocol("UDP");
 
-        public static bool operator ==(GlobalForwardingRuleIPProtocol left, GlobalForwardingRuleIPProtocol right) => left.Equals(right);
-        public static bool operator !=(GlobalForwardingRuleIPProtocol left, GlobalForwardingRuleIPProtocol right) => !left.Equals(right);
+        public static bool operator ==(GlobalForwardingRuleIpProtocol left, GlobalForwardingRuleIpProtocol right) => left.Equals(right);
+        public static bool operator !=(GlobalForwardingRuleIpProtocol left, GlobalForwardingRuleIpProtocol right) => !left.Equals(right);
 
-        public static explicit operator string(GlobalForwardingRuleIPProtocol value) => value._value;
+        public static explicit operator string(GlobalForwardingRuleIpProtocol value) => value._value;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object? obj) => obj is GlobalForwardingRuleIPProtocol other && Equals(other);
-        public bool Equals(GlobalForwardingRuleIPProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => obj is GlobalForwardingRuleIpProtocol other && Equals(other);
+        public bool Equals(GlobalForwardingRuleIpProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;

--- a/sdk/dotnet/Compute/Alpha/ForwardingRule.cs
+++ b/sdk/dotnet/Compute/Alpha/ForwardingRule.cs
@@ -16,41 +16,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     public partial class ForwardingRule : Pulumi.CustomResource
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Output("IPAddress")]
-        public Output<string> IPAddress { get; private set; } = null!;
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Output("IPProtocol")]
-        public Output<string> IPProtocol { get; private set; } = null!;
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +54,41 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// </summary>
         [Output("fingerprint")]
         public Output<string> Fingerprint { get; private set; } = null!;
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Output("ipAddress")]
+        public Output<string> IpAddress { get; private set; } = null!;
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Output("ipProtocol")]
+        public Output<string> IpProtocol { get; private set; } = null!;
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
@@ -320,41 +320,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     public sealed class ForwardingRuleArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Input("IPAddress")]
-        public Input<string>? IPAddress { get; set; }
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Input("IPProtocol")]
-        public Input<Pulumi.GoogleNative.Compute.Alpha.ForwardingRuleIPProtocol>? IPProtocol { get; set; }
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -379,6 +344,41 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Input("ipAddress")]
+        public Input<string>? IpAddress { get; set; }
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Input("ipProtocol")]
+        public Input<Pulumi.GoogleNative.Compute.Alpha.ForwardingRuleIpProtocol>? IpProtocol { get; set; }
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.

--- a/sdk/dotnet/Compute/Alpha/GetForwardingRule.cs
+++ b/sdk/dotnet/Compute/Alpha/GetForwardingRule.cs
@@ -40,37 +40,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     public sealed class GetForwardingRuleResult
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        public readonly string IPAddress;
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        public readonly string IPProtocol;
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -98,6 +67,37 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         /// </summary>
         public readonly string Fingerprint;
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        public readonly string IpAddress;
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        public readonly string IpProtocol;
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         /// </summary>
@@ -241,10 +241,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
 
         [OutputConstructor]
         private GetForwardingRuleResult(
-            string IPAddress,
-
-            string IPProtocol,
-
             bool allPorts,
 
             bool allowGlobalAccess,
@@ -256,6 +252,10 @@ namespace Pulumi.GoogleNative.Compute.Alpha
             string description,
 
             string fingerprint,
+
+            string ipAddress,
+
+            string ipProtocol,
 
             string ipVersion,
 
@@ -301,14 +301,14 @@ namespace Pulumi.GoogleNative.Compute.Alpha
 
             string target)
         {
-            this.IPAddress = IPAddress;
-            this.IPProtocol = IPProtocol;
             AllPorts = allPorts;
             AllowGlobalAccess = allowGlobalAccess;
             BackendService = backendService;
             CreationTimestamp = creationTimestamp;
             Description = description;
             Fingerprint = fingerprint;
+            IpAddress = ipAddress;
+            IpProtocol = ipProtocol;
             IpVersion = ipVersion;
             IsMirroringCollector = isMirroringCollector;
             Kind = kind;

--- a/sdk/dotnet/Compute/Alpha/GetGlobalForwardingRule.cs
+++ b/sdk/dotnet/Compute/Alpha/GetGlobalForwardingRule.cs
@@ -37,37 +37,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     public sealed class GetGlobalForwardingRuleResult
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        public readonly string IPAddress;
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        public readonly string IPProtocol;
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -95,6 +64,37 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         /// </summary>
         public readonly string Fingerprint;
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        public readonly string IpAddress;
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        public readonly string IpProtocol;
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         /// </summary>
@@ -238,10 +238,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
 
         [OutputConstructor]
         private GetGlobalForwardingRuleResult(
-            string IPAddress,
-
-            string IPProtocol,
-
             bool allPorts,
 
             bool allowGlobalAccess,
@@ -253,6 +249,10 @@ namespace Pulumi.GoogleNative.Compute.Alpha
             string description,
 
             string fingerprint,
+
+            string ipAddress,
+
+            string ipProtocol,
 
             string ipVersion,
 
@@ -298,14 +298,14 @@ namespace Pulumi.GoogleNative.Compute.Alpha
 
             string target)
         {
-            this.IPAddress = IPAddress;
-            this.IPProtocol = IPProtocol;
             AllPorts = allPorts;
             AllowGlobalAccess = allowGlobalAccess;
             BackendService = backendService;
             CreationTimestamp = creationTimestamp;
             Description = description;
             Fingerprint = fingerprint;
+            IpAddress = ipAddress;
+            IpProtocol = ipProtocol;
             IpVersion = ipVersion;
             IsMirroringCollector = isMirroringCollector;
             Kind = kind;

--- a/sdk/dotnet/Compute/Alpha/GlobalForwardingRule.cs
+++ b/sdk/dotnet/Compute/Alpha/GlobalForwardingRule.cs
@@ -16,41 +16,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     public partial class GlobalForwardingRule : Pulumi.CustomResource
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Output("IPAddress")]
-        public Output<string> IPAddress { get; private set; } = null!;
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Output("IPProtocol")]
-        public Output<string> IPProtocol { get; private set; } = null!;
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +54,41 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// </summary>
         [Output("fingerprint")]
         public Output<string> Fingerprint { get; private set; } = null!;
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Output("ipAddress")]
+        public Output<string> IpAddress { get; private set; } = null!;
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Output("ipProtocol")]
+        public Output<string> IpProtocol { get; private set; } = null!;
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
@@ -320,41 +320,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
     public sealed class GlobalForwardingRuleArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Input("IPAddress")]
-        public Input<string>? IPAddress { get; set; }
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Input("IPProtocol")]
-        public Input<Pulumi.GoogleNative.Compute.Alpha.GlobalForwardingRuleIPProtocol>? IPProtocol { get; set; }
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -379,6 +344,41 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Input("ipAddress")]
+        public Input<string>? IpAddress { get; set; }
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Input("ipProtocol")]
+        public Input<Pulumi.GoogleNative.Compute.Alpha.GlobalForwardingRuleIpProtocol>? IpProtocol { get; set; }
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.

--- a/sdk/dotnet/Compute/Alpha/Inputs/FirewallAllowedItemArgs.cs
+++ b/sdk/dotnet/Compute/Alpha/Inputs/FirewallAllowedItemArgs.cs
@@ -15,8 +15,8 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Inputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        [Input("IPProtocol")]
-        public Input<string>? IPProtocol { get; set; }
+        [Input("ipProtocol")]
+        public Input<string>? IpProtocol { get; set; }
 
         [Input("ports")]
         private InputList<string>? _ports;

--- a/sdk/dotnet/Compute/Alpha/Inputs/FirewallDeniedItemArgs.cs
+++ b/sdk/dotnet/Compute/Alpha/Inputs/FirewallDeniedItemArgs.cs
@@ -15,8 +15,8 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Inputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        [Input("IPProtocol")]
-        public Input<string>? IPProtocol { get; set; }
+        [Input("ipProtocol")]
+        public Input<string>? IpProtocol { get; set; }
 
         [Input("ports")]
         private InputList<string>? _ports;

--- a/sdk/dotnet/Compute/Alpha/Inputs/PacketMirroringFilterArgs.cs
+++ b/sdk/dotnet/Compute/Alpha/Inputs/PacketMirroringFilterArgs.cs
@@ -12,18 +12,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Inputs
 
     public sealed class PacketMirroringFilterArgs : Pulumi.ResourceArgs
     {
-        [Input("IPProtocols")]
-        private InputList<string>? _IPProtocols;
-
-        /// <summary>
-        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        /// </summary>
-        public InputList<string> IPProtocols
-        {
-            get => _IPProtocols ?? (_IPProtocols = new InputList<string>());
-            set => _IPProtocols = value;
-        }
-
         [Input("cidrRanges")]
         private InputList<string>? _cidrRanges;
 
@@ -41,6 +29,18 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Inputs
         /// </summary>
         [Input("direction")]
         public Input<Pulumi.GoogleNative.Compute.Alpha.PacketMirroringFilterDirection>? Direction { get; set; }
+
+        [Input("ipProtocols")]
+        private InputList<string>? _ipProtocols;
+
+        /// <summary>
+        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        /// </summary>
+        public InputList<string> IpProtocols
+        {
+            get => _ipProtocols ?? (_ipProtocols = new InputList<string>());
+            set => _ipProtocols = value;
+        }
 
         public PacketMirroringFilterArgs()
         {

--- a/sdk/dotnet/Compute/Alpha/Outputs/FirewallAllowedItemResponse.cs
+++ b/sdk/dotnet/Compute/Alpha/Outputs/FirewallAllowedItemResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Outputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        public readonly string IPProtocol;
+        public readonly string IpProtocol;
         /// <summary>
         /// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
         /// 
@@ -26,11 +26,11 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Outputs
 
         [OutputConstructor]
         private FirewallAllowedItemResponse(
-            string IPProtocol,
+            string ipProtocol,
 
             ImmutableArray<string> ports)
         {
-            this.IPProtocol = IPProtocol;
+            IpProtocol = ipProtocol;
             Ports = ports;
         }
     }

--- a/sdk/dotnet/Compute/Alpha/Outputs/FirewallDeniedItemResponse.cs
+++ b/sdk/dotnet/Compute/Alpha/Outputs/FirewallDeniedItemResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Outputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        public readonly string IPProtocol;
+        public readonly string IpProtocol;
         /// <summary>
         /// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
         /// 
@@ -26,11 +26,11 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Outputs
 
         [OutputConstructor]
         private FirewallDeniedItemResponse(
-            string IPProtocol,
+            string ipProtocol,
 
             ImmutableArray<string> ports)
         {
-            this.IPProtocol = IPProtocol;
+            IpProtocol = ipProtocol;
             Ports = ports;
         }
     }

--- a/sdk/dotnet/Compute/Alpha/Outputs/PacketMirroringFilterResponse.cs
+++ b/sdk/dotnet/Compute/Alpha/Outputs/PacketMirroringFilterResponse.cs
@@ -14,10 +14,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Outputs
     public sealed class PacketMirroringFilterResponse
     {
         /// <summary>
-        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        /// </summary>
-        public readonly ImmutableArray<string> IPProtocols;
-        /// <summary>
         /// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         /// </summary>
         public readonly ImmutableArray<string> CidrRanges;
@@ -25,18 +21,22 @@ namespace Pulumi.GoogleNative.Compute.Alpha.Outputs
         /// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
         /// </summary>
         public readonly string Direction;
+        /// <summary>
+        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        /// </summary>
+        public readonly ImmutableArray<string> IpProtocols;
 
         [OutputConstructor]
         private PacketMirroringFilterResponse(
-            ImmutableArray<string> IPProtocols,
-
             ImmutableArray<string> cidrRanges,
 
-            string direction)
+            string direction,
+
+            ImmutableArray<string> ipProtocols)
         {
-            this.IPProtocols = IPProtocols;
             CidrRanges = cidrRanges;
             Direction = direction;
+            IpProtocols = ipProtocols;
         }
     }
 }

--- a/sdk/dotnet/Compute/Beta/Enums.cs
+++ b/sdk/dotnet/Compute/Beta/Enums.cs
@@ -1299,30 +1299,30 @@ namespace Pulumi.GoogleNative.Compute.Beta
     /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
     /// </summary>
     [EnumType]
-    public readonly struct ForwardingRuleIPProtocol : IEquatable<ForwardingRuleIPProtocol>
+    public readonly struct ForwardingRuleIpProtocol : IEquatable<ForwardingRuleIpProtocol>
     {
         private readonly string _value;
 
-        private ForwardingRuleIPProtocol(string value)
+        private ForwardingRuleIpProtocol(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        public static ForwardingRuleIPProtocol Ah { get; } = new ForwardingRuleIPProtocol("AH");
-        public static ForwardingRuleIPProtocol Esp { get; } = new ForwardingRuleIPProtocol("ESP");
-        public static ForwardingRuleIPProtocol Icmp { get; } = new ForwardingRuleIPProtocol("ICMP");
-        public static ForwardingRuleIPProtocol Sctp { get; } = new ForwardingRuleIPProtocol("SCTP");
-        public static ForwardingRuleIPProtocol Tcp { get; } = new ForwardingRuleIPProtocol("TCP");
-        public static ForwardingRuleIPProtocol Udp { get; } = new ForwardingRuleIPProtocol("UDP");
+        public static ForwardingRuleIpProtocol Ah { get; } = new ForwardingRuleIpProtocol("AH");
+        public static ForwardingRuleIpProtocol Esp { get; } = new ForwardingRuleIpProtocol("ESP");
+        public static ForwardingRuleIpProtocol Icmp { get; } = new ForwardingRuleIpProtocol("ICMP");
+        public static ForwardingRuleIpProtocol Sctp { get; } = new ForwardingRuleIpProtocol("SCTP");
+        public static ForwardingRuleIpProtocol Tcp { get; } = new ForwardingRuleIpProtocol("TCP");
+        public static ForwardingRuleIpProtocol Udp { get; } = new ForwardingRuleIpProtocol("UDP");
 
-        public static bool operator ==(ForwardingRuleIPProtocol left, ForwardingRuleIPProtocol right) => left.Equals(right);
-        public static bool operator !=(ForwardingRuleIPProtocol left, ForwardingRuleIPProtocol right) => !left.Equals(right);
+        public static bool operator ==(ForwardingRuleIpProtocol left, ForwardingRuleIpProtocol right) => left.Equals(right);
+        public static bool operator !=(ForwardingRuleIpProtocol left, ForwardingRuleIpProtocol right) => !left.Equals(right);
 
-        public static explicit operator string(ForwardingRuleIPProtocol value) => value._value;
+        public static explicit operator string(ForwardingRuleIpProtocol value) => value._value;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object? obj) => obj is ForwardingRuleIPProtocol other && Equals(other);
-        public bool Equals(ForwardingRuleIPProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => obj is ForwardingRuleIpProtocol other && Equals(other);
+        public bool Equals(ForwardingRuleIpProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;
@@ -1635,30 +1635,30 @@ namespace Pulumi.GoogleNative.Compute.Beta
     /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
     /// </summary>
     [EnumType]
-    public readonly struct GlobalForwardingRuleIPProtocol : IEquatable<GlobalForwardingRuleIPProtocol>
+    public readonly struct GlobalForwardingRuleIpProtocol : IEquatable<GlobalForwardingRuleIpProtocol>
     {
         private readonly string _value;
 
-        private GlobalForwardingRuleIPProtocol(string value)
+        private GlobalForwardingRuleIpProtocol(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        public static GlobalForwardingRuleIPProtocol Ah { get; } = new GlobalForwardingRuleIPProtocol("AH");
-        public static GlobalForwardingRuleIPProtocol Esp { get; } = new GlobalForwardingRuleIPProtocol("ESP");
-        public static GlobalForwardingRuleIPProtocol Icmp { get; } = new GlobalForwardingRuleIPProtocol("ICMP");
-        public static GlobalForwardingRuleIPProtocol Sctp { get; } = new GlobalForwardingRuleIPProtocol("SCTP");
-        public static GlobalForwardingRuleIPProtocol Tcp { get; } = new GlobalForwardingRuleIPProtocol("TCP");
-        public static GlobalForwardingRuleIPProtocol Udp { get; } = new GlobalForwardingRuleIPProtocol("UDP");
+        public static GlobalForwardingRuleIpProtocol Ah { get; } = new GlobalForwardingRuleIpProtocol("AH");
+        public static GlobalForwardingRuleIpProtocol Esp { get; } = new GlobalForwardingRuleIpProtocol("ESP");
+        public static GlobalForwardingRuleIpProtocol Icmp { get; } = new GlobalForwardingRuleIpProtocol("ICMP");
+        public static GlobalForwardingRuleIpProtocol Sctp { get; } = new GlobalForwardingRuleIpProtocol("SCTP");
+        public static GlobalForwardingRuleIpProtocol Tcp { get; } = new GlobalForwardingRuleIpProtocol("TCP");
+        public static GlobalForwardingRuleIpProtocol Udp { get; } = new GlobalForwardingRuleIpProtocol("UDP");
 
-        public static bool operator ==(GlobalForwardingRuleIPProtocol left, GlobalForwardingRuleIPProtocol right) => left.Equals(right);
-        public static bool operator !=(GlobalForwardingRuleIPProtocol left, GlobalForwardingRuleIPProtocol right) => !left.Equals(right);
+        public static bool operator ==(GlobalForwardingRuleIpProtocol left, GlobalForwardingRuleIpProtocol right) => left.Equals(right);
+        public static bool operator !=(GlobalForwardingRuleIpProtocol left, GlobalForwardingRuleIpProtocol right) => !left.Equals(right);
 
-        public static explicit operator string(GlobalForwardingRuleIPProtocol value) => value._value;
+        public static explicit operator string(GlobalForwardingRuleIpProtocol value) => value._value;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object? obj) => obj is GlobalForwardingRuleIPProtocol other && Equals(other);
-        public bool Equals(GlobalForwardingRuleIPProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => obj is GlobalForwardingRuleIpProtocol other && Equals(other);
+        public bool Equals(GlobalForwardingRuleIpProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;

--- a/sdk/dotnet/Compute/Beta/ForwardingRule.cs
+++ b/sdk/dotnet/Compute/Beta/ForwardingRule.cs
@@ -16,41 +16,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
     public partial class ForwardingRule : Pulumi.CustomResource
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Output("IPAddress")]
-        public Output<string> IPAddress { get; private set; } = null!;
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Output("IPProtocol")]
-        public Output<string> IPProtocol { get; private set; } = null!;
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +54,41 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Output("fingerprint")]
         public Output<string> Fingerprint { get; private set; } = null!;
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Output("ipAddress")]
+        public Output<string> IpAddress { get; private set; } = null!;
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Output("ipProtocol")]
+        public Output<string> IpProtocol { get; private set; } = null!;
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
@@ -311,41 +311,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
     public sealed class ForwardingRuleArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Input("IPAddress")]
-        public Input<string>? IPAddress { get; set; }
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Input("IPProtocol")]
-        public Input<Pulumi.GoogleNative.Compute.Beta.ForwardingRuleIPProtocol>? IPProtocol { get; set; }
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -370,6 +335,41 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Input("ipAddress")]
+        public Input<string>? IpAddress { get; set; }
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Input("ipProtocol")]
+        public Input<Pulumi.GoogleNative.Compute.Beta.ForwardingRuleIpProtocol>? IpProtocol { get; set; }
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.

--- a/sdk/dotnet/Compute/Beta/GetForwardingRule.cs
+++ b/sdk/dotnet/Compute/Beta/GetForwardingRule.cs
@@ -40,37 +40,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
     public sealed class GetForwardingRuleResult
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        public readonly string IPAddress;
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        public readonly string IPProtocol;
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -98,6 +67,37 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         /// </summary>
         public readonly string Fingerprint;
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        public readonly string IpAddress;
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        public readonly string IpProtocol;
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         /// </summary>
@@ -236,10 +236,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
 
         [OutputConstructor]
         private GetForwardingRuleResult(
-            string IPAddress,
-
-            string IPProtocol,
-
             bool allPorts,
 
             bool allowGlobalAccess,
@@ -251,6 +247,10 @@ namespace Pulumi.GoogleNative.Compute.Beta
             string description,
 
             string fingerprint,
+
+            string ipAddress,
+
+            string ipProtocol,
 
             string ipVersion,
 
@@ -292,14 +292,14 @@ namespace Pulumi.GoogleNative.Compute.Beta
 
             string target)
         {
-            this.IPAddress = IPAddress;
-            this.IPProtocol = IPProtocol;
             AllPorts = allPorts;
             AllowGlobalAccess = allowGlobalAccess;
             BackendService = backendService;
             CreationTimestamp = creationTimestamp;
             Description = description;
             Fingerprint = fingerprint;
+            IpAddress = ipAddress;
+            IpProtocol = ipProtocol;
             IpVersion = ipVersion;
             IsMirroringCollector = isMirroringCollector;
             Kind = kind;

--- a/sdk/dotnet/Compute/Beta/GetGlobalForwardingRule.cs
+++ b/sdk/dotnet/Compute/Beta/GetGlobalForwardingRule.cs
@@ -37,37 +37,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
     public sealed class GetGlobalForwardingRuleResult
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        public readonly string IPAddress;
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        public readonly string IPProtocol;
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -95,6 +64,37 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         /// </summary>
         public readonly string Fingerprint;
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        public readonly string IpAddress;
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        public readonly string IpProtocol;
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         /// </summary>
@@ -233,10 +233,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
 
         [OutputConstructor]
         private GetGlobalForwardingRuleResult(
-            string IPAddress,
-
-            string IPProtocol,
-
             bool allPorts,
 
             bool allowGlobalAccess,
@@ -248,6 +244,10 @@ namespace Pulumi.GoogleNative.Compute.Beta
             string description,
 
             string fingerprint,
+
+            string ipAddress,
+
+            string ipProtocol,
 
             string ipVersion,
 
@@ -289,14 +289,14 @@ namespace Pulumi.GoogleNative.Compute.Beta
 
             string target)
         {
-            this.IPAddress = IPAddress;
-            this.IPProtocol = IPProtocol;
             AllPorts = allPorts;
             AllowGlobalAccess = allowGlobalAccess;
             BackendService = backendService;
             CreationTimestamp = creationTimestamp;
             Description = description;
             Fingerprint = fingerprint;
+            IpAddress = ipAddress;
+            IpProtocol = ipProtocol;
             IpVersion = ipVersion;
             IsMirroringCollector = isMirroringCollector;
             Kind = kind;

--- a/sdk/dotnet/Compute/Beta/GlobalForwardingRule.cs
+++ b/sdk/dotnet/Compute/Beta/GlobalForwardingRule.cs
@@ -16,41 +16,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
     public partial class GlobalForwardingRule : Pulumi.CustomResource
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Output("IPAddress")]
-        public Output<string> IPAddress { get; private set; } = null!;
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Output("IPProtocol")]
-        public Output<string> IPProtocol { get; private set; } = null!;
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +54,41 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Output("fingerprint")]
         public Output<string> Fingerprint { get; private set; } = null!;
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Output("ipAddress")]
+        public Output<string> IpAddress { get; private set; } = null!;
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Output("ipProtocol")]
+        public Output<string> IpProtocol { get; private set; } = null!;
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
@@ -311,41 +311,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
     public sealed class GlobalForwardingRuleArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Input("IPAddress")]
-        public Input<string>? IPAddress { get; set; }
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Input("IPProtocol")]
-        public Input<Pulumi.GoogleNative.Compute.Beta.GlobalForwardingRuleIPProtocol>? IPProtocol { get; set; }
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -370,6 +335,41 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Input("ipAddress")]
+        public Input<string>? IpAddress { get; set; }
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Input("ipProtocol")]
+        public Input<Pulumi.GoogleNative.Compute.Beta.GlobalForwardingRuleIpProtocol>? IpProtocol { get; set; }
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.

--- a/sdk/dotnet/Compute/Beta/Inputs/FirewallAllowedItemArgs.cs
+++ b/sdk/dotnet/Compute/Beta/Inputs/FirewallAllowedItemArgs.cs
@@ -15,8 +15,8 @@ namespace Pulumi.GoogleNative.Compute.Beta.Inputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        [Input("IPProtocol")]
-        public Input<string>? IPProtocol { get; set; }
+        [Input("ipProtocol")]
+        public Input<string>? IpProtocol { get; set; }
 
         [Input("ports")]
         private InputList<string>? _ports;

--- a/sdk/dotnet/Compute/Beta/Inputs/FirewallDeniedItemArgs.cs
+++ b/sdk/dotnet/Compute/Beta/Inputs/FirewallDeniedItemArgs.cs
@@ -15,8 +15,8 @@ namespace Pulumi.GoogleNative.Compute.Beta.Inputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        [Input("IPProtocol")]
-        public Input<string>? IPProtocol { get; set; }
+        [Input("ipProtocol")]
+        public Input<string>? IpProtocol { get; set; }
 
         [Input("ports")]
         private InputList<string>? _ports;

--- a/sdk/dotnet/Compute/Beta/Inputs/PacketMirroringFilterArgs.cs
+++ b/sdk/dotnet/Compute/Beta/Inputs/PacketMirroringFilterArgs.cs
@@ -12,18 +12,6 @@ namespace Pulumi.GoogleNative.Compute.Beta.Inputs
 
     public sealed class PacketMirroringFilterArgs : Pulumi.ResourceArgs
     {
-        [Input("IPProtocols")]
-        private InputList<string>? _IPProtocols;
-
-        /// <summary>
-        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        /// </summary>
-        public InputList<string> IPProtocols
-        {
-            get => _IPProtocols ?? (_IPProtocols = new InputList<string>());
-            set => _IPProtocols = value;
-        }
-
         [Input("cidrRanges")]
         private InputList<string>? _cidrRanges;
 
@@ -41,6 +29,18 @@ namespace Pulumi.GoogleNative.Compute.Beta.Inputs
         /// </summary>
         [Input("direction")]
         public Input<Pulumi.GoogleNative.Compute.Beta.PacketMirroringFilterDirection>? Direction { get; set; }
+
+        [Input("ipProtocols")]
+        private InputList<string>? _ipProtocols;
+
+        /// <summary>
+        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        /// </summary>
+        public InputList<string> IpProtocols
+        {
+            get => _ipProtocols ?? (_ipProtocols = new InputList<string>());
+            set => _ipProtocols = value;
+        }
 
         public PacketMirroringFilterArgs()
         {

--- a/sdk/dotnet/Compute/Beta/Outputs/FirewallAllowedItemResponse.cs
+++ b/sdk/dotnet/Compute/Beta/Outputs/FirewallAllowedItemResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GoogleNative.Compute.Beta.Outputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        public readonly string IPProtocol;
+        public readonly string IpProtocol;
         /// <summary>
         /// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
         /// 
@@ -26,11 +26,11 @@ namespace Pulumi.GoogleNative.Compute.Beta.Outputs
 
         [OutputConstructor]
         private FirewallAllowedItemResponse(
-            string IPProtocol,
+            string ipProtocol,
 
             ImmutableArray<string> ports)
         {
-            this.IPProtocol = IPProtocol;
+            IpProtocol = ipProtocol;
             Ports = ports;
         }
     }

--- a/sdk/dotnet/Compute/Beta/Outputs/FirewallDeniedItemResponse.cs
+++ b/sdk/dotnet/Compute/Beta/Outputs/FirewallDeniedItemResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GoogleNative.Compute.Beta.Outputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        public readonly string IPProtocol;
+        public readonly string IpProtocol;
         /// <summary>
         /// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
         /// 
@@ -26,11 +26,11 @@ namespace Pulumi.GoogleNative.Compute.Beta.Outputs
 
         [OutputConstructor]
         private FirewallDeniedItemResponse(
-            string IPProtocol,
+            string ipProtocol,
 
             ImmutableArray<string> ports)
         {
-            this.IPProtocol = IPProtocol;
+            IpProtocol = ipProtocol;
             Ports = ports;
         }
     }

--- a/sdk/dotnet/Compute/Beta/Outputs/PacketMirroringFilterResponse.cs
+++ b/sdk/dotnet/Compute/Beta/Outputs/PacketMirroringFilterResponse.cs
@@ -14,10 +14,6 @@ namespace Pulumi.GoogleNative.Compute.Beta.Outputs
     public sealed class PacketMirroringFilterResponse
     {
         /// <summary>
-        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        /// </summary>
-        public readonly ImmutableArray<string> IPProtocols;
-        /// <summary>
         /// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         /// </summary>
         public readonly ImmutableArray<string> CidrRanges;
@@ -25,18 +21,22 @@ namespace Pulumi.GoogleNative.Compute.Beta.Outputs
         /// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
         /// </summary>
         public readonly string Direction;
+        /// <summary>
+        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        /// </summary>
+        public readonly ImmutableArray<string> IpProtocols;
 
         [OutputConstructor]
         private PacketMirroringFilterResponse(
-            ImmutableArray<string> IPProtocols,
-
             ImmutableArray<string> cidrRanges,
 
-            string direction)
+            string direction,
+
+            ImmutableArray<string> ipProtocols)
         {
-            this.IPProtocols = IPProtocols;
             CidrRanges = cidrRanges;
             Direction = direction;
+            IpProtocols = ipProtocols;
         }
     }
 }

--- a/sdk/dotnet/Compute/V1/Enums.cs
+++ b/sdk/dotnet/Compute/V1/Enums.cs
@@ -1192,30 +1192,30 @@ namespace Pulumi.GoogleNative.Compute.V1
     /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
     /// </summary>
     [EnumType]
-    public readonly struct ForwardingRuleIPProtocol : IEquatable<ForwardingRuleIPProtocol>
+    public readonly struct ForwardingRuleIpProtocol : IEquatable<ForwardingRuleIpProtocol>
     {
         private readonly string _value;
 
-        private ForwardingRuleIPProtocol(string value)
+        private ForwardingRuleIpProtocol(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        public static ForwardingRuleIPProtocol Ah { get; } = new ForwardingRuleIPProtocol("AH");
-        public static ForwardingRuleIPProtocol Esp { get; } = new ForwardingRuleIPProtocol("ESP");
-        public static ForwardingRuleIPProtocol Icmp { get; } = new ForwardingRuleIPProtocol("ICMP");
-        public static ForwardingRuleIPProtocol Sctp { get; } = new ForwardingRuleIPProtocol("SCTP");
-        public static ForwardingRuleIPProtocol Tcp { get; } = new ForwardingRuleIPProtocol("TCP");
-        public static ForwardingRuleIPProtocol Udp { get; } = new ForwardingRuleIPProtocol("UDP");
+        public static ForwardingRuleIpProtocol Ah { get; } = new ForwardingRuleIpProtocol("AH");
+        public static ForwardingRuleIpProtocol Esp { get; } = new ForwardingRuleIpProtocol("ESP");
+        public static ForwardingRuleIpProtocol Icmp { get; } = new ForwardingRuleIpProtocol("ICMP");
+        public static ForwardingRuleIpProtocol Sctp { get; } = new ForwardingRuleIpProtocol("SCTP");
+        public static ForwardingRuleIpProtocol Tcp { get; } = new ForwardingRuleIpProtocol("TCP");
+        public static ForwardingRuleIpProtocol Udp { get; } = new ForwardingRuleIpProtocol("UDP");
 
-        public static bool operator ==(ForwardingRuleIPProtocol left, ForwardingRuleIPProtocol right) => left.Equals(right);
-        public static bool operator !=(ForwardingRuleIPProtocol left, ForwardingRuleIPProtocol right) => !left.Equals(right);
+        public static bool operator ==(ForwardingRuleIpProtocol left, ForwardingRuleIpProtocol right) => left.Equals(right);
+        public static bool operator !=(ForwardingRuleIpProtocol left, ForwardingRuleIpProtocol right) => !left.Equals(right);
 
-        public static explicit operator string(ForwardingRuleIPProtocol value) => value._value;
+        public static explicit operator string(ForwardingRuleIpProtocol value) => value._value;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object? obj) => obj is ForwardingRuleIPProtocol other && Equals(other);
-        public bool Equals(ForwardingRuleIPProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => obj is ForwardingRuleIpProtocol other && Equals(other);
+        public bool Equals(ForwardingRuleIpProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;
@@ -1528,30 +1528,30 @@ namespace Pulumi.GoogleNative.Compute.V1
     /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
     /// </summary>
     [EnumType]
-    public readonly struct GlobalForwardingRuleIPProtocol : IEquatable<GlobalForwardingRuleIPProtocol>
+    public readonly struct GlobalForwardingRuleIpProtocol : IEquatable<GlobalForwardingRuleIpProtocol>
     {
         private readonly string _value;
 
-        private GlobalForwardingRuleIPProtocol(string value)
+        private GlobalForwardingRuleIpProtocol(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        public static GlobalForwardingRuleIPProtocol Ah { get; } = new GlobalForwardingRuleIPProtocol("AH");
-        public static GlobalForwardingRuleIPProtocol Esp { get; } = new GlobalForwardingRuleIPProtocol("ESP");
-        public static GlobalForwardingRuleIPProtocol Icmp { get; } = new GlobalForwardingRuleIPProtocol("ICMP");
-        public static GlobalForwardingRuleIPProtocol Sctp { get; } = new GlobalForwardingRuleIPProtocol("SCTP");
-        public static GlobalForwardingRuleIPProtocol Tcp { get; } = new GlobalForwardingRuleIPProtocol("TCP");
-        public static GlobalForwardingRuleIPProtocol Udp { get; } = new GlobalForwardingRuleIPProtocol("UDP");
+        public static GlobalForwardingRuleIpProtocol Ah { get; } = new GlobalForwardingRuleIpProtocol("AH");
+        public static GlobalForwardingRuleIpProtocol Esp { get; } = new GlobalForwardingRuleIpProtocol("ESP");
+        public static GlobalForwardingRuleIpProtocol Icmp { get; } = new GlobalForwardingRuleIpProtocol("ICMP");
+        public static GlobalForwardingRuleIpProtocol Sctp { get; } = new GlobalForwardingRuleIpProtocol("SCTP");
+        public static GlobalForwardingRuleIpProtocol Tcp { get; } = new GlobalForwardingRuleIpProtocol("TCP");
+        public static GlobalForwardingRuleIpProtocol Udp { get; } = new GlobalForwardingRuleIpProtocol("UDP");
 
-        public static bool operator ==(GlobalForwardingRuleIPProtocol left, GlobalForwardingRuleIPProtocol right) => left.Equals(right);
-        public static bool operator !=(GlobalForwardingRuleIPProtocol left, GlobalForwardingRuleIPProtocol right) => !left.Equals(right);
+        public static bool operator ==(GlobalForwardingRuleIpProtocol left, GlobalForwardingRuleIpProtocol right) => left.Equals(right);
+        public static bool operator !=(GlobalForwardingRuleIpProtocol left, GlobalForwardingRuleIpProtocol right) => !left.Equals(right);
 
-        public static explicit operator string(GlobalForwardingRuleIPProtocol value) => value._value;
+        public static explicit operator string(GlobalForwardingRuleIpProtocol value) => value._value;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object? obj) => obj is GlobalForwardingRuleIPProtocol other && Equals(other);
-        public bool Equals(GlobalForwardingRuleIPProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => obj is GlobalForwardingRuleIpProtocol other && Equals(other);
+        public bool Equals(GlobalForwardingRuleIpProtocol other) => string.Equals(_value, other._value, StringComparison.Ordinal);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;

--- a/sdk/dotnet/Compute/V1/ForwardingRule.cs
+++ b/sdk/dotnet/Compute/V1/ForwardingRule.cs
@@ -16,41 +16,6 @@ namespace Pulumi.GoogleNative.Compute.V1
     public partial class ForwardingRule : Pulumi.CustomResource
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Output("IPAddress")]
-        public Output<string> IPAddress { get; private set; } = null!;
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Output("IPProtocol")]
-        public Output<string> IPProtocol { get; private set; } = null!;
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +54,41 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Output("fingerprint")]
         public Output<string> Fingerprint { get; private set; } = null!;
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Output("ipAddress")]
+        public Output<string> IpAddress { get; private set; } = null!;
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Output("ipProtocol")]
+        public Output<string> IpProtocol { get; private set; } = null!;
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
@@ -311,41 +311,6 @@ namespace Pulumi.GoogleNative.Compute.V1
     public sealed class ForwardingRuleArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Input("IPAddress")]
-        public Input<string>? IPAddress { get; set; }
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Input("IPProtocol")]
-        public Input<Pulumi.GoogleNative.Compute.V1.ForwardingRuleIPProtocol>? IPProtocol { get; set; }
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -370,6 +335,41 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Input("ipAddress")]
+        public Input<string>? IpAddress { get; set; }
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Input("ipProtocol")]
+        public Input<Pulumi.GoogleNative.Compute.V1.ForwardingRuleIpProtocol>? IpProtocol { get; set; }
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.

--- a/sdk/dotnet/Compute/V1/GetForwardingRule.cs
+++ b/sdk/dotnet/Compute/V1/GetForwardingRule.cs
@@ -40,37 +40,6 @@ namespace Pulumi.GoogleNative.Compute.V1
     public sealed class GetForwardingRuleResult
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        public readonly string IPAddress;
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        public readonly string IPProtocol;
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -98,6 +67,37 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         /// </summary>
         public readonly string Fingerprint;
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        public readonly string IpAddress;
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        public readonly string IpProtocol;
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         /// </summary>
@@ -236,10 +236,6 @@ namespace Pulumi.GoogleNative.Compute.V1
 
         [OutputConstructor]
         private GetForwardingRuleResult(
-            string IPAddress,
-
-            string IPProtocol,
-
             bool allPorts,
 
             bool allowGlobalAccess,
@@ -251,6 +247,10 @@ namespace Pulumi.GoogleNative.Compute.V1
             string description,
 
             string fingerprint,
+
+            string ipAddress,
+
+            string ipProtocol,
 
             string ipVersion,
 
@@ -292,14 +292,14 @@ namespace Pulumi.GoogleNative.Compute.V1
 
             string target)
         {
-            this.IPAddress = IPAddress;
-            this.IPProtocol = IPProtocol;
             AllPorts = allPorts;
             AllowGlobalAccess = allowGlobalAccess;
             BackendService = backendService;
             CreationTimestamp = creationTimestamp;
             Description = description;
             Fingerprint = fingerprint;
+            IpAddress = ipAddress;
+            IpProtocol = ipProtocol;
             IpVersion = ipVersion;
             IsMirroringCollector = isMirroringCollector;
             Kind = kind;

--- a/sdk/dotnet/Compute/V1/GetGlobalForwardingRule.cs
+++ b/sdk/dotnet/Compute/V1/GetGlobalForwardingRule.cs
@@ -37,37 +37,6 @@ namespace Pulumi.GoogleNative.Compute.V1
     public sealed class GetGlobalForwardingRuleResult
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        public readonly string IPAddress;
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        public readonly string IPProtocol;
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -95,6 +64,37 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         /// </summary>
         public readonly string Fingerprint;
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        public readonly string IpAddress;
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        public readonly string IpProtocol;
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         /// </summary>
@@ -233,10 +233,6 @@ namespace Pulumi.GoogleNative.Compute.V1
 
         [OutputConstructor]
         private GetGlobalForwardingRuleResult(
-            string IPAddress,
-
-            string IPProtocol,
-
             bool allPorts,
 
             bool allowGlobalAccess,
@@ -248,6 +244,10 @@ namespace Pulumi.GoogleNative.Compute.V1
             string description,
 
             string fingerprint,
+
+            string ipAddress,
+
+            string ipProtocol,
 
             string ipVersion,
 
@@ -289,14 +289,14 @@ namespace Pulumi.GoogleNative.Compute.V1
 
             string target)
         {
-            this.IPAddress = IPAddress;
-            this.IPProtocol = IPProtocol;
             AllPorts = allPorts;
             AllowGlobalAccess = allowGlobalAccess;
             BackendService = backendService;
             CreationTimestamp = creationTimestamp;
             Description = description;
             Fingerprint = fingerprint;
+            IpAddress = ipAddress;
+            IpProtocol = ipProtocol;
             IpVersion = ipVersion;
             IsMirroringCollector = isMirroringCollector;
             Kind = kind;

--- a/sdk/dotnet/Compute/V1/GlobalForwardingRule.cs
+++ b/sdk/dotnet/Compute/V1/GlobalForwardingRule.cs
@@ -16,41 +16,6 @@ namespace Pulumi.GoogleNative.Compute.V1
     public partial class GlobalForwardingRule : Pulumi.CustomResource
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Output("IPAddress")]
-        public Output<string> IPAddress { get; private set; } = null!;
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Output("IPProtocol")]
-        public Output<string> IPProtocol { get; private set; } = null!;
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +54,41 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Output("fingerprint")]
         public Output<string> Fingerprint { get; private set; } = null!;
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Output("ipAddress")]
+        public Output<string> IpAddress { get; private set; } = null!;
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Output("ipProtocol")]
+        public Output<string> IpProtocol { get; private set; } = null!;
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
@@ -311,41 +311,6 @@ namespace Pulumi.GoogleNative.Compute.V1
     public sealed class GlobalForwardingRuleArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-        /// 
-        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-        /// 
-        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        /// - projects/project_id/regions/region/addresses/address-name 
-        /// - regions/region/addresses/address-name 
-        /// - global/addresses/address-name 
-        /// - address-name  
-        /// 
-        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-        /// 
-        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-        /// 
-        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        /// </summary>
-        [Input("IPAddress")]
-        public Input<string>? IPAddress { get; set; }
-
-        /// <summary>
-        /// The IP protocol to which this rule applies.
-        /// 
-        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-        /// 
-        /// The valid IP protocols are different for different load balancing products:  
-        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        /// </summary>
-        [Input("IPProtocol")]
-        public Input<Pulumi.GoogleNative.Compute.V1.GlobalForwardingRuleIPProtocol>? IPProtocol { get; set; }
-
-        /// <summary>
         /// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
         /// 
         /// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -370,6 +335,41 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+        /// 
+        /// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+        /// 
+        /// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        /// - projects/project_id/regions/region/addresses/address-name 
+        /// - regions/region/addresses/address-name 
+        /// - global/addresses/address-name 
+        /// - address-name  
+        /// 
+        /// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+        /// 
+        /// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+        /// 
+        /// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        /// </summary>
+        [Input("ipAddress")]
+        public Input<string>? IpAddress { get; set; }
+
+        /// <summary>
+        /// The IP protocol to which this rule applies.
+        /// 
+        /// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+        /// 
+        /// The valid IP protocols are different for different load balancing products:  
+        /// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        /// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        /// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        /// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        /// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        /// </summary>
+        [Input("ipProtocol")]
+        public Input<Pulumi.GoogleNative.Compute.V1.GlobalForwardingRuleIpProtocol>? IpProtocol { get; set; }
 
         /// <summary>
         /// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.

--- a/sdk/dotnet/Compute/V1/Inputs/FirewallAllowedItemArgs.cs
+++ b/sdk/dotnet/Compute/V1/Inputs/FirewallAllowedItemArgs.cs
@@ -15,8 +15,8 @@ namespace Pulumi.GoogleNative.Compute.V1.Inputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        [Input("IPProtocol")]
-        public Input<string>? IPProtocol { get; set; }
+        [Input("ipProtocol")]
+        public Input<string>? IpProtocol { get; set; }
 
         [Input("ports")]
         private InputList<string>? _ports;

--- a/sdk/dotnet/Compute/V1/Inputs/FirewallDeniedItemArgs.cs
+++ b/sdk/dotnet/Compute/V1/Inputs/FirewallDeniedItemArgs.cs
@@ -15,8 +15,8 @@ namespace Pulumi.GoogleNative.Compute.V1.Inputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        [Input("IPProtocol")]
-        public Input<string>? IPProtocol { get; set; }
+        [Input("ipProtocol")]
+        public Input<string>? IpProtocol { get; set; }
 
         [Input("ports")]
         private InputList<string>? _ports;

--- a/sdk/dotnet/Compute/V1/Inputs/PacketMirroringFilterArgs.cs
+++ b/sdk/dotnet/Compute/V1/Inputs/PacketMirroringFilterArgs.cs
@@ -12,18 +12,6 @@ namespace Pulumi.GoogleNative.Compute.V1.Inputs
 
     public sealed class PacketMirroringFilterArgs : Pulumi.ResourceArgs
     {
-        [Input("IPProtocols")]
-        private InputList<string>? _IPProtocols;
-
-        /// <summary>
-        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        /// </summary>
-        public InputList<string> IPProtocols
-        {
-            get => _IPProtocols ?? (_IPProtocols = new InputList<string>());
-            set => _IPProtocols = value;
-        }
-
         [Input("cidrRanges")]
         private InputList<string>? _cidrRanges;
 
@@ -41,6 +29,18 @@ namespace Pulumi.GoogleNative.Compute.V1.Inputs
         /// </summary>
         [Input("direction")]
         public Input<Pulumi.GoogleNative.Compute.V1.PacketMirroringFilterDirection>? Direction { get; set; }
+
+        [Input("ipProtocols")]
+        private InputList<string>? _ipProtocols;
+
+        /// <summary>
+        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        /// </summary>
+        public InputList<string> IpProtocols
+        {
+            get => _ipProtocols ?? (_ipProtocols = new InputList<string>());
+            set => _ipProtocols = value;
+        }
 
         public PacketMirroringFilterArgs()
         {

--- a/sdk/dotnet/Compute/V1/Outputs/FirewallAllowedItemResponse.cs
+++ b/sdk/dotnet/Compute/V1/Outputs/FirewallAllowedItemResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GoogleNative.Compute.V1.Outputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        public readonly string IPProtocol;
+        public readonly string IpProtocol;
         /// <summary>
         /// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
         /// 
@@ -26,11 +26,11 @@ namespace Pulumi.GoogleNative.Compute.V1.Outputs
 
         [OutputConstructor]
         private FirewallAllowedItemResponse(
-            string IPProtocol,
+            string ipProtocol,
 
             ImmutableArray<string> ports)
         {
-            this.IPProtocol = IPProtocol;
+            IpProtocol = ipProtocol;
             Ports = ports;
         }
     }

--- a/sdk/dotnet/Compute/V1/Outputs/FirewallDeniedItemResponse.cs
+++ b/sdk/dotnet/Compute/V1/Outputs/FirewallDeniedItemResponse.cs
@@ -16,7 +16,7 @@ namespace Pulumi.GoogleNative.Compute.V1.Outputs
         /// <summary>
         /// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
         /// </summary>
-        public readonly string IPProtocol;
+        public readonly string IpProtocol;
         /// <summary>
         /// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
         /// 
@@ -26,11 +26,11 @@ namespace Pulumi.GoogleNative.Compute.V1.Outputs
 
         [OutputConstructor]
         private FirewallDeniedItemResponse(
-            string IPProtocol,
+            string ipProtocol,
 
             ImmutableArray<string> ports)
         {
-            this.IPProtocol = IPProtocol;
+            IpProtocol = ipProtocol;
             Ports = ports;
         }
     }

--- a/sdk/dotnet/Compute/V1/Outputs/PacketMirroringFilterResponse.cs
+++ b/sdk/dotnet/Compute/V1/Outputs/PacketMirroringFilterResponse.cs
@@ -14,10 +14,6 @@ namespace Pulumi.GoogleNative.Compute.V1.Outputs
     public sealed class PacketMirroringFilterResponse
     {
         /// <summary>
-        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        /// </summary>
-        public readonly ImmutableArray<string> IPProtocols;
-        /// <summary>
         /// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         /// </summary>
         public readonly ImmutableArray<string> CidrRanges;
@@ -25,18 +21,22 @@ namespace Pulumi.GoogleNative.Compute.V1.Outputs
         /// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
         /// </summary>
         public readonly string Direction;
+        /// <summary>
+        /// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        /// </summary>
+        public readonly ImmutableArray<string> IpProtocols;
 
         [OutputConstructor]
         private PacketMirroringFilterResponse(
-            ImmutableArray<string> IPProtocols,
-
             ImmutableArray<string> cidrRanges,
 
-            string direction)
+            string direction,
+
+            ImmutableArray<string> ipProtocols)
         {
-            this.IPProtocols = IPProtocols;
             CidrRanges = cidrRanges;
             Direction = direction;
+            IpProtocols = ipProtocols;
         }
     }
 }

--- a/sdk/dotnet/Storage/V1/GetNotification.cs
+++ b/sdk/dotnet/Storage/V1/GetNotification.cs
@@ -45,7 +45,7 @@ namespace Pulumi.GoogleNative.Storage.V1
         /// <summary>
         /// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
         /// </summary>
-        public readonly ImmutableDictionary<string, string> Custom_attributes;
+        public readonly ImmutableDictionary<string, string> CustomAttributes;
         /// <summary>
         /// HTTP 1.1 Entity tag for this subscription notification.
         /// </summary>
@@ -53,7 +53,7 @@ namespace Pulumi.GoogleNative.Storage.V1
         /// <summary>
         /// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
         /// </summary>
-        public readonly ImmutableArray<string> Event_types;
+        public readonly ImmutableArray<string> EventTypes;
         /// <summary>
         /// The kind of item this is. For notifications, this is always storage#notification.
         /// </summary>
@@ -61,11 +61,11 @@ namespace Pulumi.GoogleNative.Storage.V1
         /// <summary>
         /// If present, only apply this notification configuration to object names that begin with this prefix.
         /// </summary>
-        public readonly string Object_name_prefix;
+        public readonly string ObjectNamePrefix;
         /// <summary>
         /// The desired content of the Payload.
         /// </summary>
-        public readonly string Payload_format;
+        public readonly string PayloadFormat;
         /// <summary>
         /// The canonical URL of this notification.
         /// </summary>
@@ -77,28 +77,28 @@ namespace Pulumi.GoogleNative.Storage.V1
 
         [OutputConstructor]
         private GetNotificationResult(
-            ImmutableDictionary<string, string> custom_attributes,
+            ImmutableDictionary<string, string> customAttributes,
 
             string etag,
 
-            ImmutableArray<string> event_types,
+            ImmutableArray<string> eventTypes,
 
             string kind,
 
-            string object_name_prefix,
+            string objectNamePrefix,
 
-            string payload_format,
+            string payloadFormat,
 
             string selfLink,
 
             string topic)
         {
-            Custom_attributes = custom_attributes;
+            CustomAttributes = customAttributes;
             Etag = etag;
-            Event_types = event_types;
+            EventTypes = eventTypes;
             Kind = kind;
-            Object_name_prefix = object_name_prefix;
-            Payload_format = payload_format;
+            ObjectNamePrefix = objectNamePrefix;
+            PayloadFormat = payloadFormat;
             SelfLink = selfLink;
             Topic = topic;
         }

--- a/sdk/dotnet/Storage/V1/Notification.cs
+++ b/sdk/dotnet/Storage/V1/Notification.cs
@@ -18,8 +18,8 @@ namespace Pulumi.GoogleNative.Storage.V1
         /// <summary>
         /// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
         /// </summary>
-        [Output("custom_attributes")]
-        public Output<ImmutableDictionary<string, string>> Custom_attributes { get; private set; } = null!;
+        [Output("customAttributes")]
+        public Output<ImmutableDictionary<string, string>> CustomAttributes { get; private set; } = null!;
 
         /// <summary>
         /// HTTP 1.1 Entity tag for this subscription notification.
@@ -30,8 +30,8 @@ namespace Pulumi.GoogleNative.Storage.V1
         /// <summary>
         /// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
         /// </summary>
-        [Output("event_types")]
-        public Output<ImmutableArray<string>> Event_types { get; private set; } = null!;
+        [Output("eventTypes")]
+        public Output<ImmutableArray<string>> EventTypes { get; private set; } = null!;
 
         /// <summary>
         /// The kind of item this is. For notifications, this is always storage#notification.
@@ -42,14 +42,14 @@ namespace Pulumi.GoogleNative.Storage.V1
         /// <summary>
         /// If present, only apply this notification configuration to object names that begin with this prefix.
         /// </summary>
-        [Output("object_name_prefix")]
-        public Output<string> Object_name_prefix { get; private set; } = null!;
+        [Output("objectNamePrefix")]
+        public Output<string> ObjectNamePrefix { get; private set; } = null!;
 
         /// <summary>
         /// The desired content of the Payload.
         /// </summary>
-        [Output("payload_format")]
-        public Output<string> Payload_format { get; private set; } = null!;
+        [Output("payloadFormat")]
+        public Output<string> PayloadFormat { get; private set; } = null!;
 
         /// <summary>
         /// The canonical URL of this notification.
@@ -111,16 +111,16 @@ namespace Pulumi.GoogleNative.Storage.V1
         [Input("bucket", required: true)]
         public Input<string> Bucket { get; set; } = null!;
 
-        [Input("custom_attributes")]
-        private InputMap<string>? _custom_attributes;
+        [Input("customAttributes")]
+        private InputMap<string>? _customAttributes;
 
         /// <summary>
         /// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
         /// </summary>
-        public InputMap<string> Custom_attributes
+        public InputMap<string> CustomAttributes
         {
-            get => _custom_attributes ?? (_custom_attributes = new InputMap<string>());
-            set => _custom_attributes = value;
+            get => _customAttributes ?? (_customAttributes = new InputMap<string>());
+            set => _customAttributes = value;
         }
 
         /// <summary>
@@ -129,16 +129,16 @@ namespace Pulumi.GoogleNative.Storage.V1
         [Input("etag")]
         public Input<string>? Etag { get; set; }
 
-        [Input("event_types")]
-        private InputList<string>? _event_types;
+        [Input("eventTypes")]
+        private InputList<string>? _eventTypes;
 
         /// <summary>
         /// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
         /// </summary>
-        public InputList<string> Event_types
+        public InputList<string> EventTypes
         {
-            get => _event_types ?? (_event_types = new InputList<string>());
-            set => _event_types = value;
+            get => _eventTypes ?? (_eventTypes = new InputList<string>());
+            set => _eventTypes = value;
         }
 
         /// <summary>
@@ -156,14 +156,14 @@ namespace Pulumi.GoogleNative.Storage.V1
         /// <summary>
         /// If present, only apply this notification configuration to object names that begin with this prefix.
         /// </summary>
-        [Input("object_name_prefix")]
-        public Input<string>? Object_name_prefix { get; set; }
+        [Input("objectNamePrefix")]
+        public Input<string>? ObjectNamePrefix { get; set; }
 
         /// <summary>
         /// The desired content of the Payload.
         /// </summary>
-        [Input("payload_format")]
-        public Input<string>? Payload_format { get; set; }
+        [Input("payloadFormat")]
+        public Input<string>? PayloadFormat { get; set; }
 
         [Input("provisionalUserProject")]
         public Input<string>? ProvisionalUserProject { get; set; }

--- a/sdk/go/google/apigee/v1/pulumiTypes.go
+++ b/sdk/go/google/apigee/v1/pulumiTypes.go
@@ -1190,7 +1190,7 @@ type GoogleCloudApigeeV1CanaryEvaluationMetricLabels struct {
 	// The environment ID associated with the metrics.
 	Env *string `pulumi:"env"`
 	// Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-	Instance_id *string `pulumi:"instance_id"`
+	InstanceId *string `pulumi:"instanceId"`
 	// Required. The location associated with the metrics.
 	Location *string `pulumi:"location"`
 }
@@ -1211,7 +1211,7 @@ type GoogleCloudApigeeV1CanaryEvaluationMetricLabelsArgs struct {
 	// The environment ID associated with the metrics.
 	Env pulumi.StringPtrInput `pulumi:"env"`
 	// Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-	Instance_id pulumi.StringPtrInput `pulumi:"instance_id"`
+	InstanceId pulumi.StringPtrInput `pulumi:"instanceId"`
 	// Required. The location associated with the metrics.
 	Location pulumi.StringPtrInput `pulumi:"location"`
 }
@@ -1300,8 +1300,8 @@ func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsOutput) Env() pulumi.Stri
 }
 
 // Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsOutput) Instance_id() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v GoogleCloudApigeeV1CanaryEvaluationMetricLabels) *string { return v.Instance_id }).(pulumi.StringPtrOutput)
+func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsOutput) InstanceId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v GoogleCloudApigeeV1CanaryEvaluationMetricLabels) *string { return v.InstanceId }).(pulumi.StringPtrOutput)
 }
 
 // Required. The location associated with the metrics.
@@ -1340,12 +1340,12 @@ func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsPtrOutput) Env() pulumi.S
 }
 
 // Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsPtrOutput) Instance_id() pulumi.StringPtrOutput {
+func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsPtrOutput) InstanceId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *GoogleCloudApigeeV1CanaryEvaluationMetricLabels) *string {
 		if v == nil {
 			return nil
 		}
-		return v.Instance_id
+		return v.InstanceId
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -1364,7 +1364,7 @@ type GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse struct {
 	// The environment ID associated with the metrics.
 	Env string `pulumi:"env"`
 	// Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-	Instance_id string `pulumi:"instance_id"`
+	InstanceId string `pulumi:"instanceId"`
 	// Required. The location associated with the metrics.
 	Location string `pulumi:"location"`
 }
@@ -1385,7 +1385,7 @@ type GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponseArgs struct {
 	// The environment ID associated with the metrics.
 	Env pulumi.StringInput `pulumi:"env"`
 	// Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-	Instance_id pulumi.StringInput `pulumi:"instance_id"`
+	InstanceId pulumi.StringInput `pulumi:"instanceId"`
 	// Required. The location associated with the metrics.
 	Location pulumi.StringInput `pulumi:"location"`
 }
@@ -1474,8 +1474,8 @@ func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponseOutput) Env() pul
 }
 
 // Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponseOutput) Instance_id() pulumi.StringOutput {
-	return o.ApplyT(func(v GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse) string { return v.Instance_id }).(pulumi.StringOutput)
+func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponseOutput) InstanceId() pulumi.StringOutput {
+	return o.ApplyT(func(v GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse) string { return v.InstanceId }).(pulumi.StringOutput)
 }
 
 // Required. The location associated with the metrics.
@@ -1514,12 +1514,12 @@ func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponsePtrOutput) Env() 
 }
 
 // Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
-func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponsePtrOutput) Instance_id() pulumi.StringPtrOutput {
+func (o GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponsePtrOutput) InstanceId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse) *string {
 		if v == nil {
 			return nil
 		}
-		return &v.Instance_id
+		return &v.InstanceId
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/google/bigquery/v2/getJob.go
+++ b/sdk/go/google/bigquery/v2/getJob.go
@@ -39,5 +39,5 @@ type LookupJobResult struct {
 	// The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
 	Status JobStatusResponse `pulumi:"status"`
 	// Email address of the user who ran the job.
-	User_email string `pulumi:"user_email"`
+	UserEmail string `pulumi:"userEmail"`
 }

--- a/sdk/go/google/bigquery/v2/job.go
+++ b/sdk/go/google/bigquery/v2/job.go
@@ -30,7 +30,7 @@ type Job struct {
 	// The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
 	Status JobStatusResponseOutput `pulumi:"status"`
 	// Email address of the user who ran the job.
-	User_email pulumi.StringOutput `pulumi:"user_email"`
+	UserEmail pulumi.StringOutput `pulumi:"userEmail"`
 }
 
 // NewJob registers a new resource with the given unique name, arguments, and options.
@@ -80,7 +80,7 @@ type jobState struct {
 	// The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
 	Status *JobStatusResponse `pulumi:"status"`
 	// Email address of the user who ran the job.
-	User_email *string `pulumi:"user_email"`
+	UserEmail *string `pulumi:"userEmail"`
 }
 
 type JobState struct {
@@ -99,7 +99,7 @@ type JobState struct {
 	// The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
 	Status JobStatusResponsePtrInput
 	// Email address of the user who ran the job.
-	User_email pulumi.StringPtrInput
+	UserEmail pulumi.StringPtrInput
 }
 
 func (JobState) ElementType() reflect.Type {

--- a/sdk/go/google/bigquery/v2/pulumiTypes.go
+++ b/sdk/go/google/bigquery/v2/pulumiTypes.go
@@ -3759,8 +3759,8 @@ func (o CsvOptionsResponsePtrOutput) SkipLeadingRows() pulumi.StringPtrOutput {
 
 type DatasetAccessEntry struct {
 	// [Required] The dataset this entry applies to.
-	Dataset      *DatasetReference                    `pulumi:"dataset"`
-	Target_types []DatasetAccessEntryTarget_typesItem `pulumi:"target_types"`
+	Dataset     *DatasetReference                   `pulumi:"dataset"`
+	TargetTypes []DatasetAccessEntryTargetTypesItem `pulumi:"targetTypes"`
 }
 
 // DatasetAccessEntryInput is an input type that accepts DatasetAccessEntryArgs and DatasetAccessEntryOutput values.
@@ -3776,8 +3776,8 @@ type DatasetAccessEntryInput interface {
 
 type DatasetAccessEntryArgs struct {
 	// [Required] The dataset this entry applies to.
-	Dataset      DatasetReferencePtrInput                     `pulumi:"dataset"`
-	Target_types DatasetAccessEntryTarget_typesItemArrayInput `pulumi:"target_types"`
+	Dataset     DatasetReferencePtrInput                    `pulumi:"dataset"`
+	TargetTypes DatasetAccessEntryTargetTypesItemArrayInput `pulumi:"targetTypes"`
 }
 
 func (DatasetAccessEntryArgs) ElementType() reflect.Type {
@@ -3862,8 +3862,8 @@ func (o DatasetAccessEntryOutput) Dataset() DatasetReferencePtrOutput {
 	return o.ApplyT(func(v DatasetAccessEntry) *DatasetReference { return v.Dataset }).(DatasetReferencePtrOutput)
 }
 
-func (o DatasetAccessEntryOutput) Target_types() DatasetAccessEntryTarget_typesItemArrayOutput {
-	return o.ApplyT(func(v DatasetAccessEntry) []DatasetAccessEntryTarget_typesItem { return v.Target_types }).(DatasetAccessEntryTarget_typesItemArrayOutput)
+func (o DatasetAccessEntryOutput) TargetTypes() DatasetAccessEntryTargetTypesItemArrayOutput {
+	return o.ApplyT(func(v DatasetAccessEntry) []DatasetAccessEntryTargetTypesItem { return v.TargetTypes }).(DatasetAccessEntryTargetTypesItemArrayOutput)
 }
 
 type DatasetAccessEntryPtrOutput struct{ *pulumi.OutputState }
@@ -3894,19 +3894,19 @@ func (o DatasetAccessEntryPtrOutput) Dataset() DatasetReferencePtrOutput {
 	}).(DatasetReferencePtrOutput)
 }
 
-func (o DatasetAccessEntryPtrOutput) Target_types() DatasetAccessEntryTarget_typesItemArrayOutput {
-	return o.ApplyT(func(v *DatasetAccessEntry) []DatasetAccessEntryTarget_typesItem {
+func (o DatasetAccessEntryPtrOutput) TargetTypes() DatasetAccessEntryTargetTypesItemArrayOutput {
+	return o.ApplyT(func(v *DatasetAccessEntry) []DatasetAccessEntryTargetTypesItem {
 		if v == nil {
 			return nil
 		}
-		return v.Target_types
-	}).(DatasetAccessEntryTarget_typesItemArrayOutput)
+		return v.TargetTypes
+	}).(DatasetAccessEntryTargetTypesItemArrayOutput)
 }
 
 type DatasetAccessEntryResponse struct {
 	// [Required] The dataset this entry applies to.
-	Dataset      DatasetReferenceResponse                     `pulumi:"dataset"`
-	Target_types []DatasetAccessEntryTarget_typesItemResponse `pulumi:"target_types"`
+	Dataset     DatasetReferenceResponse                    `pulumi:"dataset"`
+	TargetTypes []DatasetAccessEntryTargetTypesItemResponse `pulumi:"targetTypes"`
 }
 
 // DatasetAccessEntryResponseInput is an input type that accepts DatasetAccessEntryResponseArgs and DatasetAccessEntryResponseOutput values.
@@ -3922,8 +3922,8 @@ type DatasetAccessEntryResponseInput interface {
 
 type DatasetAccessEntryResponseArgs struct {
 	// [Required] The dataset this entry applies to.
-	Dataset      DatasetReferenceResponseInput                        `pulumi:"dataset"`
-	Target_types DatasetAccessEntryTarget_typesItemResponseArrayInput `pulumi:"target_types"`
+	Dataset     DatasetReferenceResponseInput                       `pulumi:"dataset"`
+	TargetTypes DatasetAccessEntryTargetTypesItemResponseArrayInput `pulumi:"targetTypes"`
 }
 
 func (DatasetAccessEntryResponseArgs) ElementType() reflect.Type {
@@ -3957,202 +3957,202 @@ func (o DatasetAccessEntryResponseOutput) Dataset() DatasetReferenceResponseOutp
 	return o.ApplyT(func(v DatasetAccessEntryResponse) DatasetReferenceResponse { return v.Dataset }).(DatasetReferenceResponseOutput)
 }
 
-func (o DatasetAccessEntryResponseOutput) Target_types() DatasetAccessEntryTarget_typesItemResponseArrayOutput {
-	return o.ApplyT(func(v DatasetAccessEntryResponse) []DatasetAccessEntryTarget_typesItemResponse { return v.Target_types }).(DatasetAccessEntryTarget_typesItemResponseArrayOutput)
+func (o DatasetAccessEntryResponseOutput) TargetTypes() DatasetAccessEntryTargetTypesItemResponseArrayOutput {
+	return o.ApplyT(func(v DatasetAccessEntryResponse) []DatasetAccessEntryTargetTypesItemResponse { return v.TargetTypes }).(DatasetAccessEntryTargetTypesItemResponseArrayOutput)
 }
 
-type DatasetAccessEntryTarget_typesItem struct {
+type DatasetAccessEntryTargetTypesItem struct {
 	// [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
 	TargetType *string `pulumi:"targetType"`
 }
 
-// DatasetAccessEntryTarget_typesItemInput is an input type that accepts DatasetAccessEntryTarget_typesItemArgs and DatasetAccessEntryTarget_typesItemOutput values.
-// You can construct a concrete instance of `DatasetAccessEntryTarget_typesItemInput` via:
+// DatasetAccessEntryTargetTypesItemInput is an input type that accepts DatasetAccessEntryTargetTypesItemArgs and DatasetAccessEntryTargetTypesItemOutput values.
+// You can construct a concrete instance of `DatasetAccessEntryTargetTypesItemInput` via:
 //
-//          DatasetAccessEntryTarget_typesItemArgs{...}
-type DatasetAccessEntryTarget_typesItemInput interface {
+//          DatasetAccessEntryTargetTypesItemArgs{...}
+type DatasetAccessEntryTargetTypesItemInput interface {
 	pulumi.Input
 
-	ToDatasetAccessEntryTarget_typesItemOutput() DatasetAccessEntryTarget_typesItemOutput
-	ToDatasetAccessEntryTarget_typesItemOutputWithContext(context.Context) DatasetAccessEntryTarget_typesItemOutput
+	ToDatasetAccessEntryTargetTypesItemOutput() DatasetAccessEntryTargetTypesItemOutput
+	ToDatasetAccessEntryTargetTypesItemOutputWithContext(context.Context) DatasetAccessEntryTargetTypesItemOutput
 }
 
-type DatasetAccessEntryTarget_typesItemArgs struct {
+type DatasetAccessEntryTargetTypesItemArgs struct {
 	// [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
 	TargetType pulumi.StringPtrInput `pulumi:"targetType"`
 }
 
-func (DatasetAccessEntryTarget_typesItemArgs) ElementType() reflect.Type {
-	return reflect.TypeOf((*DatasetAccessEntryTarget_typesItem)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*DatasetAccessEntryTargetTypesItem)(nil)).Elem()
 }
 
-func (i DatasetAccessEntryTarget_typesItemArgs) ToDatasetAccessEntryTarget_typesItemOutput() DatasetAccessEntryTarget_typesItemOutput {
-	return i.ToDatasetAccessEntryTarget_typesItemOutputWithContext(context.Background())
+func (i DatasetAccessEntryTargetTypesItemArgs) ToDatasetAccessEntryTargetTypesItemOutput() DatasetAccessEntryTargetTypesItemOutput {
+	return i.ToDatasetAccessEntryTargetTypesItemOutputWithContext(context.Background())
 }
 
-func (i DatasetAccessEntryTarget_typesItemArgs) ToDatasetAccessEntryTarget_typesItemOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTarget_typesItemOutput)
+func (i DatasetAccessEntryTargetTypesItemArgs) ToDatasetAccessEntryTargetTypesItemOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTargetTypesItemOutput)
 }
 
-// DatasetAccessEntryTarget_typesItemArrayInput is an input type that accepts DatasetAccessEntryTarget_typesItemArray and DatasetAccessEntryTarget_typesItemArrayOutput values.
-// You can construct a concrete instance of `DatasetAccessEntryTarget_typesItemArrayInput` via:
+// DatasetAccessEntryTargetTypesItemArrayInput is an input type that accepts DatasetAccessEntryTargetTypesItemArray and DatasetAccessEntryTargetTypesItemArrayOutput values.
+// You can construct a concrete instance of `DatasetAccessEntryTargetTypesItemArrayInput` via:
 //
-//          DatasetAccessEntryTarget_typesItemArray{ DatasetAccessEntryTarget_typesItemArgs{...} }
-type DatasetAccessEntryTarget_typesItemArrayInput interface {
+//          DatasetAccessEntryTargetTypesItemArray{ DatasetAccessEntryTargetTypesItemArgs{...} }
+type DatasetAccessEntryTargetTypesItemArrayInput interface {
 	pulumi.Input
 
-	ToDatasetAccessEntryTarget_typesItemArrayOutput() DatasetAccessEntryTarget_typesItemArrayOutput
-	ToDatasetAccessEntryTarget_typesItemArrayOutputWithContext(context.Context) DatasetAccessEntryTarget_typesItemArrayOutput
+	ToDatasetAccessEntryTargetTypesItemArrayOutput() DatasetAccessEntryTargetTypesItemArrayOutput
+	ToDatasetAccessEntryTargetTypesItemArrayOutputWithContext(context.Context) DatasetAccessEntryTargetTypesItemArrayOutput
 }
 
-type DatasetAccessEntryTarget_typesItemArray []DatasetAccessEntryTarget_typesItemInput
+type DatasetAccessEntryTargetTypesItemArray []DatasetAccessEntryTargetTypesItemInput
 
-func (DatasetAccessEntryTarget_typesItemArray) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]DatasetAccessEntryTarget_typesItem)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]DatasetAccessEntryTargetTypesItem)(nil)).Elem()
 }
 
-func (i DatasetAccessEntryTarget_typesItemArray) ToDatasetAccessEntryTarget_typesItemArrayOutput() DatasetAccessEntryTarget_typesItemArrayOutput {
-	return i.ToDatasetAccessEntryTarget_typesItemArrayOutputWithContext(context.Background())
+func (i DatasetAccessEntryTargetTypesItemArray) ToDatasetAccessEntryTargetTypesItemArrayOutput() DatasetAccessEntryTargetTypesItemArrayOutput {
+	return i.ToDatasetAccessEntryTargetTypesItemArrayOutputWithContext(context.Background())
 }
 
-func (i DatasetAccessEntryTarget_typesItemArray) ToDatasetAccessEntryTarget_typesItemArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemArrayOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTarget_typesItemArrayOutput)
+func (i DatasetAccessEntryTargetTypesItemArray) ToDatasetAccessEntryTargetTypesItemArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTargetTypesItemArrayOutput)
 }
 
-type DatasetAccessEntryTarget_typesItemOutput struct{ *pulumi.OutputState }
+type DatasetAccessEntryTargetTypesItemOutput struct{ *pulumi.OutputState }
 
-func (DatasetAccessEntryTarget_typesItemOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*DatasetAccessEntryTarget_typesItem)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*DatasetAccessEntryTargetTypesItem)(nil)).Elem()
 }
 
-func (o DatasetAccessEntryTarget_typesItemOutput) ToDatasetAccessEntryTarget_typesItemOutput() DatasetAccessEntryTarget_typesItemOutput {
+func (o DatasetAccessEntryTargetTypesItemOutput) ToDatasetAccessEntryTargetTypesItemOutput() DatasetAccessEntryTargetTypesItemOutput {
 	return o
 }
 
-func (o DatasetAccessEntryTarget_typesItemOutput) ToDatasetAccessEntryTarget_typesItemOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemOutput {
+func (o DatasetAccessEntryTargetTypesItemOutput) ToDatasetAccessEntryTargetTypesItemOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemOutput {
 	return o
 }
 
 // [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
-func (o DatasetAccessEntryTarget_typesItemOutput) TargetType() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DatasetAccessEntryTarget_typesItem) *string { return v.TargetType }).(pulumi.StringPtrOutput)
+func (o DatasetAccessEntryTargetTypesItemOutput) TargetType() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v DatasetAccessEntryTargetTypesItem) *string { return v.TargetType }).(pulumi.StringPtrOutput)
 }
 
-type DatasetAccessEntryTarget_typesItemArrayOutput struct{ *pulumi.OutputState }
+type DatasetAccessEntryTargetTypesItemArrayOutput struct{ *pulumi.OutputState }
 
-func (DatasetAccessEntryTarget_typesItemArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]DatasetAccessEntryTarget_typesItem)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]DatasetAccessEntryTargetTypesItem)(nil)).Elem()
 }
 
-func (o DatasetAccessEntryTarget_typesItemArrayOutput) ToDatasetAccessEntryTarget_typesItemArrayOutput() DatasetAccessEntryTarget_typesItemArrayOutput {
+func (o DatasetAccessEntryTargetTypesItemArrayOutput) ToDatasetAccessEntryTargetTypesItemArrayOutput() DatasetAccessEntryTargetTypesItemArrayOutput {
 	return o
 }
 
-func (o DatasetAccessEntryTarget_typesItemArrayOutput) ToDatasetAccessEntryTarget_typesItemArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemArrayOutput {
+func (o DatasetAccessEntryTargetTypesItemArrayOutput) ToDatasetAccessEntryTargetTypesItemArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemArrayOutput {
 	return o
 }
 
-func (o DatasetAccessEntryTarget_typesItemArrayOutput) Index(i pulumi.IntInput) DatasetAccessEntryTarget_typesItemOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) DatasetAccessEntryTarget_typesItem {
-		return vs[0].([]DatasetAccessEntryTarget_typesItem)[vs[1].(int)]
-	}).(DatasetAccessEntryTarget_typesItemOutput)
+func (o DatasetAccessEntryTargetTypesItemArrayOutput) Index(i pulumi.IntInput) DatasetAccessEntryTargetTypesItemOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) DatasetAccessEntryTargetTypesItem {
+		return vs[0].([]DatasetAccessEntryTargetTypesItem)[vs[1].(int)]
+	}).(DatasetAccessEntryTargetTypesItemOutput)
 }
 
-type DatasetAccessEntryTarget_typesItemResponse struct {
+type DatasetAccessEntryTargetTypesItemResponse struct {
 	// [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
 	TargetType string `pulumi:"targetType"`
 }
 
-// DatasetAccessEntryTarget_typesItemResponseInput is an input type that accepts DatasetAccessEntryTarget_typesItemResponseArgs and DatasetAccessEntryTarget_typesItemResponseOutput values.
-// You can construct a concrete instance of `DatasetAccessEntryTarget_typesItemResponseInput` via:
+// DatasetAccessEntryTargetTypesItemResponseInput is an input type that accepts DatasetAccessEntryTargetTypesItemResponseArgs and DatasetAccessEntryTargetTypesItemResponseOutput values.
+// You can construct a concrete instance of `DatasetAccessEntryTargetTypesItemResponseInput` via:
 //
-//          DatasetAccessEntryTarget_typesItemResponseArgs{...}
-type DatasetAccessEntryTarget_typesItemResponseInput interface {
+//          DatasetAccessEntryTargetTypesItemResponseArgs{...}
+type DatasetAccessEntryTargetTypesItemResponseInput interface {
 	pulumi.Input
 
-	ToDatasetAccessEntryTarget_typesItemResponseOutput() DatasetAccessEntryTarget_typesItemResponseOutput
-	ToDatasetAccessEntryTarget_typesItemResponseOutputWithContext(context.Context) DatasetAccessEntryTarget_typesItemResponseOutput
+	ToDatasetAccessEntryTargetTypesItemResponseOutput() DatasetAccessEntryTargetTypesItemResponseOutput
+	ToDatasetAccessEntryTargetTypesItemResponseOutputWithContext(context.Context) DatasetAccessEntryTargetTypesItemResponseOutput
 }
 
-type DatasetAccessEntryTarget_typesItemResponseArgs struct {
+type DatasetAccessEntryTargetTypesItemResponseArgs struct {
 	// [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
 	TargetType pulumi.StringInput `pulumi:"targetType"`
 }
 
-func (DatasetAccessEntryTarget_typesItemResponseArgs) ElementType() reflect.Type {
-	return reflect.TypeOf((*DatasetAccessEntryTarget_typesItemResponse)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemResponseArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*DatasetAccessEntryTargetTypesItemResponse)(nil)).Elem()
 }
 
-func (i DatasetAccessEntryTarget_typesItemResponseArgs) ToDatasetAccessEntryTarget_typesItemResponseOutput() DatasetAccessEntryTarget_typesItemResponseOutput {
-	return i.ToDatasetAccessEntryTarget_typesItemResponseOutputWithContext(context.Background())
+func (i DatasetAccessEntryTargetTypesItemResponseArgs) ToDatasetAccessEntryTargetTypesItemResponseOutput() DatasetAccessEntryTargetTypesItemResponseOutput {
+	return i.ToDatasetAccessEntryTargetTypesItemResponseOutputWithContext(context.Background())
 }
 
-func (i DatasetAccessEntryTarget_typesItemResponseArgs) ToDatasetAccessEntryTarget_typesItemResponseOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemResponseOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTarget_typesItemResponseOutput)
+func (i DatasetAccessEntryTargetTypesItemResponseArgs) ToDatasetAccessEntryTargetTypesItemResponseOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemResponseOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTargetTypesItemResponseOutput)
 }
 
-// DatasetAccessEntryTarget_typesItemResponseArrayInput is an input type that accepts DatasetAccessEntryTarget_typesItemResponseArray and DatasetAccessEntryTarget_typesItemResponseArrayOutput values.
-// You can construct a concrete instance of `DatasetAccessEntryTarget_typesItemResponseArrayInput` via:
+// DatasetAccessEntryTargetTypesItemResponseArrayInput is an input type that accepts DatasetAccessEntryTargetTypesItemResponseArray and DatasetAccessEntryTargetTypesItemResponseArrayOutput values.
+// You can construct a concrete instance of `DatasetAccessEntryTargetTypesItemResponseArrayInput` via:
 //
-//          DatasetAccessEntryTarget_typesItemResponseArray{ DatasetAccessEntryTarget_typesItemResponseArgs{...} }
-type DatasetAccessEntryTarget_typesItemResponseArrayInput interface {
+//          DatasetAccessEntryTargetTypesItemResponseArray{ DatasetAccessEntryTargetTypesItemResponseArgs{...} }
+type DatasetAccessEntryTargetTypesItemResponseArrayInput interface {
 	pulumi.Input
 
-	ToDatasetAccessEntryTarget_typesItemResponseArrayOutput() DatasetAccessEntryTarget_typesItemResponseArrayOutput
-	ToDatasetAccessEntryTarget_typesItemResponseArrayOutputWithContext(context.Context) DatasetAccessEntryTarget_typesItemResponseArrayOutput
+	ToDatasetAccessEntryTargetTypesItemResponseArrayOutput() DatasetAccessEntryTargetTypesItemResponseArrayOutput
+	ToDatasetAccessEntryTargetTypesItemResponseArrayOutputWithContext(context.Context) DatasetAccessEntryTargetTypesItemResponseArrayOutput
 }
 
-type DatasetAccessEntryTarget_typesItemResponseArray []DatasetAccessEntryTarget_typesItemResponseInput
+type DatasetAccessEntryTargetTypesItemResponseArray []DatasetAccessEntryTargetTypesItemResponseInput
 
-func (DatasetAccessEntryTarget_typesItemResponseArray) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]DatasetAccessEntryTarget_typesItemResponse)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemResponseArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]DatasetAccessEntryTargetTypesItemResponse)(nil)).Elem()
 }
 
-func (i DatasetAccessEntryTarget_typesItemResponseArray) ToDatasetAccessEntryTarget_typesItemResponseArrayOutput() DatasetAccessEntryTarget_typesItemResponseArrayOutput {
-	return i.ToDatasetAccessEntryTarget_typesItemResponseArrayOutputWithContext(context.Background())
+func (i DatasetAccessEntryTargetTypesItemResponseArray) ToDatasetAccessEntryTargetTypesItemResponseArrayOutput() DatasetAccessEntryTargetTypesItemResponseArrayOutput {
+	return i.ToDatasetAccessEntryTargetTypesItemResponseArrayOutputWithContext(context.Background())
 }
 
-func (i DatasetAccessEntryTarget_typesItemResponseArray) ToDatasetAccessEntryTarget_typesItemResponseArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemResponseArrayOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTarget_typesItemResponseArrayOutput)
+func (i DatasetAccessEntryTargetTypesItemResponseArray) ToDatasetAccessEntryTargetTypesItemResponseArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemResponseArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DatasetAccessEntryTargetTypesItemResponseArrayOutput)
 }
 
-type DatasetAccessEntryTarget_typesItemResponseOutput struct{ *pulumi.OutputState }
+type DatasetAccessEntryTargetTypesItemResponseOutput struct{ *pulumi.OutputState }
 
-func (DatasetAccessEntryTarget_typesItemResponseOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*DatasetAccessEntryTarget_typesItemResponse)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemResponseOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*DatasetAccessEntryTargetTypesItemResponse)(nil)).Elem()
 }
 
-func (o DatasetAccessEntryTarget_typesItemResponseOutput) ToDatasetAccessEntryTarget_typesItemResponseOutput() DatasetAccessEntryTarget_typesItemResponseOutput {
+func (o DatasetAccessEntryTargetTypesItemResponseOutput) ToDatasetAccessEntryTargetTypesItemResponseOutput() DatasetAccessEntryTargetTypesItemResponseOutput {
 	return o
 }
 
-func (o DatasetAccessEntryTarget_typesItemResponseOutput) ToDatasetAccessEntryTarget_typesItemResponseOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemResponseOutput {
+func (o DatasetAccessEntryTargetTypesItemResponseOutput) ToDatasetAccessEntryTargetTypesItemResponseOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemResponseOutput {
 	return o
 }
 
 // [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
-func (o DatasetAccessEntryTarget_typesItemResponseOutput) TargetType() pulumi.StringOutput {
-	return o.ApplyT(func(v DatasetAccessEntryTarget_typesItemResponse) string { return v.TargetType }).(pulumi.StringOutput)
+func (o DatasetAccessEntryTargetTypesItemResponseOutput) TargetType() pulumi.StringOutput {
+	return o.ApplyT(func(v DatasetAccessEntryTargetTypesItemResponse) string { return v.TargetType }).(pulumi.StringOutput)
 }
 
-type DatasetAccessEntryTarget_typesItemResponseArrayOutput struct{ *pulumi.OutputState }
+type DatasetAccessEntryTargetTypesItemResponseArrayOutput struct{ *pulumi.OutputState }
 
-func (DatasetAccessEntryTarget_typesItemResponseArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]DatasetAccessEntryTarget_typesItemResponse)(nil)).Elem()
+func (DatasetAccessEntryTargetTypesItemResponseArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]DatasetAccessEntryTargetTypesItemResponse)(nil)).Elem()
 }
 
-func (o DatasetAccessEntryTarget_typesItemResponseArrayOutput) ToDatasetAccessEntryTarget_typesItemResponseArrayOutput() DatasetAccessEntryTarget_typesItemResponseArrayOutput {
+func (o DatasetAccessEntryTargetTypesItemResponseArrayOutput) ToDatasetAccessEntryTargetTypesItemResponseArrayOutput() DatasetAccessEntryTargetTypesItemResponseArrayOutput {
 	return o
 }
 
-func (o DatasetAccessEntryTarget_typesItemResponseArrayOutput) ToDatasetAccessEntryTarget_typesItemResponseArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTarget_typesItemResponseArrayOutput {
+func (o DatasetAccessEntryTargetTypesItemResponseArrayOutput) ToDatasetAccessEntryTargetTypesItemResponseArrayOutputWithContext(ctx context.Context) DatasetAccessEntryTargetTypesItemResponseArrayOutput {
 	return o
 }
 
-func (o DatasetAccessEntryTarget_typesItemResponseArrayOutput) Index(i pulumi.IntInput) DatasetAccessEntryTarget_typesItemResponseOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) DatasetAccessEntryTarget_typesItemResponse {
-		return vs[0].([]DatasetAccessEntryTarget_typesItemResponse)[vs[1].(int)]
-	}).(DatasetAccessEntryTarget_typesItemResponseOutput)
+func (o DatasetAccessEntryTargetTypesItemResponseArrayOutput) Index(i pulumi.IntInput) DatasetAccessEntryTargetTypesItemResponseOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) DatasetAccessEntryTargetTypesItemResponse {
+		return vs[0].([]DatasetAccessEntryTargetTypesItemResponse)[vs[1].(int)]
+	}).(DatasetAccessEntryTargetTypesItemResponseOutput)
 }
 
 type DatasetAccessItem struct {
@@ -13207,10 +13207,10 @@ type JobStatisticsResponse struct {
 	Query JobStatistics2Response `pulumi:"query"`
 	// Quotas which delayed this job's start time.
 	QuotaDeferments []string `pulumi:"quotaDeferments"`
+	// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+	ReservationId string `pulumi:"reservationId"`
 	// Job resource usage breakdown by reservation.
 	ReservationUsage []JobStatisticsReservationUsageItemResponse `pulumi:"reservationUsage"`
-	// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
-	Reservation_id string `pulumi:"reservation_id"`
 	// [Preview] Statistics for row-level security. Present only for query and extract jobs.
 	RowLevelSecurityStatistics RowLevelSecurityStatisticsResponse `pulumi:"rowLevelSecurityStatistics"`
 	// Statistics for a child job of a script.
@@ -13255,10 +13255,10 @@ type JobStatisticsResponseArgs struct {
 	Query JobStatistics2ResponseInput `pulumi:"query"`
 	// Quotas which delayed this job's start time.
 	QuotaDeferments pulumi.StringArrayInput `pulumi:"quotaDeferments"`
+	// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+	ReservationId pulumi.StringInput `pulumi:"reservationId"`
 	// Job resource usage breakdown by reservation.
 	ReservationUsage JobStatisticsReservationUsageItemResponseArrayInput `pulumi:"reservationUsage"`
-	// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
-	Reservation_id pulumi.StringInput `pulumi:"reservation_id"`
 	// [Preview] Statistics for row-level security. Present only for query and extract jobs.
 	RowLevelSecurityStatistics RowLevelSecurityStatisticsResponseInput `pulumi:"rowLevelSecurityStatistics"`
 	// Statistics for a child job of a script.
@@ -13395,14 +13395,14 @@ func (o JobStatisticsResponseOutput) QuotaDeferments() pulumi.StringArrayOutput 
 	return o.ApplyT(func(v JobStatisticsResponse) []string { return v.QuotaDeferments }).(pulumi.StringArrayOutput)
 }
 
+// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+func (o JobStatisticsResponseOutput) ReservationId() pulumi.StringOutput {
+	return o.ApplyT(func(v JobStatisticsResponse) string { return v.ReservationId }).(pulumi.StringOutput)
+}
+
 // Job resource usage breakdown by reservation.
 func (o JobStatisticsResponseOutput) ReservationUsage() JobStatisticsReservationUsageItemResponseArrayOutput {
 	return o.ApplyT(func(v JobStatisticsResponse) []JobStatisticsReservationUsageItemResponse { return v.ReservationUsage }).(JobStatisticsReservationUsageItemResponseArrayOutput)
-}
-
-// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
-func (o JobStatisticsResponseOutput) Reservation_id() pulumi.StringOutput {
-	return o.ApplyT(func(v JobStatisticsResponse) string { return v.Reservation_id }).(pulumi.StringOutput)
 }
 
 // [Preview] Statistics for row-level security. Present only for query and extract jobs.
@@ -13543,6 +13543,16 @@ func (o JobStatisticsResponsePtrOutput) QuotaDeferments() pulumi.StringArrayOutp
 	}).(pulumi.StringArrayOutput)
 }
 
+// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+func (o JobStatisticsResponsePtrOutput) ReservationId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *JobStatisticsResponse) *string {
+		if v == nil {
+			return nil
+		}
+		return &v.ReservationId
+	}).(pulumi.StringPtrOutput)
+}
+
 // Job resource usage breakdown by reservation.
 func (o JobStatisticsResponsePtrOutput) ReservationUsage() JobStatisticsReservationUsageItemResponseArrayOutput {
 	return o.ApplyT(func(v *JobStatisticsResponse) []JobStatisticsReservationUsageItemResponse {
@@ -13551,16 +13561,6 @@ func (o JobStatisticsResponsePtrOutput) ReservationUsage() JobStatisticsReservat
 		}
 		return v.ReservationUsage
 	}).(JobStatisticsReservationUsageItemResponseArrayOutput)
-}
-
-// Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
-func (o JobStatisticsResponsePtrOutput) Reservation_id() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *JobStatisticsResponse) *string {
-		if v == nil {
-			return nil
-		}
-		return &v.Reservation_id
-	}).(pulumi.StringPtrOutput)
 }
 
 // [Preview] Statistics for row-level security. Present only for query and extract jobs.
@@ -22262,10 +22262,10 @@ func init() {
 	pulumi.RegisterOutputType(DatasetAccessEntryOutput{})
 	pulumi.RegisterOutputType(DatasetAccessEntryPtrOutput{})
 	pulumi.RegisterOutputType(DatasetAccessEntryResponseOutput{})
-	pulumi.RegisterOutputType(DatasetAccessEntryTarget_typesItemOutput{})
-	pulumi.RegisterOutputType(DatasetAccessEntryTarget_typesItemArrayOutput{})
-	pulumi.RegisterOutputType(DatasetAccessEntryTarget_typesItemResponseOutput{})
-	pulumi.RegisterOutputType(DatasetAccessEntryTarget_typesItemResponseArrayOutput{})
+	pulumi.RegisterOutputType(DatasetAccessEntryTargetTypesItemOutput{})
+	pulumi.RegisterOutputType(DatasetAccessEntryTargetTypesItemArrayOutput{})
+	pulumi.RegisterOutputType(DatasetAccessEntryTargetTypesItemResponseOutput{})
+	pulumi.RegisterOutputType(DatasetAccessEntryTargetTypesItemResponseArrayOutput{})
 	pulumi.RegisterOutputType(DatasetAccessItemOutput{})
 	pulumi.RegisterOutputType(DatasetAccessItemArrayOutput{})
 	pulumi.RegisterOutputType(DatasetAccessItemResponseOutput{})

--- a/sdk/go/google/compute/alpha/forwardingRule.go
+++ b/sdk/go/google/compute/alpha/forwardingRule.go
@@ -15,33 +15,6 @@ import (
 type ForwardingRule struct {
 	pulumi.CustomResourceState
 
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringOutput `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringOutput `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -58,6 +31,33 @@ type ForwardingRule struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringOutput `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringOutput `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringOutput `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringOutput `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -194,33 +194,6 @@ func GetForwardingRule(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering ForwardingRule resources.
 type forwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -237,6 +210,33 @@ type forwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint *string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress *string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -339,33 +339,6 @@ type forwardingRuleState struct {
 }
 
 type ForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringPtrInput
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -382,6 +355,33 @@ type ForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringPtrInput
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringPtrInput
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringPtrInput
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringPtrInput
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -488,6 +488,16 @@ func (ForwardingRuleState) ElementType() reflect.Type {
 }
 
 type forwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts *bool `pulumi:"allPorts"`
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService *string `pulumi:"backendService"`
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description *string `pulumi:"description"`
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -503,7 +513,7 @@ type forwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
+	IpAddress *string `pulumi:"ipAddress"`
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -514,17 +524,7 @@ type forwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts *bool `pulumi:"allPorts"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService *string `pulumi:"backendService"`
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description *string `pulumi:"description"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -613,6 +613,16 @@ type forwardingRuleArgs struct {
 
 // The set of arguments for constructing a ForwardingRule resource.
 type ForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts pulumi.BoolPtrInput
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess pulumi.BoolPtrInput
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService pulumi.StringPtrInput
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description pulumi.StringPtrInput
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -628,7 +638,7 @@ type ForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
+	IpAddress pulumi.StringPtrInput
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -639,17 +649,7 @@ type ForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *ForwardingRuleIPProtocol
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts pulumi.BoolPtrInput
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess pulumi.BoolPtrInput
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService pulumi.StringPtrInput
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description pulumi.StringPtrInput
+	IpProtocol *ForwardingRuleIpProtocol
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *ForwardingRuleIpVersion
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/alpha/getForwardingRule.go
+++ b/sdk/go/google/compute/alpha/getForwardingRule.go
@@ -24,33 +24,6 @@ type LookupForwardingRuleArgs struct {
 }
 
 type LookupForwardingRuleResult struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -67,6 +40,33 @@ type LookupForwardingRuleResult struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/alpha/getGlobalForwardingRule.go
+++ b/sdk/go/google/compute/alpha/getGlobalForwardingRule.go
@@ -23,33 +23,6 @@ type LookupGlobalForwardingRuleArgs struct {
 }
 
 type LookupGlobalForwardingRuleResult struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -66,6 +39,33 @@ type LookupGlobalForwardingRuleResult struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/alpha/globalForwardingRule.go
+++ b/sdk/go/google/compute/alpha/globalForwardingRule.go
@@ -15,33 +15,6 @@ import (
 type GlobalForwardingRule struct {
 	pulumi.CustomResourceState
 
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringOutput `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringOutput `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -58,6 +31,33 @@ type GlobalForwardingRule struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringOutput `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringOutput `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringOutput `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringOutput `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -191,33 +191,6 @@ func GetGlobalForwardingRule(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering GlobalForwardingRule resources.
 type globalForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -234,6 +207,33 @@ type globalForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint *string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress *string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -336,33 +336,6 @@ type globalForwardingRuleState struct {
 }
 
 type GlobalForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringPtrInput
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -379,6 +352,33 @@ type GlobalForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringPtrInput
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringPtrInput
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringPtrInput
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringPtrInput
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -485,6 +485,16 @@ func (GlobalForwardingRuleState) ElementType() reflect.Type {
 }
 
 type globalForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts *bool `pulumi:"allPorts"`
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService *string `pulumi:"backendService"`
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description *string `pulumi:"description"`
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -500,7 +510,7 @@ type globalForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
+	IpAddress *string `pulumi:"ipAddress"`
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -511,17 +521,7 @@ type globalForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts *bool `pulumi:"allPorts"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService *string `pulumi:"backendService"`
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description *string `pulumi:"description"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -609,6 +609,16 @@ type globalForwardingRuleArgs struct {
 
 // The set of arguments for constructing a GlobalForwardingRule resource.
 type GlobalForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts pulumi.BoolPtrInput
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess pulumi.BoolPtrInput
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService pulumi.StringPtrInput
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description pulumi.StringPtrInput
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -624,7 +634,7 @@ type GlobalForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
+	IpAddress pulumi.StringPtrInput
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -635,17 +645,7 @@ type GlobalForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *GlobalForwardingRuleIPProtocol
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts pulumi.BoolPtrInput
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess pulumi.BoolPtrInput
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService pulumi.StringPtrInput
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description pulumi.StringPtrInput
+	IpProtocol *GlobalForwardingRuleIpProtocol
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *GlobalForwardingRuleIpVersion
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/alpha/pulumiEnums.go
+++ b/sdk/go/google/compute/alpha/pulumiEnums.go
@@ -1348,35 +1348,35 @@ func (e FirewallPolicyRuleDirection) ToStringPtrOutputWithContext(ctx context.Co
 // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-type ForwardingRuleIPProtocol pulumi.String
+type ForwardingRuleIpProtocol pulumi.String
 
 const (
-	ForwardingRuleIPProtocolAh   = ForwardingRuleIPProtocol("AH")
-	ForwardingRuleIPProtocolAll  = ForwardingRuleIPProtocol("ALL")
-	ForwardingRuleIPProtocolEsp  = ForwardingRuleIPProtocol("ESP")
-	ForwardingRuleIPProtocolIcmp = ForwardingRuleIPProtocol("ICMP")
-	ForwardingRuleIPProtocolSctp = ForwardingRuleIPProtocol("SCTP")
-	ForwardingRuleIPProtocolTcp  = ForwardingRuleIPProtocol("TCP")
-	ForwardingRuleIPProtocolUdp  = ForwardingRuleIPProtocol("UDP")
+	ForwardingRuleIpProtocolAh   = ForwardingRuleIpProtocol("AH")
+	ForwardingRuleIpProtocolAll  = ForwardingRuleIpProtocol("ALL")
+	ForwardingRuleIpProtocolEsp  = ForwardingRuleIpProtocol("ESP")
+	ForwardingRuleIpProtocolIcmp = ForwardingRuleIpProtocol("ICMP")
+	ForwardingRuleIpProtocolSctp = ForwardingRuleIpProtocol("SCTP")
+	ForwardingRuleIpProtocolTcp  = ForwardingRuleIpProtocol("TCP")
+	ForwardingRuleIpProtocolUdp  = ForwardingRuleIpProtocol("UDP")
 )
 
-func (ForwardingRuleIPProtocol) ElementType() reflect.Type {
+func (ForwardingRuleIpProtocol) ElementType() reflect.Type {
 	return reflect.TypeOf((*pulumi.String)(nil)).Elem()
 }
 
-func (e ForwardingRuleIPProtocol) ToStringOutput() pulumi.StringOutput {
+func (e ForwardingRuleIpProtocol) ToStringOutput() pulumi.StringOutput {
 	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e ForwardingRuleIPProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+func (e ForwardingRuleIpProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
 	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e ForwardingRuleIPProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
+func (e ForwardingRuleIpProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
 }
 
-func (e ForwardingRuleIPProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+func (e ForwardingRuleIpProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
 }
 
@@ -1695,35 +1695,35 @@ func (e GlobalAddressPurpose) ToStringPtrOutputWithContext(ctx context.Context) 
 // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-type GlobalForwardingRuleIPProtocol pulumi.String
+type GlobalForwardingRuleIpProtocol pulumi.String
 
 const (
-	GlobalForwardingRuleIPProtocolAh   = GlobalForwardingRuleIPProtocol("AH")
-	GlobalForwardingRuleIPProtocolAll  = GlobalForwardingRuleIPProtocol("ALL")
-	GlobalForwardingRuleIPProtocolEsp  = GlobalForwardingRuleIPProtocol("ESP")
-	GlobalForwardingRuleIPProtocolIcmp = GlobalForwardingRuleIPProtocol("ICMP")
-	GlobalForwardingRuleIPProtocolSctp = GlobalForwardingRuleIPProtocol("SCTP")
-	GlobalForwardingRuleIPProtocolTcp  = GlobalForwardingRuleIPProtocol("TCP")
-	GlobalForwardingRuleIPProtocolUdp  = GlobalForwardingRuleIPProtocol("UDP")
+	GlobalForwardingRuleIpProtocolAh   = GlobalForwardingRuleIpProtocol("AH")
+	GlobalForwardingRuleIpProtocolAll  = GlobalForwardingRuleIpProtocol("ALL")
+	GlobalForwardingRuleIpProtocolEsp  = GlobalForwardingRuleIpProtocol("ESP")
+	GlobalForwardingRuleIpProtocolIcmp = GlobalForwardingRuleIpProtocol("ICMP")
+	GlobalForwardingRuleIpProtocolSctp = GlobalForwardingRuleIpProtocol("SCTP")
+	GlobalForwardingRuleIpProtocolTcp  = GlobalForwardingRuleIpProtocol("TCP")
+	GlobalForwardingRuleIpProtocolUdp  = GlobalForwardingRuleIpProtocol("UDP")
 )
 
-func (GlobalForwardingRuleIPProtocol) ElementType() reflect.Type {
+func (GlobalForwardingRuleIpProtocol) ElementType() reflect.Type {
 	return reflect.TypeOf((*pulumi.String)(nil)).Elem()
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringOutput() pulumi.StringOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringOutput() pulumi.StringOutput {
 	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
 	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
 }
 

--- a/sdk/go/google/compute/alpha/pulumiTypes.go
+++ b/sdk/go/google/compute/alpha/pulumiTypes.go
@@ -18899,7 +18899,7 @@ func (o FileContentBufferResponseArrayOutput) Index(i pulumi.IntInput) FileConte
 
 type FirewallAllowedItem struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol *string `pulumi:"IPProtocol"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -18919,7 +18919,7 @@ type FirewallAllowedItemInput interface {
 
 type FirewallAllowedItemArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringPtrInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringPtrInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -18978,8 +18978,8 @@ func (o FirewallAllowedItemOutput) ToFirewallAllowedItemOutputWithContext(ctx co
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallAllowedItemOutput) IPProtocol() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FirewallAllowedItem) *string { return v.IPProtocol }).(pulumi.StringPtrOutput)
+func (o FirewallAllowedItemOutput) IpProtocol() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FirewallAllowedItem) *string { return v.IpProtocol }).(pulumi.StringPtrOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -19011,7 +19011,7 @@ func (o FirewallAllowedItemArrayOutput) Index(i pulumi.IntInput) FirewallAllowed
 
 type FirewallAllowedItemResponse struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol string `pulumi:"IPProtocol"`
+	IpProtocol string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -19031,7 +19031,7 @@ type FirewallAllowedItemResponseInput interface {
 
 type FirewallAllowedItemResponseArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -19090,8 +19090,8 @@ func (o FirewallAllowedItemResponseOutput) ToFirewallAllowedItemResponseOutputWi
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallAllowedItemResponseOutput) IPProtocol() pulumi.StringOutput {
-	return o.ApplyT(func(v FirewallAllowedItemResponse) string { return v.IPProtocol }).(pulumi.StringOutput)
+func (o FirewallAllowedItemResponseOutput) IpProtocol() pulumi.StringOutput {
+	return o.ApplyT(func(v FirewallAllowedItemResponse) string { return v.IpProtocol }).(pulumi.StringOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -19123,7 +19123,7 @@ func (o FirewallAllowedItemResponseArrayOutput) Index(i pulumi.IntInput) Firewal
 
 type FirewallDeniedItem struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol *string `pulumi:"IPProtocol"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -19143,7 +19143,7 @@ type FirewallDeniedItemInput interface {
 
 type FirewallDeniedItemArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringPtrInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringPtrInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -19202,8 +19202,8 @@ func (o FirewallDeniedItemOutput) ToFirewallDeniedItemOutputWithContext(ctx cont
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallDeniedItemOutput) IPProtocol() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FirewallDeniedItem) *string { return v.IPProtocol }).(pulumi.StringPtrOutput)
+func (o FirewallDeniedItemOutput) IpProtocol() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FirewallDeniedItem) *string { return v.IpProtocol }).(pulumi.StringPtrOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -19235,7 +19235,7 @@ func (o FirewallDeniedItemArrayOutput) Index(i pulumi.IntInput) FirewallDeniedIt
 
 type FirewallDeniedItemResponse struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol string `pulumi:"IPProtocol"`
+	IpProtocol string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -19255,7 +19255,7 @@ type FirewallDeniedItemResponseInput interface {
 
 type FirewallDeniedItemResponseArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -19314,8 +19314,8 @@ func (o FirewallDeniedItemResponseOutput) ToFirewallDeniedItemResponseOutputWith
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallDeniedItemResponseOutput) IPProtocol() pulumi.StringOutput {
-	return o.ApplyT(func(v FirewallDeniedItemResponse) string { return v.IPProtocol }).(pulumi.StringOutput)
+func (o FirewallDeniedItemResponseOutput) IpProtocol() pulumi.StringOutput {
+	return o.ApplyT(func(v FirewallDeniedItemResponse) string { return v.IpProtocol }).(pulumi.StringOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -43962,12 +43962,12 @@ func (o OutlierDetectionResponsePtrOutput) SuccessRateStdevFactor() pulumi.IntPt
 }
 
 type PacketMirroringFilter struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols []string `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges []string `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction *string `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols []string `pulumi:"ipProtocols"`
 }
 
 // PacketMirroringFilterInput is an input type that accepts PacketMirroringFilterArgs and PacketMirroringFilterOutput values.
@@ -43982,12 +43982,12 @@ type PacketMirroringFilterInput interface {
 }
 
 type PacketMirroringFilterArgs struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols pulumi.StringArrayInput `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges pulumi.StringArrayInput `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction *PacketMirroringFilterDirection `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols pulumi.StringArrayInput `pulumi:"ipProtocols"`
 }
 
 func (PacketMirroringFilterArgs) ElementType() reflect.Type {
@@ -44067,11 +44067,6 @@ func (o PacketMirroringFilterOutput) ToPacketMirroringFilterPtrOutputWithContext
 	}).(PacketMirroringFilterPtrOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.IPProtocols }).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.CidrRanges }).(pulumi.StringArrayOutput)
@@ -44080,6 +44075,11 @@ func (o PacketMirroringFilterOutput) CidrRanges() pulumi.StringArrayOutput {
 // Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 func (o PacketMirroringFilterOutput) Direction() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v PacketMirroringFilter) *string { return v.Direction }).(pulumi.StringPtrOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.IpProtocols }).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringFilterPtrOutput struct{ *pulumi.OutputState }
@@ -44098,16 +44098,6 @@ func (o PacketMirroringFilterPtrOutput) ToPacketMirroringFilterPtrOutputWithCont
 
 func (o PacketMirroringFilterPtrOutput) Elem() PacketMirroringFilterOutput {
 	return o.ApplyT(func(v *PacketMirroringFilter) PacketMirroringFilter { return *v }).(PacketMirroringFilterOutput)
-}
-
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterPtrOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *PacketMirroringFilter) []string {
-		if v == nil {
-			return nil
-		}
-		return v.IPProtocols
-	}).(pulumi.StringArrayOutput)
 }
 
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
@@ -44130,13 +44120,23 @@ func (o PacketMirroringFilterPtrOutput) Direction() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterPtrOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *PacketMirroringFilter) []string {
+		if v == nil {
+			return nil
+		}
+		return v.IpProtocols
+	}).(pulumi.StringArrayOutput)
+}
+
 type PacketMirroringFilterResponse struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols []string `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges []string `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction string `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols []string `pulumi:"ipProtocols"`
 }
 
 // PacketMirroringFilterResponseInput is an input type that accepts PacketMirroringFilterResponseArgs and PacketMirroringFilterResponseOutput values.
@@ -44151,12 +44151,12 @@ type PacketMirroringFilterResponseInput interface {
 }
 
 type PacketMirroringFilterResponseArgs struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols pulumi.StringArrayInput `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges pulumi.StringArrayInput `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction pulumi.StringInput `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols pulumi.StringArrayInput `pulumi:"ipProtocols"`
 }
 
 func (PacketMirroringFilterResponseArgs) ElementType() reflect.Type {
@@ -44236,11 +44236,6 @@ func (o PacketMirroringFilterResponseOutput) ToPacketMirroringFilterResponsePtrO
 	}).(PacketMirroringFilterResponsePtrOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterResponseOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.IPProtocols }).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterResponseOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.CidrRanges }).(pulumi.StringArrayOutput)
@@ -44249,6 +44244,11 @@ func (o PacketMirroringFilterResponseOutput) CidrRanges() pulumi.StringArrayOutp
 // Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 func (o PacketMirroringFilterResponseOutput) Direction() pulumi.StringOutput {
 	return o.ApplyT(func(v PacketMirroringFilterResponse) string { return v.Direction }).(pulumi.StringOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterResponseOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.IpProtocols }).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringFilterResponsePtrOutput struct{ *pulumi.OutputState }
@@ -44269,16 +44269,6 @@ func (o PacketMirroringFilterResponsePtrOutput) Elem() PacketMirroringFilterResp
 	return o.ApplyT(func(v *PacketMirroringFilterResponse) PacketMirroringFilterResponse { return *v }).(PacketMirroringFilterResponseOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterResponsePtrOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
-		if v == nil {
-			return nil
-		}
-		return v.IPProtocols
-	}).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterResponsePtrOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
@@ -44297,6 +44287,16 @@ func (o PacketMirroringFilterResponsePtrOutput) Direction() pulumi.StringPtrOutp
 		}
 		return &v.Direction
 	}).(pulumi.StringPtrOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterResponsePtrOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
+		if v == nil {
+			return nil
+		}
+		return v.IpProtocols
+	}).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringForwardingRuleInfo struct {

--- a/sdk/go/google/compute/beta/forwardingRule.go
+++ b/sdk/go/google/compute/beta/forwardingRule.go
@@ -15,33 +15,6 @@ import (
 type ForwardingRule struct {
 	pulumi.CustomResourceState
 
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringOutput `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringOutput `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -58,6 +31,33 @@ type ForwardingRule struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringOutput `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringOutput `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringOutput `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringOutput `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -191,33 +191,6 @@ func GetForwardingRule(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering ForwardingRule resources.
 type forwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -234,6 +207,33 @@ type forwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint *string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress *string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -333,33 +333,6 @@ type forwardingRuleState struct {
 }
 
 type ForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringPtrInput
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -376,6 +349,33 @@ type ForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringPtrInput
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringPtrInput
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringPtrInput
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringPtrInput
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -479,6 +479,16 @@ func (ForwardingRuleState) ElementType() reflect.Type {
 }
 
 type forwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts *bool `pulumi:"allPorts"`
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService *string `pulumi:"backendService"`
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description *string `pulumi:"description"`
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -494,7 +504,7 @@ type forwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
+	IpAddress *string `pulumi:"ipAddress"`
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -505,17 +515,7 @@ type forwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts *bool `pulumi:"allPorts"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService *string `pulumi:"backendService"`
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description *string `pulumi:"description"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -603,6 +603,16 @@ type forwardingRuleArgs struct {
 
 // The set of arguments for constructing a ForwardingRule resource.
 type ForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts pulumi.BoolPtrInput
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess pulumi.BoolPtrInput
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService pulumi.StringPtrInput
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description pulumi.StringPtrInput
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -618,7 +628,7 @@ type ForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
+	IpAddress pulumi.StringPtrInput
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -629,17 +639,7 @@ type ForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *ForwardingRuleIPProtocol
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts pulumi.BoolPtrInput
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess pulumi.BoolPtrInput
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService pulumi.StringPtrInput
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description pulumi.StringPtrInput
+	IpProtocol *ForwardingRuleIpProtocol
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *ForwardingRuleIpVersion
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/beta/getForwardingRule.go
+++ b/sdk/go/google/compute/beta/getForwardingRule.go
@@ -24,33 +24,6 @@ type LookupForwardingRuleArgs struct {
 }
 
 type LookupForwardingRuleResult struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -67,6 +40,33 @@ type LookupForwardingRuleResult struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/beta/getGlobalForwardingRule.go
+++ b/sdk/go/google/compute/beta/getGlobalForwardingRule.go
@@ -23,33 +23,6 @@ type LookupGlobalForwardingRuleArgs struct {
 }
 
 type LookupGlobalForwardingRuleResult struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -66,6 +39,33 @@ type LookupGlobalForwardingRuleResult struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/beta/globalForwardingRule.go
+++ b/sdk/go/google/compute/beta/globalForwardingRule.go
@@ -15,33 +15,6 @@ import (
 type GlobalForwardingRule struct {
 	pulumi.CustomResourceState
 
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringOutput `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringOutput `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -58,6 +31,33 @@ type GlobalForwardingRule struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringOutput `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringOutput `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringOutput `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringOutput `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -188,33 +188,6 @@ func GetGlobalForwardingRule(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering GlobalForwardingRule resources.
 type globalForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -231,6 +204,33 @@ type globalForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint *string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress *string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -330,33 +330,6 @@ type globalForwardingRuleState struct {
 }
 
 type GlobalForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringPtrInput
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -373,6 +346,33 @@ type GlobalForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringPtrInput
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringPtrInput
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringPtrInput
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringPtrInput
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -476,6 +476,16 @@ func (GlobalForwardingRuleState) ElementType() reflect.Type {
 }
 
 type globalForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts *bool `pulumi:"allPorts"`
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService *string `pulumi:"backendService"`
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description *string `pulumi:"description"`
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -491,7 +501,7 @@ type globalForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
+	IpAddress *string `pulumi:"ipAddress"`
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -502,17 +512,7 @@ type globalForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts *bool `pulumi:"allPorts"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService *string `pulumi:"backendService"`
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description *string `pulumi:"description"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -599,6 +599,16 @@ type globalForwardingRuleArgs struct {
 
 // The set of arguments for constructing a GlobalForwardingRule resource.
 type GlobalForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts pulumi.BoolPtrInput
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess pulumi.BoolPtrInput
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService pulumi.StringPtrInput
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description pulumi.StringPtrInput
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -614,7 +624,7 @@ type GlobalForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
+	IpAddress pulumi.StringPtrInput
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -625,17 +635,7 @@ type GlobalForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *GlobalForwardingRuleIPProtocol
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts pulumi.BoolPtrInput
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess pulumi.BoolPtrInput
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService pulumi.StringPtrInput
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description pulumi.StringPtrInput
+	IpProtocol *GlobalForwardingRuleIpProtocol
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *GlobalForwardingRuleIpVersion
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/beta/pulumiEnums.go
+++ b/sdk/go/google/compute/beta/pulumiEnums.go
@@ -1188,34 +1188,34 @@ func (e FirewallPolicyRuleDirection) ToStringPtrOutputWithContext(ctx context.Co
 // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-type ForwardingRuleIPProtocol pulumi.String
+type ForwardingRuleIpProtocol pulumi.String
 
 const (
-	ForwardingRuleIPProtocolAh   = ForwardingRuleIPProtocol("AH")
-	ForwardingRuleIPProtocolEsp  = ForwardingRuleIPProtocol("ESP")
-	ForwardingRuleIPProtocolIcmp = ForwardingRuleIPProtocol("ICMP")
-	ForwardingRuleIPProtocolSctp = ForwardingRuleIPProtocol("SCTP")
-	ForwardingRuleIPProtocolTcp  = ForwardingRuleIPProtocol("TCP")
-	ForwardingRuleIPProtocolUdp  = ForwardingRuleIPProtocol("UDP")
+	ForwardingRuleIpProtocolAh   = ForwardingRuleIpProtocol("AH")
+	ForwardingRuleIpProtocolEsp  = ForwardingRuleIpProtocol("ESP")
+	ForwardingRuleIpProtocolIcmp = ForwardingRuleIpProtocol("ICMP")
+	ForwardingRuleIpProtocolSctp = ForwardingRuleIpProtocol("SCTP")
+	ForwardingRuleIpProtocolTcp  = ForwardingRuleIpProtocol("TCP")
+	ForwardingRuleIpProtocolUdp  = ForwardingRuleIpProtocol("UDP")
 )
 
-func (ForwardingRuleIPProtocol) ElementType() reflect.Type {
+func (ForwardingRuleIpProtocol) ElementType() reflect.Type {
 	return reflect.TypeOf((*pulumi.String)(nil)).Elem()
 }
 
-func (e ForwardingRuleIPProtocol) ToStringOutput() pulumi.StringOutput {
+func (e ForwardingRuleIpProtocol) ToStringOutput() pulumi.StringOutput {
 	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e ForwardingRuleIPProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+func (e ForwardingRuleIpProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
 	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e ForwardingRuleIPProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
+func (e ForwardingRuleIpProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
 }
 
-func (e ForwardingRuleIPProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+func (e ForwardingRuleIpProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
 }
 
@@ -1495,34 +1495,34 @@ func (e GlobalAddressPurpose) ToStringPtrOutputWithContext(ctx context.Context) 
 // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-type GlobalForwardingRuleIPProtocol pulumi.String
+type GlobalForwardingRuleIpProtocol pulumi.String
 
 const (
-	GlobalForwardingRuleIPProtocolAh   = GlobalForwardingRuleIPProtocol("AH")
-	GlobalForwardingRuleIPProtocolEsp  = GlobalForwardingRuleIPProtocol("ESP")
-	GlobalForwardingRuleIPProtocolIcmp = GlobalForwardingRuleIPProtocol("ICMP")
-	GlobalForwardingRuleIPProtocolSctp = GlobalForwardingRuleIPProtocol("SCTP")
-	GlobalForwardingRuleIPProtocolTcp  = GlobalForwardingRuleIPProtocol("TCP")
-	GlobalForwardingRuleIPProtocolUdp  = GlobalForwardingRuleIPProtocol("UDP")
+	GlobalForwardingRuleIpProtocolAh   = GlobalForwardingRuleIpProtocol("AH")
+	GlobalForwardingRuleIpProtocolEsp  = GlobalForwardingRuleIpProtocol("ESP")
+	GlobalForwardingRuleIpProtocolIcmp = GlobalForwardingRuleIpProtocol("ICMP")
+	GlobalForwardingRuleIpProtocolSctp = GlobalForwardingRuleIpProtocol("SCTP")
+	GlobalForwardingRuleIpProtocolTcp  = GlobalForwardingRuleIpProtocol("TCP")
+	GlobalForwardingRuleIpProtocolUdp  = GlobalForwardingRuleIpProtocol("UDP")
 )
 
-func (GlobalForwardingRuleIPProtocol) ElementType() reflect.Type {
+func (GlobalForwardingRuleIpProtocol) ElementType() reflect.Type {
 	return reflect.TypeOf((*pulumi.String)(nil)).Elem()
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringOutput() pulumi.StringOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringOutput() pulumi.StringOutput {
 	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
 	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
 }
 

--- a/sdk/go/google/compute/beta/pulumiTypes.go
+++ b/sdk/go/google/compute/beta/pulumiTypes.go
@@ -17299,7 +17299,7 @@ func (o FileContentBufferResponseArrayOutput) Index(i pulumi.IntInput) FileConte
 
 type FirewallAllowedItem struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol *string `pulumi:"IPProtocol"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17319,7 +17319,7 @@ type FirewallAllowedItemInput interface {
 
 type FirewallAllowedItemArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringPtrInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringPtrInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17378,8 +17378,8 @@ func (o FirewallAllowedItemOutput) ToFirewallAllowedItemOutputWithContext(ctx co
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallAllowedItemOutput) IPProtocol() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FirewallAllowedItem) *string { return v.IPProtocol }).(pulumi.StringPtrOutput)
+func (o FirewallAllowedItemOutput) IpProtocol() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FirewallAllowedItem) *string { return v.IpProtocol }).(pulumi.StringPtrOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -17411,7 +17411,7 @@ func (o FirewallAllowedItemArrayOutput) Index(i pulumi.IntInput) FirewallAllowed
 
 type FirewallAllowedItemResponse struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol string `pulumi:"IPProtocol"`
+	IpProtocol string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17431,7 +17431,7 @@ type FirewallAllowedItemResponseInput interface {
 
 type FirewallAllowedItemResponseArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17490,8 +17490,8 @@ func (o FirewallAllowedItemResponseOutput) ToFirewallAllowedItemResponseOutputWi
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallAllowedItemResponseOutput) IPProtocol() pulumi.StringOutput {
-	return o.ApplyT(func(v FirewallAllowedItemResponse) string { return v.IPProtocol }).(pulumi.StringOutput)
+func (o FirewallAllowedItemResponseOutput) IpProtocol() pulumi.StringOutput {
+	return o.ApplyT(func(v FirewallAllowedItemResponse) string { return v.IpProtocol }).(pulumi.StringOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -17523,7 +17523,7 @@ func (o FirewallAllowedItemResponseArrayOutput) Index(i pulumi.IntInput) Firewal
 
 type FirewallDeniedItem struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol *string `pulumi:"IPProtocol"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17543,7 +17543,7 @@ type FirewallDeniedItemInput interface {
 
 type FirewallDeniedItemArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringPtrInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringPtrInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17602,8 +17602,8 @@ func (o FirewallDeniedItemOutput) ToFirewallDeniedItemOutputWithContext(ctx cont
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallDeniedItemOutput) IPProtocol() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FirewallDeniedItem) *string { return v.IPProtocol }).(pulumi.StringPtrOutput)
+func (o FirewallDeniedItemOutput) IpProtocol() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FirewallDeniedItem) *string { return v.IpProtocol }).(pulumi.StringPtrOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -17635,7 +17635,7 @@ func (o FirewallDeniedItemArrayOutput) Index(i pulumi.IntInput) FirewallDeniedIt
 
 type FirewallDeniedItemResponse struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol string `pulumi:"IPProtocol"`
+	IpProtocol string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17655,7 +17655,7 @@ type FirewallDeniedItemResponseInput interface {
 
 type FirewallDeniedItemResponseArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -17714,8 +17714,8 @@ func (o FirewallDeniedItemResponseOutput) ToFirewallDeniedItemResponseOutputWith
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallDeniedItemResponseOutput) IPProtocol() pulumi.StringOutput {
-	return o.ApplyT(func(v FirewallDeniedItemResponse) string { return v.IPProtocol }).(pulumi.StringOutput)
+func (o FirewallDeniedItemResponseOutput) IpProtocol() pulumi.StringOutput {
+	return o.ApplyT(func(v FirewallDeniedItemResponse) string { return v.IpProtocol }).(pulumi.StringOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -39705,12 +39705,12 @@ func (o OutlierDetectionResponsePtrOutput) SuccessRateStdevFactor() pulumi.IntPt
 }
 
 type PacketMirroringFilter struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols []string `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges []string `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction *string `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols []string `pulumi:"ipProtocols"`
 }
 
 // PacketMirroringFilterInput is an input type that accepts PacketMirroringFilterArgs and PacketMirroringFilterOutput values.
@@ -39725,12 +39725,12 @@ type PacketMirroringFilterInput interface {
 }
 
 type PacketMirroringFilterArgs struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols pulumi.StringArrayInput `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges pulumi.StringArrayInput `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction *PacketMirroringFilterDirection `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols pulumi.StringArrayInput `pulumi:"ipProtocols"`
 }
 
 func (PacketMirroringFilterArgs) ElementType() reflect.Type {
@@ -39810,11 +39810,6 @@ func (o PacketMirroringFilterOutput) ToPacketMirroringFilterPtrOutputWithContext
 	}).(PacketMirroringFilterPtrOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.IPProtocols }).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.CidrRanges }).(pulumi.StringArrayOutput)
@@ -39823,6 +39818,11 @@ func (o PacketMirroringFilterOutput) CidrRanges() pulumi.StringArrayOutput {
 // Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 func (o PacketMirroringFilterOutput) Direction() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v PacketMirroringFilter) *string { return v.Direction }).(pulumi.StringPtrOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.IpProtocols }).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringFilterPtrOutput struct{ *pulumi.OutputState }
@@ -39841,16 +39841,6 @@ func (o PacketMirroringFilterPtrOutput) ToPacketMirroringFilterPtrOutputWithCont
 
 func (o PacketMirroringFilterPtrOutput) Elem() PacketMirroringFilterOutput {
 	return o.ApplyT(func(v *PacketMirroringFilter) PacketMirroringFilter { return *v }).(PacketMirroringFilterOutput)
-}
-
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterPtrOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *PacketMirroringFilter) []string {
-		if v == nil {
-			return nil
-		}
-		return v.IPProtocols
-	}).(pulumi.StringArrayOutput)
 }
 
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
@@ -39873,13 +39863,23 @@ func (o PacketMirroringFilterPtrOutput) Direction() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterPtrOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *PacketMirroringFilter) []string {
+		if v == nil {
+			return nil
+		}
+		return v.IpProtocols
+	}).(pulumi.StringArrayOutput)
+}
+
 type PacketMirroringFilterResponse struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols []string `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges []string `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction string `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols []string `pulumi:"ipProtocols"`
 }
 
 // PacketMirroringFilterResponseInput is an input type that accepts PacketMirroringFilterResponseArgs and PacketMirroringFilterResponseOutput values.
@@ -39894,12 +39894,12 @@ type PacketMirroringFilterResponseInput interface {
 }
 
 type PacketMirroringFilterResponseArgs struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols pulumi.StringArrayInput `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges pulumi.StringArrayInput `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction pulumi.StringInput `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols pulumi.StringArrayInput `pulumi:"ipProtocols"`
 }
 
 func (PacketMirroringFilterResponseArgs) ElementType() reflect.Type {
@@ -39979,11 +39979,6 @@ func (o PacketMirroringFilterResponseOutput) ToPacketMirroringFilterResponsePtrO
 	}).(PacketMirroringFilterResponsePtrOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterResponseOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.IPProtocols }).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterResponseOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.CidrRanges }).(pulumi.StringArrayOutput)
@@ -39992,6 +39987,11 @@ func (o PacketMirroringFilterResponseOutput) CidrRanges() pulumi.StringArrayOutp
 // Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 func (o PacketMirroringFilterResponseOutput) Direction() pulumi.StringOutput {
 	return o.ApplyT(func(v PacketMirroringFilterResponse) string { return v.Direction }).(pulumi.StringOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterResponseOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.IpProtocols }).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringFilterResponsePtrOutput struct{ *pulumi.OutputState }
@@ -40012,16 +40012,6 @@ func (o PacketMirroringFilterResponsePtrOutput) Elem() PacketMirroringFilterResp
 	return o.ApplyT(func(v *PacketMirroringFilterResponse) PacketMirroringFilterResponse { return *v }).(PacketMirroringFilterResponseOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterResponsePtrOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
-		if v == nil {
-			return nil
-		}
-		return v.IPProtocols
-	}).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterResponsePtrOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
@@ -40040,6 +40030,16 @@ func (o PacketMirroringFilterResponsePtrOutput) Direction() pulumi.StringPtrOutp
 		}
 		return &v.Direction
 	}).(pulumi.StringPtrOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterResponsePtrOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
+		if v == nil {
+			return nil
+		}
+		return v.IpProtocols
+	}).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringForwardingRuleInfo struct {

--- a/sdk/go/google/compute/v1/forwardingRule.go
+++ b/sdk/go/google/compute/v1/forwardingRule.go
@@ -15,33 +15,6 @@ import (
 type ForwardingRule struct {
 	pulumi.CustomResourceState
 
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringOutput `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringOutput `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -58,6 +31,33 @@ type ForwardingRule struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringOutput `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringOutput `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringOutput `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringOutput `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -191,33 +191,6 @@ func GetForwardingRule(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering ForwardingRule resources.
 type forwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -234,6 +207,33 @@ type forwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint *string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress *string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -333,33 +333,6 @@ type forwardingRuleState struct {
 }
 
 type ForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringPtrInput
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -376,6 +349,33 @@ type ForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringPtrInput
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringPtrInput
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringPtrInput
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringPtrInput
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -479,6 +479,16 @@ func (ForwardingRuleState) ElementType() reflect.Type {
 }
 
 type forwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts *bool `pulumi:"allPorts"`
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService *string `pulumi:"backendService"`
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description *string `pulumi:"description"`
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -494,7 +504,7 @@ type forwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
+	IpAddress *string `pulumi:"ipAddress"`
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -505,17 +515,7 @@ type forwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts *bool `pulumi:"allPorts"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService *string `pulumi:"backendService"`
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description *string `pulumi:"description"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -603,6 +603,16 @@ type forwardingRuleArgs struct {
 
 // The set of arguments for constructing a ForwardingRule resource.
 type ForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts pulumi.BoolPtrInput
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess pulumi.BoolPtrInput
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService pulumi.StringPtrInput
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description pulumi.StringPtrInput
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -618,7 +628,7 @@ type ForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
+	IpAddress pulumi.StringPtrInput
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -629,17 +639,7 @@ type ForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *ForwardingRuleIPProtocol
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts pulumi.BoolPtrInput
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess pulumi.BoolPtrInput
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService pulumi.StringPtrInput
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description pulumi.StringPtrInput
+	IpProtocol *ForwardingRuleIpProtocol
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *ForwardingRuleIpVersion
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/v1/getForwardingRule.go
+++ b/sdk/go/google/compute/v1/getForwardingRule.go
@@ -24,33 +24,6 @@ type LookupForwardingRuleArgs struct {
 }
 
 type LookupForwardingRuleResult struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -67,6 +40,33 @@ type LookupForwardingRuleResult struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/v1/getGlobalForwardingRule.go
+++ b/sdk/go/google/compute/v1/getGlobalForwardingRule.go
@@ -23,33 +23,6 @@ type LookupGlobalForwardingRuleArgs struct {
 }
 
 type LookupGlobalForwardingRuleResult struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -66,6 +39,33 @@ type LookupGlobalForwardingRuleResult struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/v1/globalForwardingRule.go
+++ b/sdk/go/google/compute/v1/globalForwardingRule.go
@@ -15,33 +15,6 @@ import (
 type GlobalForwardingRule struct {
 	pulumi.CustomResourceState
 
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringOutput `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringOutput `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -58,6 +31,33 @@ type GlobalForwardingRule struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringOutput `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringOutput `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringOutput `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringOutput `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -188,33 +188,6 @@ func GetGlobalForwardingRule(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering GlobalForwardingRule resources.
 type globalForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -231,6 +204,33 @@ type globalForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint *string `pulumi:"fingerprint"`
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress *string `pulumi:"ipAddress"`
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -330,33 +330,6 @@ type globalForwardingRuleState struct {
 }
 
 type GlobalForwardingRuleState struct {
-	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-	//
-	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-	//
-	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
-	// - projects/project_id/regions/region/addresses/address-name
-	// - regions/region/addresses/address-name
-	// - global/addresses/address-name
-	// - address-name
-	//
-	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-	//
-	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-	//
-	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
-	// The IP protocol to which this rule applies.
-	//
-	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-	//
-	// The valid IP protocols are different for different load balancing products:
-	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
-	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
-	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
-	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
-	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol pulumi.StringPtrInput
 	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
 	//
 	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -373,6 +346,33 @@ type GlobalForwardingRuleState struct {
 	//
 	// To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
 	Fingerprint pulumi.StringPtrInput
+	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+	//
+	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+	//
+	// * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:
+	// - projects/project_id/regions/region/addresses/address-name
+	// - regions/region/addresses/address-name
+	// - global/addresses/address-name
+	// - address-name
+	//
+	// The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+	//
+	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+	//
+	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+	IpAddress pulumi.StringPtrInput
+	// The IP protocol to which this rule applies.
+	//
+	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+	//
+	// The valid IP protocols are different for different load balancing products:
+	// - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid.
+	// - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.
+	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
+	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
+	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+	IpProtocol pulumi.StringPtrInput
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion pulumi.StringPtrInput
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -476,6 +476,16 @@ func (GlobalForwardingRuleState) ElementType() reflect.Type {
 }
 
 type globalForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts *bool `pulumi:"allPorts"`
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService *string `pulumi:"backendService"`
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description *string `pulumi:"description"`
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -491,7 +501,7 @@ type globalForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress *string `pulumi:"IPAddress"`
+	IpAddress *string `pulumi:"ipAddress"`
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -502,17 +512,7 @@ type globalForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *string `pulumi:"IPProtocol"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts *bool `pulumi:"allPorts"`
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess *bool `pulumi:"allowGlobalAccess"`
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService *string `pulumi:"backendService"`
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description *string `pulumi:"description"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *string `pulumi:"ipVersion"`
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
@@ -599,6 +599,16 @@ type globalForwardingRuleArgs struct {
 
 // The set of arguments for constructing a GlobalForwardingRule resource.
 type GlobalForwardingRuleArgs struct {
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+	//
+	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+	AllPorts pulumi.BoolPtrInput
+	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+	AllowGlobalAccess pulumi.BoolPtrInput
+	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+	BackendService pulumi.StringPtrInput
+	// An optional description of this resource. Provide this property when you create the resource.
+	Description pulumi.StringPtrInput
 	// IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
 	//
 	// If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -614,7 +624,7 @@ type GlobalForwardingRuleArgs struct {
 	// Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
 	//
 	// For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-	IPAddress pulumi.StringPtrInput
+	IpAddress pulumi.StringPtrInput
 	// The IP protocol to which this rule applies.
 	//
 	// For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
@@ -625,17 +635,7 @@ type GlobalForwardingRuleArgs struct {
 	// - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 	// - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 	// - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-	IPProtocol *GlobalForwardingRuleIPProtocol
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-	//
-	// When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-	AllPorts pulumi.BoolPtrInput
-	// This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-	AllowGlobalAccess pulumi.BoolPtrInput
-	// Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-	BackendService pulumi.StringPtrInput
-	// An optional description of this resource. Provide this property when you create the resource.
-	Description pulumi.StringPtrInput
+	IpProtocol *GlobalForwardingRuleIpProtocol
 	// The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
 	IpVersion *GlobalForwardingRuleIpVersion
 	// Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.

--- a/sdk/go/google/compute/v1/pulumiEnums.go
+++ b/sdk/go/google/compute/v1/pulumiEnums.go
@@ -1090,34 +1090,34 @@ func (e FirewallPolicyRuleDirection) ToStringPtrOutputWithContext(ctx context.Co
 // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-type ForwardingRuleIPProtocol pulumi.String
+type ForwardingRuleIpProtocol pulumi.String
 
 const (
-	ForwardingRuleIPProtocolAh   = ForwardingRuleIPProtocol("AH")
-	ForwardingRuleIPProtocolEsp  = ForwardingRuleIPProtocol("ESP")
-	ForwardingRuleIPProtocolIcmp = ForwardingRuleIPProtocol("ICMP")
-	ForwardingRuleIPProtocolSctp = ForwardingRuleIPProtocol("SCTP")
-	ForwardingRuleIPProtocolTcp  = ForwardingRuleIPProtocol("TCP")
-	ForwardingRuleIPProtocolUdp  = ForwardingRuleIPProtocol("UDP")
+	ForwardingRuleIpProtocolAh   = ForwardingRuleIpProtocol("AH")
+	ForwardingRuleIpProtocolEsp  = ForwardingRuleIpProtocol("ESP")
+	ForwardingRuleIpProtocolIcmp = ForwardingRuleIpProtocol("ICMP")
+	ForwardingRuleIpProtocolSctp = ForwardingRuleIpProtocol("SCTP")
+	ForwardingRuleIpProtocolTcp  = ForwardingRuleIpProtocol("TCP")
+	ForwardingRuleIpProtocolUdp  = ForwardingRuleIpProtocol("UDP")
 )
 
-func (ForwardingRuleIPProtocol) ElementType() reflect.Type {
+func (ForwardingRuleIpProtocol) ElementType() reflect.Type {
 	return reflect.TypeOf((*pulumi.String)(nil)).Elem()
 }
 
-func (e ForwardingRuleIPProtocol) ToStringOutput() pulumi.StringOutput {
+func (e ForwardingRuleIpProtocol) ToStringOutput() pulumi.StringOutput {
 	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e ForwardingRuleIPProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+func (e ForwardingRuleIpProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
 	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e ForwardingRuleIPProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
+func (e ForwardingRuleIpProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
 }
 
-func (e ForwardingRuleIPProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+func (e ForwardingRuleIpProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
 }
 
@@ -1397,34 +1397,34 @@ func (e GlobalAddressPurpose) ToStringPtrOutputWithContext(ctx context.Context) 
 // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
 // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
 // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-type GlobalForwardingRuleIPProtocol pulumi.String
+type GlobalForwardingRuleIpProtocol pulumi.String
 
 const (
-	GlobalForwardingRuleIPProtocolAh   = GlobalForwardingRuleIPProtocol("AH")
-	GlobalForwardingRuleIPProtocolEsp  = GlobalForwardingRuleIPProtocol("ESP")
-	GlobalForwardingRuleIPProtocolIcmp = GlobalForwardingRuleIPProtocol("ICMP")
-	GlobalForwardingRuleIPProtocolSctp = GlobalForwardingRuleIPProtocol("SCTP")
-	GlobalForwardingRuleIPProtocolTcp  = GlobalForwardingRuleIPProtocol("TCP")
-	GlobalForwardingRuleIPProtocolUdp  = GlobalForwardingRuleIPProtocol("UDP")
+	GlobalForwardingRuleIpProtocolAh   = GlobalForwardingRuleIpProtocol("AH")
+	GlobalForwardingRuleIpProtocolEsp  = GlobalForwardingRuleIpProtocol("ESP")
+	GlobalForwardingRuleIpProtocolIcmp = GlobalForwardingRuleIpProtocol("ICMP")
+	GlobalForwardingRuleIpProtocolSctp = GlobalForwardingRuleIpProtocol("SCTP")
+	GlobalForwardingRuleIpProtocolTcp  = GlobalForwardingRuleIpProtocol("TCP")
+	GlobalForwardingRuleIpProtocolUdp  = GlobalForwardingRuleIpProtocol("UDP")
 )
 
-func (GlobalForwardingRuleIPProtocol) ElementType() reflect.Type {
+func (GlobalForwardingRuleIpProtocol) ElementType() reflect.Type {
 	return reflect.TypeOf((*pulumi.String)(nil)).Elem()
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringOutput() pulumi.StringOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringOutput() pulumi.StringOutput {
 	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
 	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringPtrOutput() pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
 }
 
-func (e GlobalForwardingRuleIPProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+func (e GlobalForwardingRuleIpProtocol) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
 }
 

--- a/sdk/go/google/compute/v1/pulumiTypes.go
+++ b/sdk/go/google/compute/v1/pulumiTypes.go
@@ -16295,7 +16295,7 @@ func (o FileContentBufferResponseArrayOutput) Index(i pulumi.IntInput) FileConte
 
 type FirewallAllowedItem struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol *string `pulumi:"IPProtocol"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16315,7 +16315,7 @@ type FirewallAllowedItemInput interface {
 
 type FirewallAllowedItemArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringPtrInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringPtrInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16374,8 +16374,8 @@ func (o FirewallAllowedItemOutput) ToFirewallAllowedItemOutputWithContext(ctx co
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallAllowedItemOutput) IPProtocol() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FirewallAllowedItem) *string { return v.IPProtocol }).(pulumi.StringPtrOutput)
+func (o FirewallAllowedItemOutput) IpProtocol() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FirewallAllowedItem) *string { return v.IpProtocol }).(pulumi.StringPtrOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -16407,7 +16407,7 @@ func (o FirewallAllowedItemArrayOutput) Index(i pulumi.IntInput) FirewallAllowed
 
 type FirewallAllowedItemResponse struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol string `pulumi:"IPProtocol"`
+	IpProtocol string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16427,7 +16427,7 @@ type FirewallAllowedItemResponseInput interface {
 
 type FirewallAllowedItemResponseArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16486,8 +16486,8 @@ func (o FirewallAllowedItemResponseOutput) ToFirewallAllowedItemResponseOutputWi
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallAllowedItemResponseOutput) IPProtocol() pulumi.StringOutput {
-	return o.ApplyT(func(v FirewallAllowedItemResponse) string { return v.IPProtocol }).(pulumi.StringOutput)
+func (o FirewallAllowedItemResponseOutput) IpProtocol() pulumi.StringOutput {
+	return o.ApplyT(func(v FirewallAllowedItemResponse) string { return v.IpProtocol }).(pulumi.StringOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -16519,7 +16519,7 @@ func (o FirewallAllowedItemResponseArrayOutput) Index(i pulumi.IntInput) Firewal
 
 type FirewallDeniedItem struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol *string `pulumi:"IPProtocol"`
+	IpProtocol *string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16539,7 +16539,7 @@ type FirewallDeniedItemInput interface {
 
 type FirewallDeniedItemArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringPtrInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringPtrInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16598,8 +16598,8 @@ func (o FirewallDeniedItemOutput) ToFirewallDeniedItemOutputWithContext(ctx cont
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallDeniedItemOutput) IPProtocol() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v FirewallDeniedItem) *string { return v.IPProtocol }).(pulumi.StringPtrOutput)
+func (o FirewallDeniedItemOutput) IpProtocol() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FirewallDeniedItem) *string { return v.IpProtocol }).(pulumi.StringPtrOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -16631,7 +16631,7 @@ func (o FirewallDeniedItemArrayOutput) Index(i pulumi.IntInput) FirewallDeniedIt
 
 type FirewallDeniedItemResponse struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol string `pulumi:"IPProtocol"`
+	IpProtocol string `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16651,7 +16651,7 @@ type FirewallDeniedItemResponseInput interface {
 
 type FirewallDeniedItemResponseArgs struct {
 	// The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-	IPProtocol pulumi.StringInput `pulumi:"IPProtocol"`
+	IpProtocol pulumi.StringInput `pulumi:"ipProtocol"`
 	// An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
 	//
 	// Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
@@ -16710,8 +16710,8 @@ func (o FirewallDeniedItemResponseOutput) ToFirewallDeniedItemResponseOutputWith
 }
 
 // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-func (o FirewallDeniedItemResponseOutput) IPProtocol() pulumi.StringOutput {
-	return o.ApplyT(func(v FirewallDeniedItemResponse) string { return v.IPProtocol }).(pulumi.StringOutput)
+func (o FirewallDeniedItemResponseOutput) IpProtocol() pulumi.StringOutput {
+	return o.ApplyT(func(v FirewallDeniedItemResponse) string { return v.IpProtocol }).(pulumi.StringOutput)
 }
 
 // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
@@ -37977,12 +37977,12 @@ func (o OutlierDetectionResponsePtrOutput) SuccessRateStdevFactor() pulumi.IntPt
 }
 
 type PacketMirroringFilter struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols []string `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges []string `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction *string `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols []string `pulumi:"ipProtocols"`
 }
 
 // PacketMirroringFilterInput is an input type that accepts PacketMirroringFilterArgs and PacketMirroringFilterOutput values.
@@ -37997,12 +37997,12 @@ type PacketMirroringFilterInput interface {
 }
 
 type PacketMirroringFilterArgs struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols pulumi.StringArrayInput `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges pulumi.StringArrayInput `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction *PacketMirroringFilterDirection `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols pulumi.StringArrayInput `pulumi:"ipProtocols"`
 }
 
 func (PacketMirroringFilterArgs) ElementType() reflect.Type {
@@ -38082,11 +38082,6 @@ func (o PacketMirroringFilterOutput) ToPacketMirroringFilterPtrOutputWithContext
 	}).(PacketMirroringFilterPtrOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.IPProtocols }).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.CidrRanges }).(pulumi.StringArrayOutput)
@@ -38095,6 +38090,11 @@ func (o PacketMirroringFilterOutput) CidrRanges() pulumi.StringArrayOutput {
 // Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 func (o PacketMirroringFilterOutput) Direction() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v PacketMirroringFilter) *string { return v.Direction }).(pulumi.StringPtrOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v PacketMirroringFilter) []string { return v.IpProtocols }).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringFilterPtrOutput struct{ *pulumi.OutputState }
@@ -38113,16 +38113,6 @@ func (o PacketMirroringFilterPtrOutput) ToPacketMirroringFilterPtrOutputWithCont
 
 func (o PacketMirroringFilterPtrOutput) Elem() PacketMirroringFilterOutput {
 	return o.ApplyT(func(v *PacketMirroringFilter) PacketMirroringFilter { return *v }).(PacketMirroringFilterOutput)
-}
-
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterPtrOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *PacketMirroringFilter) []string {
-		if v == nil {
-			return nil
-		}
-		return v.IPProtocols
-	}).(pulumi.StringArrayOutput)
 }
 
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
@@ -38145,13 +38135,23 @@ func (o PacketMirroringFilterPtrOutput) Direction() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterPtrOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *PacketMirroringFilter) []string {
+		if v == nil {
+			return nil
+		}
+		return v.IpProtocols
+	}).(pulumi.StringArrayOutput)
+}
+
 type PacketMirroringFilterResponse struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols []string `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges []string `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction string `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols []string `pulumi:"ipProtocols"`
 }
 
 // PacketMirroringFilterResponseInput is an input type that accepts PacketMirroringFilterResponseArgs and PacketMirroringFilterResponseOutput values.
@@ -38166,12 +38166,12 @@ type PacketMirroringFilterResponseInput interface {
 }
 
 type PacketMirroringFilterResponseArgs struct {
-	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-	IPProtocols pulumi.StringArrayInput `pulumi:"IPProtocols"`
 	// IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 	CidrRanges pulumi.StringArrayInput `pulumi:"cidrRanges"`
 	// Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 	Direction pulumi.StringInput `pulumi:"direction"`
+	// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+	IpProtocols pulumi.StringArrayInput `pulumi:"ipProtocols"`
 }
 
 func (PacketMirroringFilterResponseArgs) ElementType() reflect.Type {
@@ -38251,11 +38251,6 @@ func (o PacketMirroringFilterResponseOutput) ToPacketMirroringFilterResponsePtrO
 	}).(PacketMirroringFilterResponsePtrOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterResponseOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.IPProtocols }).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterResponseOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.CidrRanges }).(pulumi.StringArrayOutput)
@@ -38264,6 +38259,11 @@ func (o PacketMirroringFilterResponseOutput) CidrRanges() pulumi.StringArrayOutp
 // Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
 func (o PacketMirroringFilterResponseOutput) Direction() pulumi.StringOutput {
 	return o.ApplyT(func(v PacketMirroringFilterResponse) string { return v.Direction }).(pulumi.StringOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterResponseOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v PacketMirroringFilterResponse) []string { return v.IpProtocols }).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringFilterResponsePtrOutput struct{ *pulumi.OutputState }
@@ -38284,16 +38284,6 @@ func (o PacketMirroringFilterResponsePtrOutput) Elem() PacketMirroringFilterResp
 	return o.ApplyT(func(v *PacketMirroringFilterResponse) PacketMirroringFilterResponse { return *v }).(PacketMirroringFilterResponseOutput)
 }
 
-// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-func (o PacketMirroringFilterResponsePtrOutput) IPProtocols() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
-		if v == nil {
-			return nil
-		}
-		return v.IPProtocols
-	}).(pulumi.StringArrayOutput)
-}
-
 // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
 func (o PacketMirroringFilterResponsePtrOutput) CidrRanges() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
@@ -38312,6 +38302,16 @@ func (o PacketMirroringFilterResponsePtrOutput) Direction() pulumi.StringPtrOutp
 		}
 		return &v.Direction
 	}).(pulumi.StringPtrOutput)
+}
+
+// Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+func (o PacketMirroringFilterResponsePtrOutput) IpProtocols() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *PacketMirroringFilterResponse) []string {
+		if v == nil {
+			return nil
+		}
+		return v.IpProtocols
+	}).(pulumi.StringArrayOutput)
 }
 
 type PacketMirroringForwardingRuleInfo struct {

--- a/sdk/go/google/storage/v1/getNotification.go
+++ b/sdk/go/google/storage/v1/getNotification.go
@@ -26,17 +26,17 @@ type LookupNotificationArgs struct {
 
 type LookupNotificationResult struct {
 	// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
-	Custom_attributes map[string]string `pulumi:"custom_attributes"`
+	CustomAttributes map[string]string `pulumi:"customAttributes"`
 	// HTTP 1.1 Entity tag for this subscription notification.
 	Etag string `pulumi:"etag"`
 	// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
-	Event_types []string `pulumi:"event_types"`
+	EventTypes []string `pulumi:"eventTypes"`
 	// The kind of item this is. For notifications, this is always storage#notification.
 	Kind string `pulumi:"kind"`
 	// If present, only apply this notification configuration to object names that begin with this prefix.
-	Object_name_prefix string `pulumi:"object_name_prefix"`
+	ObjectNamePrefix string `pulumi:"objectNamePrefix"`
 	// The desired content of the Payload.
-	Payload_format string `pulumi:"payload_format"`
+	PayloadFormat string `pulumi:"payloadFormat"`
 	// The canonical URL of this notification.
 	SelfLink string `pulumi:"selfLink"`
 	// The Cloud PubSub topic to which this subscription publishes. Formatted as: '//pubsub.googleapis.com/projects/{project-identifier}/topics/{my-topic}'

--- a/sdk/go/google/storage/v1/notification.go
+++ b/sdk/go/google/storage/v1/notification.go
@@ -16,17 +16,17 @@ type Notification struct {
 	pulumi.CustomResourceState
 
 	// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
-	Custom_attributes pulumi.StringMapOutput `pulumi:"custom_attributes"`
+	CustomAttributes pulumi.StringMapOutput `pulumi:"customAttributes"`
 	// HTTP 1.1 Entity tag for this subscription notification.
 	Etag pulumi.StringOutput `pulumi:"etag"`
 	// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
-	Event_types pulumi.StringArrayOutput `pulumi:"event_types"`
+	EventTypes pulumi.StringArrayOutput `pulumi:"eventTypes"`
 	// The kind of item this is. For notifications, this is always storage#notification.
 	Kind pulumi.StringOutput `pulumi:"kind"`
 	// If present, only apply this notification configuration to object names that begin with this prefix.
-	Object_name_prefix pulumi.StringOutput `pulumi:"object_name_prefix"`
+	ObjectNamePrefix pulumi.StringOutput `pulumi:"objectNamePrefix"`
 	// The desired content of the Payload.
-	Payload_format pulumi.StringOutput `pulumi:"payload_format"`
+	PayloadFormat pulumi.StringOutput `pulumi:"payloadFormat"`
 	// The canonical URL of this notification.
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// The Cloud PubSub topic to which this subscription publishes. Formatted as: '//pubsub.googleapis.com/projects/{project-identifier}/topics/{my-topic}'
@@ -66,17 +66,17 @@ func GetNotification(ctx *pulumi.Context,
 // Input properties used for looking up and filtering Notification resources.
 type notificationState struct {
 	// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
-	Custom_attributes map[string]string `pulumi:"custom_attributes"`
+	CustomAttributes map[string]string `pulumi:"customAttributes"`
 	// HTTP 1.1 Entity tag for this subscription notification.
 	Etag *string `pulumi:"etag"`
 	// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
-	Event_types []string `pulumi:"event_types"`
+	EventTypes []string `pulumi:"eventTypes"`
 	// The kind of item this is. For notifications, this is always storage#notification.
 	Kind *string `pulumi:"kind"`
 	// If present, only apply this notification configuration to object names that begin with this prefix.
-	Object_name_prefix *string `pulumi:"object_name_prefix"`
+	ObjectNamePrefix *string `pulumi:"objectNamePrefix"`
 	// The desired content of the Payload.
-	Payload_format *string `pulumi:"payload_format"`
+	PayloadFormat *string `pulumi:"payloadFormat"`
 	// The canonical URL of this notification.
 	SelfLink *string `pulumi:"selfLink"`
 	// The Cloud PubSub topic to which this subscription publishes. Formatted as: '//pubsub.googleapis.com/projects/{project-identifier}/topics/{my-topic}'
@@ -85,17 +85,17 @@ type notificationState struct {
 
 type NotificationState struct {
 	// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
-	Custom_attributes pulumi.StringMapInput
+	CustomAttributes pulumi.StringMapInput
 	// HTTP 1.1 Entity tag for this subscription notification.
 	Etag pulumi.StringPtrInput
 	// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
-	Event_types pulumi.StringArrayInput
+	EventTypes pulumi.StringArrayInput
 	// The kind of item this is. For notifications, this is always storage#notification.
 	Kind pulumi.StringPtrInput
 	// If present, only apply this notification configuration to object names that begin with this prefix.
-	Object_name_prefix pulumi.StringPtrInput
+	ObjectNamePrefix pulumi.StringPtrInput
 	// The desired content of the Payload.
-	Payload_format pulumi.StringPtrInput
+	PayloadFormat pulumi.StringPtrInput
 	// The canonical URL of this notification.
 	SelfLink pulumi.StringPtrInput
 	// The Cloud PubSub topic to which this subscription publishes. Formatted as: '//pubsub.googleapis.com/projects/{project-identifier}/topics/{my-topic}'
@@ -109,19 +109,19 @@ func (NotificationState) ElementType() reflect.Type {
 type notificationArgs struct {
 	Bucket string `pulumi:"bucket"`
 	// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
-	Custom_attributes map[string]string `pulumi:"custom_attributes"`
+	CustomAttributes map[string]string `pulumi:"customAttributes"`
 	// HTTP 1.1 Entity tag for this subscription notification.
 	Etag *string `pulumi:"etag"`
 	// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
-	Event_types []string `pulumi:"event_types"`
+	EventTypes []string `pulumi:"eventTypes"`
 	// The ID of the notification.
 	Id *string `pulumi:"id"`
 	// The kind of item this is. For notifications, this is always storage#notification.
 	Kind *string `pulumi:"kind"`
 	// If present, only apply this notification configuration to object names that begin with this prefix.
-	Object_name_prefix *string `pulumi:"object_name_prefix"`
+	ObjectNamePrefix *string `pulumi:"objectNamePrefix"`
 	// The desired content of the Payload.
-	Payload_format         *string `pulumi:"payload_format"`
+	PayloadFormat          *string `pulumi:"payloadFormat"`
 	ProvisionalUserProject *string `pulumi:"provisionalUserProject"`
 	// The canonical URL of this notification.
 	SelfLink *string `pulumi:"selfLink"`
@@ -134,19 +134,19 @@ type notificationArgs struct {
 type NotificationArgs struct {
 	Bucket pulumi.StringInput
 	// An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
-	Custom_attributes pulumi.StringMapInput
+	CustomAttributes pulumi.StringMapInput
 	// HTTP 1.1 Entity tag for this subscription notification.
 	Etag pulumi.StringPtrInput
 	// If present, only send notifications about listed event types. If empty, sent notifications for all event types.
-	Event_types pulumi.StringArrayInput
+	EventTypes pulumi.StringArrayInput
 	// The ID of the notification.
 	Id pulumi.StringPtrInput
 	// The kind of item this is. For notifications, this is always storage#notification.
 	Kind pulumi.StringPtrInput
 	// If present, only apply this notification configuration to object names that begin with this prefix.
-	Object_name_prefix pulumi.StringPtrInput
+	ObjectNamePrefix pulumi.StringPtrInput
 	// The desired content of the Payload.
-	Payload_format         pulumi.StringPtrInput
+	PayloadFormat          pulumi.StringPtrInput
 	ProvisionalUserProject pulumi.StringPtrInput
 	// The canonical URL of this notification.
 	SelfLink pulumi.StringPtrInput

--- a/sdk/nodejs/bigquery/v2/getJob.ts
+++ b/sdk/nodejs/bigquery/v2/getJob.ts
@@ -61,5 +61,5 @@ export interface GetJobResult {
     /**
      * Email address of the user who ran the job.
      */
-    readonly user_email: string;
+    readonly userEmail: string;
 }

--- a/sdk/nodejs/bigquery/v2/job.ts
+++ b/sdk/nodejs/bigquery/v2/job.ts
@@ -66,7 +66,7 @@ export class Job extends pulumi.CustomResource {
     /**
      * Email address of the user who ran the job.
      */
-    public /*out*/ readonly user_email!: pulumi.Output<string>;
+    public /*out*/ readonly userEmail!: pulumi.Output<string>;
 
     /**
      * Create a Job resource with the given unique name, arguments, and options.
@@ -90,7 +90,7 @@ export class Job extends pulumi.CustomResource {
             inputs["selfLink"] = undefined /*out*/;
             inputs["statistics"] = undefined /*out*/;
             inputs["status"] = undefined /*out*/;
-            inputs["user_email"] = undefined /*out*/;
+            inputs["userEmail"] = undefined /*out*/;
         } else {
             inputs["configuration"] = undefined /*out*/;
             inputs["etag"] = undefined /*out*/;
@@ -99,7 +99,7 @@ export class Job extends pulumi.CustomResource {
             inputs["selfLink"] = undefined /*out*/;
             inputs["statistics"] = undefined /*out*/;
             inputs["status"] = undefined /*out*/;
-            inputs["user_email"] = undefined /*out*/;
+            inputs["userEmail"] = undefined /*out*/;
         }
         if (!opts.version) {
             opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});

--- a/sdk/nodejs/compute/alpha/forwardingRule.ts
+++ b/sdk/nodejs/compute/alpha/forwardingRule.ts
@@ -36,37 +36,6 @@ export class ForwardingRule extends pulumi.CustomResource {
     }
 
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    public readonly IPAddress!: pulumi.Output<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    public readonly IPProtocol!: pulumi.Output<string>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -94,6 +63,37 @@ export class ForwardingRule extends pulumi.CustomResource {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     public /*out*/ readonly fingerprint!: pulumi.Output<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    public readonly ipAddress!: pulumi.Output<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    public readonly ipProtocol!: pulumi.Output<string>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */
@@ -252,12 +252,12 @@ export class ForwardingRule extends pulumi.CustomResource {
             if ((!args || args.region === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'region'");
             }
-            inputs["IPAddress"] = args ? args.IPAddress : undefined;
-            inputs["IPProtocol"] = args ? args.IPProtocol : undefined;
             inputs["allPorts"] = args ? args.allPorts : undefined;
             inputs["allowGlobalAccess"] = args ? args.allowGlobalAccess : undefined;
             inputs["backendService"] = args ? args.backendService : undefined;
             inputs["description"] = args ? args.description : undefined;
+            inputs["ipAddress"] = args ? args.ipAddress : undefined;
+            inputs["ipProtocol"] = args ? args.ipProtocol : undefined;
             inputs["ipVersion"] = args ? args.ipVersion : undefined;
             inputs["isMirroringCollector"] = args ? args.isMirroringCollector : undefined;
             inputs["labels"] = args ? args.labels : undefined;
@@ -285,14 +285,14 @@ export class ForwardingRule extends pulumi.CustomResource {
             inputs["selfLinkWithId"] = undefined /*out*/;
             inputs["serviceName"] = undefined /*out*/;
         } else {
-            inputs["IPAddress"] = undefined /*out*/;
-            inputs["IPProtocol"] = undefined /*out*/;
             inputs["allPorts"] = undefined /*out*/;
             inputs["allowGlobalAccess"] = undefined /*out*/;
             inputs["backendService"] = undefined /*out*/;
             inputs["creationTimestamp"] = undefined /*out*/;
             inputs["description"] = undefined /*out*/;
             inputs["fingerprint"] = undefined /*out*/;
+            inputs["ipAddress"] = undefined /*out*/;
+            inputs["ipProtocol"] = undefined /*out*/;
             inputs["ipVersion"] = undefined /*out*/;
             inputs["isMirroringCollector"] = undefined /*out*/;
             inputs["kind"] = undefined /*out*/;
@@ -328,37 +328,6 @@ export class ForwardingRule extends pulumi.CustomResource {
  */
 export interface ForwardingRuleArgs {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    IPAddress?: pulumi.Input<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    IPProtocol?: pulumi.Input<enums.compute.alpha.ForwardingRuleIPProtocol>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -376,6 +345,37 @@ export interface ForwardingRuleArgs {
      * An optional description of this resource. Provide this property when you create the resource.
      */
     description?: pulumi.Input<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    ipAddress?: pulumi.Input<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    ipProtocol?: pulumi.Input<enums.compute.alpha.ForwardingRuleIpProtocol>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/alpha/getForwardingRule.ts
+++ b/sdk/nodejs/compute/alpha/getForwardingRule.ts
@@ -31,37 +31,6 @@ export interface GetForwardingRuleArgs {
 
 export interface GetForwardingRuleResult {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    readonly IPAddress: string;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    readonly IPProtocol: string;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +58,37 @@ export interface GetForwardingRuleResult {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     readonly fingerprint: string;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    readonly ipAddress: string;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    readonly ipProtocol: string;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/alpha/getGlobalForwardingRule.ts
+++ b/sdk/nodejs/compute/alpha/getGlobalForwardingRule.ts
@@ -29,37 +29,6 @@ export interface GetGlobalForwardingRuleArgs {
 
 export interface GetGlobalForwardingRuleResult {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    readonly IPAddress: string;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    readonly IPProtocol: string;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -87,6 +56,37 @@ export interface GetGlobalForwardingRuleResult {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     readonly fingerprint: string;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    readonly ipAddress: string;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    readonly ipProtocol: string;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/alpha/globalForwardingRule.ts
+++ b/sdk/nodejs/compute/alpha/globalForwardingRule.ts
@@ -36,37 +36,6 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
     }
 
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    public readonly IPAddress!: pulumi.Output<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    public readonly IPProtocol!: pulumi.Output<string>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -94,6 +63,37 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     public /*out*/ readonly fingerprint!: pulumi.Output<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    public readonly ipAddress!: pulumi.Output<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    public readonly ipProtocol!: pulumi.Output<string>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */
@@ -249,12 +249,12 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
             if ((!args || args.project === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'project'");
             }
-            inputs["IPAddress"] = args ? args.IPAddress : undefined;
-            inputs["IPProtocol"] = args ? args.IPProtocol : undefined;
             inputs["allPorts"] = args ? args.allPorts : undefined;
             inputs["allowGlobalAccess"] = args ? args.allowGlobalAccess : undefined;
             inputs["backendService"] = args ? args.backendService : undefined;
             inputs["description"] = args ? args.description : undefined;
+            inputs["ipAddress"] = args ? args.ipAddress : undefined;
+            inputs["ipProtocol"] = args ? args.ipProtocol : undefined;
             inputs["ipVersion"] = args ? args.ipVersion : undefined;
             inputs["isMirroringCollector"] = args ? args.isMirroringCollector : undefined;
             inputs["labels"] = args ? args.labels : undefined;
@@ -282,14 +282,14 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
             inputs["selfLinkWithId"] = undefined /*out*/;
             inputs["serviceName"] = undefined /*out*/;
         } else {
-            inputs["IPAddress"] = undefined /*out*/;
-            inputs["IPProtocol"] = undefined /*out*/;
             inputs["allPorts"] = undefined /*out*/;
             inputs["allowGlobalAccess"] = undefined /*out*/;
             inputs["backendService"] = undefined /*out*/;
             inputs["creationTimestamp"] = undefined /*out*/;
             inputs["description"] = undefined /*out*/;
             inputs["fingerprint"] = undefined /*out*/;
+            inputs["ipAddress"] = undefined /*out*/;
+            inputs["ipProtocol"] = undefined /*out*/;
             inputs["ipVersion"] = undefined /*out*/;
             inputs["isMirroringCollector"] = undefined /*out*/;
             inputs["kind"] = undefined /*out*/;
@@ -325,37 +325,6 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
  */
 export interface GlobalForwardingRuleArgs {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    IPAddress?: pulumi.Input<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    IPProtocol?: pulumi.Input<enums.compute.alpha.GlobalForwardingRuleIPProtocol>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -373,6 +342,37 @@ export interface GlobalForwardingRuleArgs {
      * An optional description of this resource. Provide this property when you create the resource.
      */
     description?: pulumi.Input<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    ipAddress?: pulumi.Input<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    ipProtocol?: pulumi.Input<enums.compute.alpha.GlobalForwardingRuleIpProtocol>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/beta/forwardingRule.ts
+++ b/sdk/nodejs/compute/beta/forwardingRule.ts
@@ -36,37 +36,6 @@ export class ForwardingRule extends pulumi.CustomResource {
     }
 
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    public readonly IPAddress!: pulumi.Output<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    public readonly IPProtocol!: pulumi.Output<string>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -94,6 +63,37 @@ export class ForwardingRule extends pulumi.CustomResource {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     public /*out*/ readonly fingerprint!: pulumi.Output<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    public readonly ipAddress!: pulumi.Output<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    public readonly ipProtocol!: pulumi.Output<string>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */
@@ -247,12 +247,12 @@ export class ForwardingRule extends pulumi.CustomResource {
             if ((!args || args.region === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'region'");
             }
-            inputs["IPAddress"] = args ? args.IPAddress : undefined;
-            inputs["IPProtocol"] = args ? args.IPProtocol : undefined;
             inputs["allPorts"] = args ? args.allPorts : undefined;
             inputs["allowGlobalAccess"] = args ? args.allowGlobalAccess : undefined;
             inputs["backendService"] = args ? args.backendService : undefined;
             inputs["description"] = args ? args.description : undefined;
+            inputs["ipAddress"] = args ? args.ipAddress : undefined;
+            inputs["ipProtocol"] = args ? args.ipProtocol : undefined;
             inputs["ipVersion"] = args ? args.ipVersion : undefined;
             inputs["isMirroringCollector"] = args ? args.isMirroringCollector : undefined;
             inputs["labels"] = args ? args.labels : undefined;
@@ -278,14 +278,14 @@ export class ForwardingRule extends pulumi.CustomResource {
             inputs["selfLink"] = undefined /*out*/;
             inputs["serviceName"] = undefined /*out*/;
         } else {
-            inputs["IPAddress"] = undefined /*out*/;
-            inputs["IPProtocol"] = undefined /*out*/;
             inputs["allPorts"] = undefined /*out*/;
             inputs["allowGlobalAccess"] = undefined /*out*/;
             inputs["backendService"] = undefined /*out*/;
             inputs["creationTimestamp"] = undefined /*out*/;
             inputs["description"] = undefined /*out*/;
             inputs["fingerprint"] = undefined /*out*/;
+            inputs["ipAddress"] = undefined /*out*/;
+            inputs["ipProtocol"] = undefined /*out*/;
             inputs["ipVersion"] = undefined /*out*/;
             inputs["isMirroringCollector"] = undefined /*out*/;
             inputs["kind"] = undefined /*out*/;
@@ -319,37 +319,6 @@ export class ForwardingRule extends pulumi.CustomResource {
  */
 export interface ForwardingRuleArgs {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    IPAddress?: pulumi.Input<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    IPProtocol?: pulumi.Input<enums.compute.beta.ForwardingRuleIPProtocol>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -367,6 +336,37 @@ export interface ForwardingRuleArgs {
      * An optional description of this resource. Provide this property when you create the resource.
      */
     description?: pulumi.Input<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    ipAddress?: pulumi.Input<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    ipProtocol?: pulumi.Input<enums.compute.beta.ForwardingRuleIpProtocol>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/beta/getForwardingRule.ts
+++ b/sdk/nodejs/compute/beta/getForwardingRule.ts
@@ -31,37 +31,6 @@ export interface GetForwardingRuleArgs {
 
 export interface GetForwardingRuleResult {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    readonly IPAddress: string;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    readonly IPProtocol: string;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +58,37 @@ export interface GetForwardingRuleResult {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     readonly fingerprint: string;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    readonly ipAddress: string;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    readonly ipProtocol: string;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/beta/getGlobalForwardingRule.ts
+++ b/sdk/nodejs/compute/beta/getGlobalForwardingRule.ts
@@ -29,37 +29,6 @@ export interface GetGlobalForwardingRuleArgs {
 
 export interface GetGlobalForwardingRuleResult {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    readonly IPAddress: string;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    readonly IPProtocol: string;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -87,6 +56,37 @@ export interface GetGlobalForwardingRuleResult {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     readonly fingerprint: string;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    readonly ipAddress: string;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    readonly ipProtocol: string;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/beta/globalForwardingRule.ts
+++ b/sdk/nodejs/compute/beta/globalForwardingRule.ts
@@ -36,37 +36,6 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
     }
 
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    public readonly IPAddress!: pulumi.Output<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    public readonly IPProtocol!: pulumi.Output<string>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -94,6 +63,37 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     public /*out*/ readonly fingerprint!: pulumi.Output<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    public readonly ipAddress!: pulumi.Output<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    public readonly ipProtocol!: pulumi.Output<string>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */
@@ -244,12 +244,12 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
             if ((!args || args.project === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'project'");
             }
-            inputs["IPAddress"] = args ? args.IPAddress : undefined;
-            inputs["IPProtocol"] = args ? args.IPProtocol : undefined;
             inputs["allPorts"] = args ? args.allPorts : undefined;
             inputs["allowGlobalAccess"] = args ? args.allowGlobalAccess : undefined;
             inputs["backendService"] = args ? args.backendService : undefined;
             inputs["description"] = args ? args.description : undefined;
+            inputs["ipAddress"] = args ? args.ipAddress : undefined;
+            inputs["ipProtocol"] = args ? args.ipProtocol : undefined;
             inputs["ipVersion"] = args ? args.ipVersion : undefined;
             inputs["isMirroringCollector"] = args ? args.isMirroringCollector : undefined;
             inputs["labels"] = args ? args.labels : undefined;
@@ -275,14 +275,14 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
             inputs["selfLink"] = undefined /*out*/;
             inputs["serviceName"] = undefined /*out*/;
         } else {
-            inputs["IPAddress"] = undefined /*out*/;
-            inputs["IPProtocol"] = undefined /*out*/;
             inputs["allPorts"] = undefined /*out*/;
             inputs["allowGlobalAccess"] = undefined /*out*/;
             inputs["backendService"] = undefined /*out*/;
             inputs["creationTimestamp"] = undefined /*out*/;
             inputs["description"] = undefined /*out*/;
             inputs["fingerprint"] = undefined /*out*/;
+            inputs["ipAddress"] = undefined /*out*/;
+            inputs["ipProtocol"] = undefined /*out*/;
             inputs["ipVersion"] = undefined /*out*/;
             inputs["isMirroringCollector"] = undefined /*out*/;
             inputs["kind"] = undefined /*out*/;
@@ -316,37 +316,6 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
  */
 export interface GlobalForwardingRuleArgs {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    IPAddress?: pulumi.Input<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    IPProtocol?: pulumi.Input<enums.compute.beta.GlobalForwardingRuleIPProtocol>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -364,6 +333,37 @@ export interface GlobalForwardingRuleArgs {
      * An optional description of this resource. Provide this property when you create the resource.
      */
     description?: pulumi.Input<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    ipAddress?: pulumi.Input<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    ipProtocol?: pulumi.Input<enums.compute.beta.GlobalForwardingRuleIpProtocol>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/v1/forwardingRule.ts
+++ b/sdk/nodejs/compute/v1/forwardingRule.ts
@@ -36,37 +36,6 @@ export class ForwardingRule extends pulumi.CustomResource {
     }
 
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    public readonly IPAddress!: pulumi.Output<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    public readonly IPProtocol!: pulumi.Output<string>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -94,6 +63,37 @@ export class ForwardingRule extends pulumi.CustomResource {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     public /*out*/ readonly fingerprint!: pulumi.Output<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    public readonly ipAddress!: pulumi.Output<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    public readonly ipProtocol!: pulumi.Output<string>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */
@@ -247,12 +247,12 @@ export class ForwardingRule extends pulumi.CustomResource {
             if ((!args || args.region === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'region'");
             }
-            inputs["IPAddress"] = args ? args.IPAddress : undefined;
-            inputs["IPProtocol"] = args ? args.IPProtocol : undefined;
             inputs["allPorts"] = args ? args.allPorts : undefined;
             inputs["allowGlobalAccess"] = args ? args.allowGlobalAccess : undefined;
             inputs["backendService"] = args ? args.backendService : undefined;
             inputs["description"] = args ? args.description : undefined;
+            inputs["ipAddress"] = args ? args.ipAddress : undefined;
+            inputs["ipProtocol"] = args ? args.ipProtocol : undefined;
             inputs["ipVersion"] = args ? args.ipVersion : undefined;
             inputs["isMirroringCollector"] = args ? args.isMirroringCollector : undefined;
             inputs["labels"] = args ? args.labels : undefined;
@@ -278,14 +278,14 @@ export class ForwardingRule extends pulumi.CustomResource {
             inputs["selfLink"] = undefined /*out*/;
             inputs["serviceName"] = undefined /*out*/;
         } else {
-            inputs["IPAddress"] = undefined /*out*/;
-            inputs["IPProtocol"] = undefined /*out*/;
             inputs["allPorts"] = undefined /*out*/;
             inputs["allowGlobalAccess"] = undefined /*out*/;
             inputs["backendService"] = undefined /*out*/;
             inputs["creationTimestamp"] = undefined /*out*/;
             inputs["description"] = undefined /*out*/;
             inputs["fingerprint"] = undefined /*out*/;
+            inputs["ipAddress"] = undefined /*out*/;
+            inputs["ipProtocol"] = undefined /*out*/;
             inputs["ipVersion"] = undefined /*out*/;
             inputs["isMirroringCollector"] = undefined /*out*/;
             inputs["kind"] = undefined /*out*/;
@@ -319,37 +319,6 @@ export class ForwardingRule extends pulumi.CustomResource {
  */
 export interface ForwardingRuleArgs {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    IPAddress?: pulumi.Input<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    IPProtocol?: pulumi.Input<enums.compute.v1.ForwardingRuleIPProtocol>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -367,6 +336,37 @@ export interface ForwardingRuleArgs {
      * An optional description of this resource. Provide this property when you create the resource.
      */
     description?: pulumi.Input<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    ipAddress?: pulumi.Input<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    ipProtocol?: pulumi.Input<enums.compute.v1.ForwardingRuleIpProtocol>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/v1/getForwardingRule.ts
+++ b/sdk/nodejs/compute/v1/getForwardingRule.ts
@@ -31,37 +31,6 @@ export interface GetForwardingRuleArgs {
 
 export interface GetForwardingRuleResult {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    readonly IPAddress: string;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    readonly IPProtocol: string;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -89,6 +58,37 @@ export interface GetForwardingRuleResult {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     readonly fingerprint: string;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    readonly ipAddress: string;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    readonly ipProtocol: string;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/v1/getGlobalForwardingRule.ts
+++ b/sdk/nodejs/compute/v1/getGlobalForwardingRule.ts
@@ -29,37 +29,6 @@ export interface GetGlobalForwardingRuleArgs {
 
 export interface GetGlobalForwardingRuleResult {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    readonly IPAddress: string;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    readonly IPProtocol: string;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -87,6 +56,37 @@ export interface GetGlobalForwardingRuleResult {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     readonly fingerprint: string;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    readonly ipAddress: string;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    readonly ipProtocol: string;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/compute/v1/globalForwardingRule.ts
+++ b/sdk/nodejs/compute/v1/globalForwardingRule.ts
@@ -36,37 +36,6 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
     }
 
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    public readonly IPAddress!: pulumi.Output<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    public readonly IPProtocol!: pulumi.Output<string>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -94,6 +63,37 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
      * To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
      */
     public /*out*/ readonly fingerprint!: pulumi.Output<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    public readonly ipAddress!: pulumi.Output<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    public readonly ipProtocol!: pulumi.Output<string>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */
@@ -244,12 +244,12 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
             if ((!args || args.project === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'project'");
             }
-            inputs["IPAddress"] = args ? args.IPAddress : undefined;
-            inputs["IPProtocol"] = args ? args.IPProtocol : undefined;
             inputs["allPorts"] = args ? args.allPorts : undefined;
             inputs["allowGlobalAccess"] = args ? args.allowGlobalAccess : undefined;
             inputs["backendService"] = args ? args.backendService : undefined;
             inputs["description"] = args ? args.description : undefined;
+            inputs["ipAddress"] = args ? args.ipAddress : undefined;
+            inputs["ipProtocol"] = args ? args.ipProtocol : undefined;
             inputs["ipVersion"] = args ? args.ipVersion : undefined;
             inputs["isMirroringCollector"] = args ? args.isMirroringCollector : undefined;
             inputs["labels"] = args ? args.labels : undefined;
@@ -275,14 +275,14 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
             inputs["selfLink"] = undefined /*out*/;
             inputs["serviceName"] = undefined /*out*/;
         } else {
-            inputs["IPAddress"] = undefined /*out*/;
-            inputs["IPProtocol"] = undefined /*out*/;
             inputs["allPorts"] = undefined /*out*/;
             inputs["allowGlobalAccess"] = undefined /*out*/;
             inputs["backendService"] = undefined /*out*/;
             inputs["creationTimestamp"] = undefined /*out*/;
             inputs["description"] = undefined /*out*/;
             inputs["fingerprint"] = undefined /*out*/;
+            inputs["ipAddress"] = undefined /*out*/;
+            inputs["ipProtocol"] = undefined /*out*/;
             inputs["ipVersion"] = undefined /*out*/;
             inputs["isMirroringCollector"] = undefined /*out*/;
             inputs["kind"] = undefined /*out*/;
@@ -316,37 +316,6 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
  */
 export interface GlobalForwardingRuleArgs {
     /**
-     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-     *
-     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-     *
-     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-     * - projects/project_id/regions/region/addresses/address-name 
-     * - regions/region/addresses/address-name 
-     * - global/addresses/address-name 
-     * - address-name  
-     *
-     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-     *
-     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-     *
-     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-     */
-    IPAddress?: pulumi.Input<string>;
-    /**
-     * The IP protocol to which this rule applies.
-     *
-     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-     *
-     * The valid IP protocols are different for different load balancing products:  
-     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-     */
-    IPProtocol?: pulumi.Input<enums.compute.v1.GlobalForwardingRuleIPProtocol>;
-    /**
      * This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
      *
      * When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
@@ -364,6 +333,37 @@ export interface GlobalForwardingRuleArgs {
      * An optional description of this resource. Provide this property when you create the resource.
      */
     description?: pulumi.Input<string>;
+    /**
+     * IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+     *
+     * If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+     *
+     * * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+     * - projects/project_id/regions/region/addresses/address-name 
+     * - regions/region/addresses/address-name 
+     * - global/addresses/address-name 
+     * - address-name  
+     *
+     * The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+     *
+     * Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+     *
+     * For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+     */
+    ipAddress?: pulumi.Input<string>;
+    /**
+     * The IP protocol to which this rule applies.
+     *
+     * For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+     *
+     * The valid IP protocols are different for different load balancing products:  
+     * - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+     * - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+     * - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+     * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+     * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+     */
+    ipProtocol?: pulumi.Input<enums.compute.v1.GlobalForwardingRuleIpProtocol>;
     /**
      * The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
      */

--- a/sdk/nodejs/storage/v1/getNotification.ts
+++ b/sdk/nodejs/storage/v1/getNotification.ts
@@ -35,7 +35,7 @@ export interface GetNotificationResult {
     /**
      * An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
      */
-    readonly custom_attributes: {[key: string]: string};
+    readonly customAttributes: {[key: string]: string};
     /**
      * HTTP 1.1 Entity tag for this subscription notification.
      */
@@ -43,7 +43,7 @@ export interface GetNotificationResult {
     /**
      * If present, only send notifications about listed event types. If empty, sent notifications for all event types.
      */
-    readonly event_types: string[];
+    readonly eventTypes: string[];
     /**
      * The kind of item this is. For notifications, this is always storage#notification.
      */
@@ -51,11 +51,11 @@ export interface GetNotificationResult {
     /**
      * If present, only apply this notification configuration to object names that begin with this prefix.
      */
-    readonly object_name_prefix: string;
+    readonly objectNamePrefix: string;
     /**
      * The desired content of the Payload.
      */
-    readonly payload_format: string;
+    readonly payloadFormat: string;
     /**
      * The canonical URL of this notification.
      */

--- a/sdk/nodejs/storage/v1/notification.ts
+++ b/sdk/nodejs/storage/v1/notification.ts
@@ -37,7 +37,7 @@ export class Notification extends pulumi.CustomResource {
     /**
      * An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
      */
-    public readonly custom_attributes!: pulumi.Output<{[key: string]: string}>;
+    public readonly customAttributes!: pulumi.Output<{[key: string]: string}>;
     /**
      * HTTP 1.1 Entity tag for this subscription notification.
      */
@@ -45,7 +45,7 @@ export class Notification extends pulumi.CustomResource {
     /**
      * If present, only send notifications about listed event types. If empty, sent notifications for all event types.
      */
-    public readonly event_types!: pulumi.Output<string[]>;
+    public readonly eventTypes!: pulumi.Output<string[]>;
     /**
      * The kind of item this is. For notifications, this is always storage#notification.
      */
@@ -53,11 +53,11 @@ export class Notification extends pulumi.CustomResource {
     /**
      * If present, only apply this notification configuration to object names that begin with this prefix.
      */
-    public readonly object_name_prefix!: pulumi.Output<string>;
+    public readonly objectNamePrefix!: pulumi.Output<string>;
     /**
      * The desired content of the Payload.
      */
-    public readonly payload_format!: pulumi.Output<string>;
+    public readonly payloadFormat!: pulumi.Output<string>;
     /**
      * The canonical URL of this notification.
      */
@@ -82,24 +82,24 @@ export class Notification extends pulumi.CustomResource {
                 throw new Error("Missing required property 'bucket'");
             }
             inputs["bucket"] = args ? args.bucket : undefined;
-            inputs["custom_attributes"] = args ? args.custom_attributes : undefined;
+            inputs["customAttributes"] = args ? args.customAttributes : undefined;
             inputs["etag"] = args ? args.etag : undefined;
-            inputs["event_types"] = args ? args.event_types : undefined;
+            inputs["eventTypes"] = args ? args.eventTypes : undefined;
             inputs["id"] = args ? args.id : undefined;
             inputs["kind"] = args ? args.kind : undefined;
-            inputs["object_name_prefix"] = args ? args.object_name_prefix : undefined;
-            inputs["payload_format"] = args ? args.payload_format : undefined;
+            inputs["objectNamePrefix"] = args ? args.objectNamePrefix : undefined;
+            inputs["payloadFormat"] = args ? args.payloadFormat : undefined;
             inputs["provisionalUserProject"] = args ? args.provisionalUserProject : undefined;
             inputs["selfLink"] = args ? args.selfLink : undefined;
             inputs["topic"] = args ? args.topic : undefined;
             inputs["userProject"] = args ? args.userProject : undefined;
         } else {
-            inputs["custom_attributes"] = undefined /*out*/;
+            inputs["customAttributes"] = undefined /*out*/;
             inputs["etag"] = undefined /*out*/;
-            inputs["event_types"] = undefined /*out*/;
+            inputs["eventTypes"] = undefined /*out*/;
             inputs["kind"] = undefined /*out*/;
-            inputs["object_name_prefix"] = undefined /*out*/;
-            inputs["payload_format"] = undefined /*out*/;
+            inputs["objectNamePrefix"] = undefined /*out*/;
+            inputs["payloadFormat"] = undefined /*out*/;
             inputs["selfLink"] = undefined /*out*/;
             inputs["topic"] = undefined /*out*/;
         }
@@ -118,7 +118,7 @@ export interface NotificationArgs {
     /**
      * An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
      */
-    custom_attributes?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    customAttributes?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * HTTP 1.1 Entity tag for this subscription notification.
      */
@@ -126,7 +126,7 @@ export interface NotificationArgs {
     /**
      * If present, only send notifications about listed event types. If empty, sent notifications for all event types.
      */
-    event_types?: pulumi.Input<pulumi.Input<string>[]>;
+    eventTypes?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * The ID of the notification.
      */
@@ -138,11 +138,11 @@ export interface NotificationArgs {
     /**
      * If present, only apply this notification configuration to object names that begin with this prefix.
      */
-    object_name_prefix?: pulumi.Input<string>;
+    objectNamePrefix?: pulumi.Input<string>;
     /**
      * The desired content of the Payload.
      */
-    payload_format?: pulumi.Input<string>;
+    payloadFormat?: pulumi.Input<string>;
     provisionalUserProject?: pulumi.Input<string>;
     /**
      * The canonical URL of this notification.

--- a/sdk/nodejs/types/enums/compute/alpha/index.ts
+++ b/sdk/nodejs/types/enums/compute/alpha/index.ts
@@ -574,7 +574,7 @@ export const FirewallPolicyRuleDirection = {
  */
 export type FirewallPolicyRuleDirection = (typeof FirewallPolicyRuleDirection)[keyof typeof FirewallPolicyRuleDirection];
 
-export const ForwardingRuleIPProtocol = {
+export const ForwardingRuleIpProtocol = {
     Ah: "AH",
     All: "ALL",
     Esp: "ESP",
@@ -596,7 +596,7 @@ export const ForwardingRuleIPProtocol = {
  * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
  * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
  */
-export type ForwardingRuleIPProtocol = (typeof ForwardingRuleIPProtocol)[keyof typeof ForwardingRuleIPProtocol];
+export type ForwardingRuleIpProtocol = (typeof ForwardingRuleIpProtocol)[keyof typeof ForwardingRuleIpProtocol];
 
 export const ForwardingRuleIpVersion = {
     Ipv4: "IPV4",
@@ -741,7 +741,7 @@ export const GlobalAddressPurpose = {
  */
 export type GlobalAddressPurpose = (typeof GlobalAddressPurpose)[keyof typeof GlobalAddressPurpose];
 
-export const GlobalForwardingRuleIPProtocol = {
+export const GlobalForwardingRuleIpProtocol = {
     Ah: "AH",
     All: "ALL",
     Esp: "ESP",
@@ -763,7 +763,7 @@ export const GlobalForwardingRuleIPProtocol = {
  * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
  * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
  */
-export type GlobalForwardingRuleIPProtocol = (typeof GlobalForwardingRuleIPProtocol)[keyof typeof GlobalForwardingRuleIPProtocol];
+export type GlobalForwardingRuleIpProtocol = (typeof GlobalForwardingRuleIpProtocol)[keyof typeof GlobalForwardingRuleIpProtocol];
 
 export const GlobalForwardingRuleIpVersion = {
     Ipv4: "IPV4",

--- a/sdk/nodejs/types/enums/compute/beta/index.ts
+++ b/sdk/nodejs/types/enums/compute/beta/index.ts
@@ -504,7 +504,7 @@ export const FirewallPolicyRuleDirection = {
  */
 export type FirewallPolicyRuleDirection = (typeof FirewallPolicyRuleDirection)[keyof typeof FirewallPolicyRuleDirection];
 
-export const ForwardingRuleIPProtocol = {
+export const ForwardingRuleIpProtocol = {
     Ah: "AH",
     Esp: "ESP",
     Icmp: "ICMP",
@@ -525,7 +525,7 @@ export const ForwardingRuleIPProtocol = {
  * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
  * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
  */
-export type ForwardingRuleIPProtocol = (typeof ForwardingRuleIPProtocol)[keyof typeof ForwardingRuleIPProtocol];
+export type ForwardingRuleIpProtocol = (typeof ForwardingRuleIpProtocol)[keyof typeof ForwardingRuleIpProtocol];
 
 export const ForwardingRuleIpVersion = {
     Ipv4: "IPV4",
@@ -651,7 +651,7 @@ export const GlobalAddressPurpose = {
  */
 export type GlobalAddressPurpose = (typeof GlobalAddressPurpose)[keyof typeof GlobalAddressPurpose];
 
-export const GlobalForwardingRuleIPProtocol = {
+export const GlobalForwardingRuleIpProtocol = {
     Ah: "AH",
     Esp: "ESP",
     Icmp: "ICMP",
@@ -672,7 +672,7 @@ export const GlobalForwardingRuleIPProtocol = {
  * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
  * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
  */
-export type GlobalForwardingRuleIPProtocol = (typeof GlobalForwardingRuleIPProtocol)[keyof typeof GlobalForwardingRuleIPProtocol];
+export type GlobalForwardingRuleIpProtocol = (typeof GlobalForwardingRuleIpProtocol)[keyof typeof GlobalForwardingRuleIpProtocol];
 
 export const GlobalForwardingRuleIpVersion = {
     Ipv4: "IPV4",

--- a/sdk/nodejs/types/enums/compute/v1/index.ts
+++ b/sdk/nodejs/types/enums/compute/v1/index.ts
@@ -460,7 +460,7 @@ export const FirewallPolicyRuleDirection = {
  */
 export type FirewallPolicyRuleDirection = (typeof FirewallPolicyRuleDirection)[keyof typeof FirewallPolicyRuleDirection];
 
-export const ForwardingRuleIPProtocol = {
+export const ForwardingRuleIpProtocol = {
     Ah: "AH",
     Esp: "ESP",
     Icmp: "ICMP",
@@ -481,7 +481,7 @@ export const ForwardingRuleIPProtocol = {
  * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
  * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
  */
-export type ForwardingRuleIPProtocol = (typeof ForwardingRuleIPProtocol)[keyof typeof ForwardingRuleIPProtocol];
+export type ForwardingRuleIpProtocol = (typeof ForwardingRuleIpProtocol)[keyof typeof ForwardingRuleIpProtocol];
 
 export const ForwardingRuleIpVersion = {
     Ipv4: "IPV4",
@@ -607,7 +607,7 @@ export const GlobalAddressPurpose = {
  */
 export type GlobalAddressPurpose = (typeof GlobalAddressPurpose)[keyof typeof GlobalAddressPurpose];
 
-export const GlobalForwardingRuleIPProtocol = {
+export const GlobalForwardingRuleIpProtocol = {
     Ah: "AH",
     Esp: "ESP",
     Icmp: "ICMP",
@@ -628,7 +628,7 @@ export const GlobalForwardingRuleIPProtocol = {
  * - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
  * - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
  */
-export type GlobalForwardingRuleIPProtocol = (typeof GlobalForwardingRuleIPProtocol)[keyof typeof GlobalForwardingRuleIPProtocol];
+export type GlobalForwardingRuleIpProtocol = (typeof GlobalForwardingRuleIpProtocol)[keyof typeof GlobalForwardingRuleIpProtocol];
 
 export const GlobalForwardingRuleIpVersion = {
     Ipv4: "IPV4",

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -765,7 +765,7 @@ export namespace apigee {
             /**
              * Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
              */
-            instance_id?: pulumi.Input<string>;
+            instanceId?: pulumi.Input<string>;
             /**
              * Required. The location associated with the metrics.
              */
@@ -3111,10 +3111,10 @@ export namespace bigquery {
              * [Required] The dataset this entry applies to.
              */
             dataset?: pulumi.Input<inputs.bigquery.v2.DatasetReferenceArgs>;
-            target_types?: pulumi.Input<pulumi.Input<inputs.bigquery.v2.DatasetAccessEntryTarget_typesItemArgs>[]>;
+            targetTypes?: pulumi.Input<pulumi.Input<inputs.bigquery.v2.DatasetAccessEntryTargetTypesItemArgs>[]>;
         }
 
-        export interface DatasetAccessEntryTarget_typesItemArgs {
+        export interface DatasetAccessEntryTargetTypesItemArgs {
             /**
              * [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
              */
@@ -9360,7 +9360,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol?: pulumi.Input<string>;
+            ipProtocol?: pulumi.Input<string>;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -9373,7 +9373,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol?: pulumi.Input<string>;
+            ipProtocol?: pulumi.Input<string>;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -10937,10 +10937,6 @@ export namespace compute {
 
         export interface PacketMirroringFilterArgs {
             /**
-             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-             */
-            IPProtocols?: pulumi.Input<pulumi.Input<string>[]>;
-            /**
              * IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
              */
             cidrRanges?: pulumi.Input<pulumi.Input<string>[]>;
@@ -10948,6 +10944,10 @@ export namespace compute {
              * Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
              */
             direction?: pulumi.Input<enums.compute.alpha.PacketMirroringFilterDirection>;
+            /**
+             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+             */
+            ipProtocols?: pulumi.Input<pulumi.Input<string>[]>;
         }
 
         export interface PacketMirroringForwardingRuleInfoArgs {
@@ -13807,7 +13807,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol?: pulumi.Input<string>;
+            ipProtocol?: pulumi.Input<string>;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -13820,7 +13820,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol?: pulumi.Input<string>;
+            ipProtocol?: pulumi.Input<string>;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -15217,10 +15217,6 @@ export namespace compute {
 
         export interface PacketMirroringFilterArgs {
             /**
-             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-             */
-            IPProtocols?: pulumi.Input<pulumi.Input<string>[]>;
-            /**
              * IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
              */
             cidrRanges?: pulumi.Input<pulumi.Input<string>[]>;
@@ -15228,6 +15224,10 @@ export namespace compute {
              * Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
              */
             direction?: pulumi.Input<enums.compute.beta.PacketMirroringFilterDirection>;
+            /**
+             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+             */
+            ipProtocols?: pulumi.Input<pulumi.Input<string>[]>;
         }
 
         export interface PacketMirroringForwardingRuleInfoArgs {
@@ -17646,7 +17646,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol?: pulumi.Input<string>;
+            ipProtocol?: pulumi.Input<string>;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -17659,7 +17659,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol?: pulumi.Input<string>;
+            ipProtocol?: pulumi.Input<string>;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -19006,10 +19006,6 @@ export namespace compute {
 
         export interface PacketMirroringFilterArgs {
             /**
-             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-             */
-            IPProtocols?: pulumi.Input<pulumi.Input<string>[]>;
-            /**
              * IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
              */
             cidrRanges?: pulumi.Input<pulumi.Input<string>[]>;
@@ -19017,6 +19013,10 @@ export namespace compute {
              * Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
              */
             direction?: pulumi.Input<enums.compute.v1.PacketMirroringFilterDirection>;
+            /**
+             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+             */
+            ipProtocols?: pulumi.Input<pulumi.Input<string>[]>;
         }
 
         export interface PacketMirroringForwardingRuleInfoArgs {

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -801,7 +801,7 @@ export namespace apigee {
             /**
              * Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.
              */
-            instance_id: string;
+            instanceId: string;
             /**
              * Required. The location associated with the metrics.
              */
@@ -3377,10 +3377,10 @@ export namespace bigquery {
              * [Required] The dataset this entry applies to.
              */
             dataset: outputs.bigquery.v2.DatasetReferenceResponse;
-            target_types: outputs.bigquery.v2.DatasetAccessEntryTarget_typesItemResponse[];
+            targetTypes: outputs.bigquery.v2.DatasetAccessEntryTargetTypesItemResponse[];
         }
 
-        export interface DatasetAccessEntryTarget_typesItemResponse {
+        export interface DatasetAccessEntryTargetTypesItemResponse {
             /**
              * [Required] Which resources in the dataset this entry applies to. Currently, only views are supported, but additional target types may be added in the future. Possible values: VIEWS: This entry applies to all views in the dataset.
              */
@@ -4238,13 +4238,13 @@ export namespace bigquery {
              */
             quotaDeferments: string[];
             /**
+             * Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+             */
+            reservationId: string;
+            /**
              * Job resource usage breakdown by reservation.
              */
             reservationUsage: outputs.bigquery.v2.JobStatisticsReservationUsageItemResponse[];
-            /**
-             * Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
-             */
-            reservation_id: string;
             /**
              * [Preview] Statistics for row-level security. Present only for query and extract jobs.
              */
@@ -11100,7 +11100,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol: string;
+            ipProtocol: string;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -11113,7 +11113,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol: string;
+            ipProtocol: string;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -12979,10 +12979,6 @@ export namespace compute {
 
         export interface PacketMirroringFilterResponse {
             /**
-             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-             */
-            IPProtocols: string[];
-            /**
              * IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
              */
             cidrRanges: string[];
@@ -12990,6 +12986,10 @@ export namespace compute {
              * Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
              */
             direction: string;
+            /**
+             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+             */
+            ipProtocols: string[];
         }
 
         export interface PacketMirroringForwardingRuleInfoResponse {
@@ -16324,7 +16324,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol: string;
+            ipProtocol: string;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -16337,7 +16337,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol: string;
+            ipProtocol: string;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -17998,10 +17998,6 @@ export namespace compute {
 
         export interface PacketMirroringFilterResponse {
             /**
-             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-             */
-            IPProtocols: string[];
-            /**
              * IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
              */
             cidrRanges: string[];
@@ -18009,6 +18005,10 @@ export namespace compute {
              * Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
              */
             direction: string;
+            /**
+             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+             */
+            ipProtocols: string[];
         }
 
         export interface PacketMirroringForwardingRuleInfoResponse {
@@ -20862,7 +20862,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol: string;
+            ipProtocol: string;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -20875,7 +20875,7 @@ export namespace compute {
             /**
              * The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
              */
-            IPProtocol: string;
+            ipProtocol: string;
             /**
              * An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
              *
@@ -22486,10 +22486,6 @@ export namespace compute {
 
         export interface PacketMirroringFilterResponse {
             /**
-             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-             */
-            IPProtocols: string[];
-            /**
              * IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
              */
             cidrRanges: string[];
@@ -22497,6 +22493,10 @@ export namespace compute {
              * Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
              */
             direction: string;
+            /**
+             * Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+             */
+            ipProtocols: string[];
         }
 
         export interface PacketMirroringForwardingRuleInfoResponse {

--- a/sdk/python/pulumi_google_native/apigee/v1/_inputs.py
+++ b/sdk/python/pulumi_google_native/apigee/v1/_inputs.py
@@ -194,7 +194,7 @@ class GoogleCloudApigeeV1CanaryEvaluationMetricLabelsArgs:
         pulumi.set(self, "env", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="instanceId")
     def instance_id(self) -> Optional[pulumi.Input[str]]:
         """
         Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.

--- a/sdk/python/pulumi_google_native/apigee/v1/outputs.py
+++ b/sdk/python/pulumi_google_native/apigee/v1/outputs.py
@@ -276,6 +276,23 @@ class GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse(dict):
     """
     Labels that can be used to filter Apigee metrics.
     """
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "instanceId":
+            suggest = "instance_id"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  env: str,
                  instance_id: str,
@@ -299,7 +316,7 @@ class GoogleCloudApigeeV1CanaryEvaluationMetricLabelsResponse(dict):
         return pulumi.get(self, "env")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="instanceId")
     def instance_id(self) -> str:
         """
         Required. The instance ID associated with the metrics. In Apigee Hybrid, the value is configured during installation.

--- a/sdk/python/pulumi_google_native/bigquery/v2/_inputs.py
+++ b/sdk/python/pulumi_google_native/bigquery/v2/_inputs.py
@@ -24,7 +24,7 @@ __all__ = [
     'ConnectionPropertyArgs',
     'CsvOptionsArgs',
     'DatasetAccessEntryArgs',
-    'DatasetAccessEntryTarget_typesItemArgs',
+    'DatasetAccessEntryTargetTypesItemArgs',
     'DatasetAccessItemArgs',
     'DatasetReferenceArgs',
     'DestinationTablePropertiesArgs',
@@ -957,7 +957,7 @@ class CsvOptionsArgs:
 class DatasetAccessEntryArgs:
     def __init__(__self__, *,
                  dataset: Optional[pulumi.Input['DatasetReferenceArgs']] = None,
-                 target_types: Optional[pulumi.Input[Sequence[pulumi.Input['DatasetAccessEntryTarget_typesItemArgs']]]] = None):
+                 target_types: Optional[pulumi.Input[Sequence[pulumi.Input['DatasetAccessEntryTargetTypesItemArgs']]]] = None):
         """
         :param pulumi.Input['DatasetReferenceArgs'] dataset: [Required] The dataset this entry applies to.
         """
@@ -979,17 +979,17 @@ class DatasetAccessEntryArgs:
         pulumi.set(self, "dataset", value)
 
     @property
-    @pulumi.getter
-    def target_types(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['DatasetAccessEntryTarget_typesItemArgs']]]]:
+    @pulumi.getter(name="targetTypes")
+    def target_types(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['DatasetAccessEntryTargetTypesItemArgs']]]]:
         return pulumi.get(self, "target_types")
 
     @target_types.setter
-    def target_types(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DatasetAccessEntryTarget_typesItemArgs']]]]):
+    def target_types(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DatasetAccessEntryTargetTypesItemArgs']]]]):
         pulumi.set(self, "target_types", value)
 
 
 @pulumi.input_type
-class DatasetAccessEntryTarget_typesItemArgs:
+class DatasetAccessEntryTargetTypesItemArgs:
     def __init__(__self__, *,
                  target_type: Optional[pulumi.Input[str]] = None):
         """

--- a/sdk/python/pulumi_google_native/bigquery/v2/get_job.py
+++ b/sdk/python/pulumi_google_native/bigquery/v2/get_job.py
@@ -100,7 +100,7 @@ class GetJobResult:
         return pulumi.get(self, "status")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="userEmail")
     def user_email(self) -> str:
         """
         Email address of the user who ran the job.

--- a/sdk/python/pulumi_google_native/bigquery/v2/job.py
+++ b/sdk/python/pulumi_google_native/bigquery/v2/job.py
@@ -219,7 +219,7 @@ class Job(pulumi.CustomResource):
         return pulumi.get(self, "status")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="userEmail")
     def user_email(self) -> pulumi.Output[str]:
         """
         Email address of the user who ran the job.

--- a/sdk/python/pulumi_google_native/bigquery/v2/outputs.py
+++ b/sdk/python/pulumi_google_native/bigquery/v2/outputs.py
@@ -26,7 +26,7 @@ __all__ = [
     'ConnectionPropertyResponse',
     'CsvOptionsResponse',
     'DatasetAccessEntryResponse',
-    'DatasetAccessEntryTarget_typesItemResponse',
+    'DatasetAccessEntryTargetTypesItemResponse',
     'DatasetAccessItemResponse',
     'DatasetReferenceResponse',
     'DestinationTablePropertiesResponse',
@@ -997,9 +997,26 @@ class CsvOptionsResponse(dict):
 
 @pulumi.output_type
 class DatasetAccessEntryResponse(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "targetTypes":
+            suggest = "target_types"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in DatasetAccessEntryResponse. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        DatasetAccessEntryResponse.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        DatasetAccessEntryResponse.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  dataset: 'outputs.DatasetReferenceResponse',
-                 target_types: Sequence['outputs.DatasetAccessEntryTarget_typesItemResponse']):
+                 target_types: Sequence['outputs.DatasetAccessEntryTargetTypesItemResponse']):
         """
         :param 'DatasetReferenceResponse' dataset: [Required] The dataset this entry applies to.
         """
@@ -1015,13 +1032,13 @@ class DatasetAccessEntryResponse(dict):
         return pulumi.get(self, "dataset")
 
     @property
-    @pulumi.getter
-    def target_types(self) -> Sequence['outputs.DatasetAccessEntryTarget_typesItemResponse']:
+    @pulumi.getter(name="targetTypes")
+    def target_types(self) -> Sequence['outputs.DatasetAccessEntryTargetTypesItemResponse']:
         return pulumi.get(self, "target_types")
 
 
 @pulumi.output_type
-class DatasetAccessEntryTarget_typesItemResponse(dict):
+class DatasetAccessEntryTargetTypesItemResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
@@ -1029,14 +1046,14 @@ class DatasetAccessEntryTarget_typesItemResponse(dict):
             suggest = "target_type"
 
         if suggest:
-            pulumi.log.warn(f"Key '{key}' not found in DatasetAccessEntryTarget_typesItemResponse. Access the value via the '{suggest}' property getter instead.")
+            pulumi.log.warn(f"Key '{key}' not found in DatasetAccessEntryTargetTypesItemResponse. Access the value via the '{suggest}' property getter instead.")
 
     def __getitem__(self, key: str) -> Any:
-        DatasetAccessEntryTarget_typesItemResponse.__key_warning(key)
+        DatasetAccessEntryTargetTypesItemResponse.__key_warning(key)
         return super().__getitem__(key)
 
     def get(self, key: str, default = None) -> Any:
-        DatasetAccessEntryTarget_typesItemResponse.__key_warning(key)
+        DatasetAccessEntryTargetTypesItemResponse.__key_warning(key)
         return super().get(key, default)
 
     def __init__(__self__, *,
@@ -3858,6 +3875,8 @@ class JobStatisticsResponse(dict):
             suggest = "parent_job_id"
         elif key == "quotaDeferments":
             suggest = "quota_deferments"
+        elif key == "reservationId":
+            suggest = "reservation_id"
         elif key == "reservationUsage":
             suggest = "reservation_usage"
         elif key == "rowLevelSecurityStatistics":
@@ -3894,8 +3913,8 @@ class JobStatisticsResponse(dict):
                  parent_job_id: str,
                  query: 'outputs.JobStatistics2Response',
                  quota_deferments: Sequence[str],
-                 reservation_usage: Sequence['outputs.JobStatisticsReservationUsageItemResponse'],
                  reservation_id: str,
+                 reservation_usage: Sequence['outputs.JobStatisticsReservationUsageItemResponse'],
                  row_level_security_statistics: 'outputs.RowLevelSecurityStatisticsResponse',
                  script_statistics: 'outputs.ScriptStatisticsResponse',
                  session_info_template: 'outputs.SessionInfoResponse',
@@ -3912,8 +3931,8 @@ class JobStatisticsResponse(dict):
         :param str parent_job_id: If this is a child job, the id of the parent.
         :param 'JobStatistics2Response' query: Statistics for a query job.
         :param Sequence[str] quota_deferments: Quotas which delayed this job's start time.
-        :param Sequence['JobStatisticsReservationUsageItemResponse'] reservation_usage: Job resource usage breakdown by reservation.
         :param str reservation_id: Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+        :param Sequence['JobStatisticsReservationUsageItemResponse'] reservation_usage: Job resource usage breakdown by reservation.
         :param 'RowLevelSecurityStatisticsResponse' row_level_security_statistics: [Preview] Statistics for row-level security. Present only for query and extract jobs.
         :param 'ScriptStatisticsResponse' script_statistics: Statistics for a child job of a script.
         :param 'SessionInfoResponse' session_info_template: [Preview] Information of the session if this job is part of one.
@@ -3930,8 +3949,8 @@ class JobStatisticsResponse(dict):
         pulumi.set(__self__, "parent_job_id", parent_job_id)
         pulumi.set(__self__, "query", query)
         pulumi.set(__self__, "quota_deferments", quota_deferments)
-        pulumi.set(__self__, "reservation_usage", reservation_usage)
         pulumi.set(__self__, "reservation_id", reservation_id)
+        pulumi.set(__self__, "reservation_usage", reservation_usage)
         pulumi.set(__self__, "row_level_security_statistics", row_level_security_statistics)
         pulumi.set(__self__, "script_statistics", script_statistics)
         pulumi.set(__self__, "session_info_template", session_info_template)
@@ -4012,20 +4031,20 @@ class JobStatisticsResponse(dict):
         return pulumi.get(self, "quota_deferments")
 
     @property
+    @pulumi.getter(name="reservationId")
+    def reservation_id(self) -> str:
+        """
+        Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
+        """
+        return pulumi.get(self, "reservation_id")
+
+    @property
     @pulumi.getter(name="reservationUsage")
     def reservation_usage(self) -> Sequence['outputs.JobStatisticsReservationUsageItemResponse']:
         """
         Job resource usage breakdown by reservation.
         """
         return pulumi.get(self, "reservation_usage")
-
-    @property
-    @pulumi.getter
-    def reservation_id(self) -> str:
-        """
-        Name of the primary reservation assigned to this job. Note that this could be different than reservations reported in the reservation usage field if parent reservations were used to execute this job.
-        """
-        return pulumi.get(self, "reservation_id")
 
     @property
     @pulumi.getter(name="rowLevelSecurityStatistics")

--- a/sdk/python/pulumi_google_native/compute/alpha/_enums.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/_enums.py
@@ -47,7 +47,7 @@ __all__ = [
     'FirewallDirection',
     'FirewallLogConfigMetadata',
     'FirewallPolicyRuleDirection',
-    'ForwardingRuleIPProtocol',
+    'ForwardingRuleIpProtocol',
     'ForwardingRuleIpVersion',
     'ForwardingRuleLoadBalancingScheme',
     'ForwardingRuleNetworkTier',
@@ -57,7 +57,7 @@ __all__ = [
     'GlobalAddressIpVersion',
     'GlobalAddressNetworkTier',
     'GlobalAddressPurpose',
-    'GlobalForwardingRuleIPProtocol',
+    'GlobalForwardingRuleIpProtocol',
     'GlobalForwardingRuleIpVersion',
     'GlobalForwardingRuleLoadBalancingScheme',
     'GlobalForwardingRuleNetworkTier',
@@ -675,7 +675,7 @@ class FirewallPolicyRuleDirection(str, Enum):
     INGRESS = "INGRESS"
 
 
-class ForwardingRuleIPProtocol(str, Enum):
+class ForwardingRuleIpProtocol(str, Enum):
     """
     The IP protocol to which this rule applies.
 
@@ -822,7 +822,7 @@ class GlobalAddressPurpose(str, Enum):
     VPC_PEERING = "VPC_PEERING"
 
 
-class GlobalForwardingRuleIPProtocol(str, Enum):
+class GlobalForwardingRuleIpProtocol(str, Enum):
     """
     The IP protocol to which this rule applies.
 

--- a/sdk/python/pulumi_google_native/compute/alpha/_inputs.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/_inputs.py
@@ -4322,7 +4322,7 @@ class FirewallAllowedItemArgs:
             pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> Optional[pulumi.Input[str]]:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -4365,7 +4365,7 @@ class FirewallDeniedItemArgs:
             pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> Optional[pulumi.Input[str]]:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -9375,32 +9375,20 @@ class OutlierDetectionArgs:
 @pulumi.input_type
 class PacketMirroringFilterArgs:
     def __init__(__self__, *,
-                 ip_protocols: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  cidr_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 direction: Optional[pulumi.Input['PacketMirroringFilterDirection']] = None):
+                 direction: Optional[pulumi.Input['PacketMirroringFilterDirection']] = None,
+                 ip_protocols: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cidr_ranges: IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param pulumi.Input['PacketMirroringFilterDirection'] direction: Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         """
-        if ip_protocols is not None:
-            pulumi.set(__self__, "ip_protocols", ip_protocols)
         if cidr_ranges is not None:
             pulumi.set(__self__, "cidr_ranges", cidr_ranges)
         if direction is not None:
             pulumi.set(__self__, "direction", direction)
-
-    @property
-    @pulumi.getter(name="IPProtocols")
-    def ip_protocols(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
-        """
-        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        """
-        return pulumi.get(self, "ip_protocols")
-
-    @ip_protocols.setter
-    def ip_protocols(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
-        pulumi.set(self, "ip_protocols", value)
+        if ip_protocols is not None:
+            pulumi.set(__self__, "ip_protocols", ip_protocols)
 
     @property
     @pulumi.getter(name="cidrRanges")
@@ -9425,6 +9413,18 @@ class PacketMirroringFilterArgs:
     @direction.setter
     def direction(self, value: Optional[pulumi.Input['PacketMirroringFilterDirection']]):
         pulumi.set(self, "direction", value)
+
+    @property
+    @pulumi.getter(name="ipProtocols")
+    def ip_protocols(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        """
+        return pulumi.get(self, "ip_protocols")
+
+    @ip_protocols.setter
+    def ip_protocols(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "ip_protocols", value)
 
 
 @pulumi.input_type

--- a/sdk/python/pulumi_google_native/compute/alpha/forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/forwarding_rule.py
@@ -18,12 +18,12 @@ class ForwardingRuleArgs:
     def __init__(__self__, *,
                  project: pulumi.Input[str],
                  region: pulumi.Input[str],
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -42,6 +42,12 @@ class ForwardingRuleArgs:
                  target: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ForwardingRule resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -57,7 +63,7 @@ class ForwardingRuleArgs:
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['ForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['ForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -67,12 +73,6 @@ class ForwardingRuleArgs:
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['ForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -143,10 +143,6 @@ class ForwardingRuleArgs:
         """
         pulumi.set(__self__, "project", project)
         pulumi.set(__self__, "region", region)
-        if ip_address is not None:
-            pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol is not None:
-            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if all_ports is not None:
             pulumi.set(__self__, "all_ports", all_ports)
         if allow_global_access is not None:
@@ -155,6 +151,10 @@ class ForwardingRuleArgs:
             pulumi.set(__self__, "backend_service", backend_service)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if ip_address is not None:
+            pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol is not None:
+            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version is not None:
             pulumi.set(__self__, "ip_version", ip_version)
         if is_mirroring_collector is not None:
@@ -207,53 +207,6 @@ class ForwardingRuleArgs:
         pulumi.set(self, "region", value)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> Optional[pulumi.Input[str]]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @ip_address.setter
-    def ip_address(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "ip_address", value)
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> Optional[pulumi.Input['ForwardingRuleIPProtocol']]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @ip_protocol.setter
-    def ip_protocol(self, value: Optional[pulumi.Input['ForwardingRuleIPProtocol']]):
-        pulumi.set(self, "ip_protocol", value)
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> Optional[pulumi.Input[bool]]:
         """
@@ -302,6 +255,53 @@ class ForwardingRuleArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> Optional[pulumi.Input[str]]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @ip_address.setter
+    def ip_address(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "ip_address", value)
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> Optional[pulumi.Input['ForwardingRuleIpProtocol']]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
+
+    @ip_protocol.setter
+    def ip_protocol(self, value: Optional[pulumi.Input['ForwardingRuleIpProtocol']]):
+        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -546,12 +546,12 @@ class ForwardingRule(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -576,6 +576,12 @@ class ForwardingRule(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -591,7 +597,7 @@ class ForwardingRule(pulumi.CustomResource):
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['ForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['ForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -601,12 +607,6 @@ class ForwardingRule(pulumi.CustomResource):
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['ForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -699,12 +699,12 @@ class ForwardingRule(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -735,12 +735,12 @@ class ForwardingRule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ForwardingRuleArgs.__new__(ForwardingRuleArgs)
 
-            __props__.__dict__["ip_address"] = ip_address
-            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["all_ports"] = all_ports
             __props__.__dict__["allow_global_access"] = allow_global_access
             __props__.__dict__["backend_service"] = backend_service
             __props__.__dict__["description"] = description
+            __props__.__dict__["ip_address"] = ip_address
+            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["ip_version"] = ip_version
             __props__.__dict__["is_mirroring_collector"] = is_mirroring_collector
             __props__.__dict__["labels"] = labels
@@ -793,14 +793,14 @@ class ForwardingRule(pulumi.CustomResource):
 
         __props__ = ForwardingRuleArgs.__new__(ForwardingRuleArgs)
 
-        __props__.__dict__["ip_address"] = None
-        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["all_ports"] = None
         __props__.__dict__["allow_global_access"] = None
         __props__.__dict__["backend_service"] = None
         __props__.__dict__["creation_timestamp"] = None
         __props__.__dict__["description"] = None
         __props__.__dict__["fingerprint"] = None
+        __props__.__dict__["ip_address"] = None
+        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["ip_version"] = None
         __props__.__dict__["is_mirroring_collector"] = None
         __props__.__dict__["kind"] = None
@@ -824,45 +824,6 @@ class ForwardingRule(pulumi.CustomResource):
         __props__.__dict__["subnetwork"] = None
         __props__.__dict__["target"] = None
         return ForwardingRule(resource_name, opts=opts, __props__=__props__)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> pulumi.Output[str]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> pulumi.Output[str]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="allPorts")
@@ -915,6 +876,45 @@ class ForwardingRule(pulumi.CustomResource):
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> pulumi.Output[str]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> pulumi.Output[str]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")

--- a/sdk/python/pulumi_google_native/compute/alpha/get_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/get_forwarding_rule.py
@@ -17,13 +17,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetForwardingRuleResult:
-    def __init__(__self__, ip_address=None, ip_protocol=None, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, psc_connection_status=None, region=None, self_link=None, self_link_with_id=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
-        if ip_address and not isinstance(ip_address, str):
-            raise TypeError("Expected argument 'ip_address' to be a str")
-        pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol and not isinstance(ip_protocol, str):
-            raise TypeError("Expected argument 'ip_protocol' to be a str")
-        pulumi.set(__self__, "ip_protocol", ip_protocol)
+    def __init__(__self__, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_address=None, ip_protocol=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, psc_connection_status=None, region=None, self_link=None, self_link_with_id=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
         if all_ports and not isinstance(all_ports, bool):
             raise TypeError("Expected argument 'all_ports' to be a bool")
         pulumi.set(__self__, "all_ports", all_ports)
@@ -42,6 +36,12 @@ class GetForwardingRuleResult:
         if fingerprint and not isinstance(fingerprint, str):
             raise TypeError("Expected argument 'fingerprint' to be a str")
         pulumi.set(__self__, "fingerprint", fingerprint)
+        if ip_address and not isinstance(ip_address, str):
+            raise TypeError("Expected argument 'ip_address' to be a str")
+        pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol and not isinstance(ip_protocol, str):
+            raise TypeError("Expected argument 'ip_protocol' to be a str")
+        pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version and not isinstance(ip_version, str):
             raise TypeError("Expected argument 'ip_version' to be a str")
         pulumi.set(__self__, "ip_version", ip_version)
@@ -110,45 +110,6 @@ class GetForwardingRuleResult:
         pulumi.set(__self__, "target", target)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> str:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> str:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> bool:
         """
@@ -199,6 +160,45 @@ class GetForwardingRuleResult:
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> str:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> str:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -435,14 +435,14 @@ class AwaitableGetForwardingRuleResult(GetForwardingRuleResult):
         if False:
             yield self
         return GetForwardingRuleResult(
-            ip_address=self.ip_address,
-            ip_protocol=self.ip_protocol,
             all_ports=self.all_ports,
             allow_global_access=self.allow_global_access,
             backend_service=self.backend_service,
             creation_timestamp=self.creation_timestamp,
             description=self.description,
             fingerprint=self.fingerprint,
+            ip_address=self.ip_address,
+            ip_protocol=self.ip_protocol,
             ip_version=self.ip_version,
             is_mirroring_collector=self.is_mirroring_collector,
             kind=self.kind,
@@ -485,14 +485,14 @@ def get_forwarding_rule(forwarding_rule: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('google-native:compute/alpha:getForwardingRule', __args__, opts=opts, typ=GetForwardingRuleResult).value
 
     return AwaitableGetForwardingRuleResult(
-        ip_address=__ret__.ip_address,
-        ip_protocol=__ret__.ip_protocol,
         all_ports=__ret__.all_ports,
         allow_global_access=__ret__.allow_global_access,
         backend_service=__ret__.backend_service,
         creation_timestamp=__ret__.creation_timestamp,
         description=__ret__.description,
         fingerprint=__ret__.fingerprint,
+        ip_address=__ret__.ip_address,
+        ip_protocol=__ret__.ip_protocol,
         ip_version=__ret__.ip_version,
         is_mirroring_collector=__ret__.is_mirroring_collector,
         kind=__ret__.kind,

--- a/sdk/python/pulumi_google_native/compute/alpha/get_global_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/get_global_forwarding_rule.py
@@ -17,13 +17,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetGlobalForwardingRuleResult:
-    def __init__(__self__, ip_address=None, ip_protocol=None, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, psc_connection_status=None, region=None, self_link=None, self_link_with_id=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
-        if ip_address and not isinstance(ip_address, str):
-            raise TypeError("Expected argument 'ip_address' to be a str")
-        pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol and not isinstance(ip_protocol, str):
-            raise TypeError("Expected argument 'ip_protocol' to be a str")
-        pulumi.set(__self__, "ip_protocol", ip_protocol)
+    def __init__(__self__, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_address=None, ip_protocol=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, psc_connection_status=None, region=None, self_link=None, self_link_with_id=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
         if all_ports and not isinstance(all_ports, bool):
             raise TypeError("Expected argument 'all_ports' to be a bool")
         pulumi.set(__self__, "all_ports", all_ports)
@@ -42,6 +36,12 @@ class GetGlobalForwardingRuleResult:
         if fingerprint and not isinstance(fingerprint, str):
             raise TypeError("Expected argument 'fingerprint' to be a str")
         pulumi.set(__self__, "fingerprint", fingerprint)
+        if ip_address and not isinstance(ip_address, str):
+            raise TypeError("Expected argument 'ip_address' to be a str")
+        pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol and not isinstance(ip_protocol, str):
+            raise TypeError("Expected argument 'ip_protocol' to be a str")
+        pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version and not isinstance(ip_version, str):
             raise TypeError("Expected argument 'ip_version' to be a str")
         pulumi.set(__self__, "ip_version", ip_version)
@@ -110,45 +110,6 @@ class GetGlobalForwardingRuleResult:
         pulumi.set(__self__, "target", target)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> str:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> str:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> bool:
         """
@@ -199,6 +160,45 @@ class GetGlobalForwardingRuleResult:
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> str:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> str:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -435,14 +435,14 @@ class AwaitableGetGlobalForwardingRuleResult(GetGlobalForwardingRuleResult):
         if False:
             yield self
         return GetGlobalForwardingRuleResult(
-            ip_address=self.ip_address,
-            ip_protocol=self.ip_protocol,
             all_ports=self.all_ports,
             allow_global_access=self.allow_global_access,
             backend_service=self.backend_service,
             creation_timestamp=self.creation_timestamp,
             description=self.description,
             fingerprint=self.fingerprint,
+            ip_address=self.ip_address,
+            ip_protocol=self.ip_protocol,
             ip_version=self.ip_version,
             is_mirroring_collector=self.is_mirroring_collector,
             kind=self.kind,
@@ -483,14 +483,14 @@ def get_global_forwarding_rule(forwarding_rule: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('google-native:compute/alpha:getGlobalForwardingRule', __args__, opts=opts, typ=GetGlobalForwardingRuleResult).value
 
     return AwaitableGetGlobalForwardingRuleResult(
-        ip_address=__ret__.ip_address,
-        ip_protocol=__ret__.ip_protocol,
         all_ports=__ret__.all_ports,
         allow_global_access=__ret__.allow_global_access,
         backend_service=__ret__.backend_service,
         creation_timestamp=__ret__.creation_timestamp,
         description=__ret__.description,
         fingerprint=__ret__.fingerprint,
+        ip_address=__ret__.ip_address,
+        ip_protocol=__ret__.ip_protocol,
         ip_version=__ret__.ip_version,
         is_mirroring_collector=__ret__.is_mirroring_collector,
         kind=__ret__.kind,

--- a/sdk/python/pulumi_google_native/compute/alpha/global_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/global_forwarding_rule.py
@@ -17,12 +17,12 @@ __all__ = ['GlobalForwardingRuleArgs', 'GlobalForwardingRule']
 class GlobalForwardingRuleArgs:
     def __init__(__self__, *,
                  project: pulumi.Input[str],
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -41,6 +41,12 @@ class GlobalForwardingRuleArgs:
                  target: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a GlobalForwardingRule resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -56,7 +62,7 @@ class GlobalForwardingRuleArgs:
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['GlobalForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['GlobalForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -66,12 +72,6 @@ class GlobalForwardingRuleArgs:
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['GlobalForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -141,10 +141,6 @@ class GlobalForwardingRuleArgs:
                If the network specified is in auto subnet mode, this field is optional. However, if the network is in custom subnet mode, a subnetwork must be specified.
         """
         pulumi.set(__self__, "project", project)
-        if ip_address is not None:
-            pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol is not None:
-            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if all_ports is not None:
             pulumi.set(__self__, "all_ports", all_ports)
         if allow_global_access is not None:
@@ -153,6 +149,10 @@ class GlobalForwardingRuleArgs:
             pulumi.set(__self__, "backend_service", backend_service)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if ip_address is not None:
+            pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol is not None:
+            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version is not None:
             pulumi.set(__self__, "ip_version", ip_version)
         if is_mirroring_collector is not None:
@@ -194,53 +194,6 @@ class GlobalForwardingRuleArgs:
     @project.setter
     def project(self, value: pulumi.Input[str]):
         pulumi.set(self, "project", value)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> Optional[pulumi.Input[str]]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @ip_address.setter
-    def ip_address(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "ip_address", value)
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @ip_protocol.setter
-    def ip_protocol(self, value: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']]):
-        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="allPorts")
@@ -291,6 +244,53 @@ class GlobalForwardingRuleArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> Optional[pulumi.Input[str]]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @ip_address.setter
+    def ip_address(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "ip_address", value)
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
+
+    @ip_protocol.setter
+    def ip_protocol(self, value: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']]):
+        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -535,12 +535,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -564,6 +564,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -579,7 +585,7 @@ class GlobalForwardingRule(pulumi.CustomResource):
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['GlobalForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['GlobalForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -589,12 +595,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['GlobalForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -687,12 +687,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -722,12 +722,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = GlobalForwardingRuleArgs.__new__(GlobalForwardingRuleArgs)
 
-            __props__.__dict__["ip_address"] = ip_address
-            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["all_ports"] = all_ports
             __props__.__dict__["allow_global_access"] = allow_global_access
             __props__.__dict__["backend_service"] = backend_service
             __props__.__dict__["description"] = description
+            __props__.__dict__["ip_address"] = ip_address
+            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["ip_version"] = ip_version
             __props__.__dict__["is_mirroring_collector"] = is_mirroring_collector
             __props__.__dict__["labels"] = labels
@@ -778,14 +778,14 @@ class GlobalForwardingRule(pulumi.CustomResource):
 
         __props__ = GlobalForwardingRuleArgs.__new__(GlobalForwardingRuleArgs)
 
-        __props__.__dict__["ip_address"] = None
-        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["all_ports"] = None
         __props__.__dict__["allow_global_access"] = None
         __props__.__dict__["backend_service"] = None
         __props__.__dict__["creation_timestamp"] = None
         __props__.__dict__["description"] = None
         __props__.__dict__["fingerprint"] = None
+        __props__.__dict__["ip_address"] = None
+        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["ip_version"] = None
         __props__.__dict__["is_mirroring_collector"] = None
         __props__.__dict__["kind"] = None
@@ -809,45 +809,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
         __props__.__dict__["subnetwork"] = None
         __props__.__dict__["target"] = None
         return GlobalForwardingRule(resource_name, opts=opts, __props__=__props__)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> pulumi.Output[str]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> pulumi.Output[str]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="allPorts")
@@ -900,6 +861,45 @@ class GlobalForwardingRule(pulumi.CustomResource):
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> pulumi.Output[str]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> pulumi.Output[str]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")

--- a/sdk/python/pulumi_google_native/compute/alpha/outputs.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/outputs.py
@@ -4677,7 +4677,7 @@ class FirewallAllowedItemResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocol":
+        if key == "ipProtocol":
             suggest = "ip_protocol"
 
         if suggest:
@@ -4704,7 +4704,7 @@ class FirewallAllowedItemResponse(dict):
         pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> str:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -4727,7 +4727,7 @@ class FirewallDeniedItemResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocol":
+        if key == "ipProtocol":
             suggest = "ip_protocol"
 
         if suggest:
@@ -4754,7 +4754,7 @@ class FirewallDeniedItemResponse(dict):
         pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> str:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -10755,10 +10755,10 @@ class PacketMirroringFilterResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocols":
-            suggest = "ip_protocols"
-        elif key == "cidrRanges":
+        if key == "cidrRanges":
             suggest = "cidr_ranges"
+        elif key == "ipProtocols":
+            suggest = "ip_protocols"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in PacketMirroringFilterResponse. Access the value via the '{suggest}' property getter instead.")
@@ -10772,25 +10772,17 @@ class PacketMirroringFilterResponse(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
-                 ip_protocols: Sequence[str],
                  cidr_ranges: Sequence[str],
-                 direction: str):
+                 direction: str,
+                 ip_protocols: Sequence[str]):
         """
-        :param Sequence[str] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param Sequence[str] cidr_ranges: IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param str direction: Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
+        :param Sequence[str] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         """
-        pulumi.set(__self__, "ip_protocols", ip_protocols)
         pulumi.set(__self__, "cidr_ranges", cidr_ranges)
         pulumi.set(__self__, "direction", direction)
-
-    @property
-    @pulumi.getter(name="IPProtocols")
-    def ip_protocols(self) -> Sequence[str]:
-        """
-        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        """
-        return pulumi.get(self, "ip_protocols")
+        pulumi.set(__self__, "ip_protocols", ip_protocols)
 
     @property
     @pulumi.getter(name="cidrRanges")
@@ -10807,6 +10799,14 @@ class PacketMirroringFilterResponse(dict):
         Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
         """
         return pulumi.get(self, "direction")
+
+    @property
+    @pulumi.getter(name="ipProtocols")
+    def ip_protocols(self) -> Sequence[str]:
+        """
+        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        """
+        return pulumi.get(self, "ip_protocols")
 
 
 @pulumi.output_type

--- a/sdk/python/pulumi_google_native/compute/beta/_enums.py
+++ b/sdk/python/pulumi_google_native/compute/beta/_enums.py
@@ -42,7 +42,7 @@ __all__ = [
     'FirewallDirection',
     'FirewallLogConfigMetadata',
     'FirewallPolicyRuleDirection',
-    'ForwardingRuleIPProtocol',
+    'ForwardingRuleIpProtocol',
     'ForwardingRuleIpVersion',
     'ForwardingRuleLoadBalancingScheme',
     'ForwardingRuleNetworkTier',
@@ -51,7 +51,7 @@ __all__ = [
     'GlobalAddressIpVersion',
     'GlobalAddressNetworkTier',
     'GlobalAddressPurpose',
-    'GlobalForwardingRuleIPProtocol',
+    'GlobalForwardingRuleIpProtocol',
     'GlobalForwardingRuleIpVersion',
     'GlobalForwardingRuleLoadBalancingScheme',
     'GlobalForwardingRuleNetworkTier',
@@ -585,7 +585,7 @@ class FirewallPolicyRuleDirection(str, Enum):
     INGRESS = "INGRESS"
 
 
-class ForwardingRuleIPProtocol(str, Enum):
+class ForwardingRuleIpProtocol(str, Enum):
     """
     The IP protocol to which this rule applies.
 
@@ -714,7 +714,7 @@ class GlobalAddressPurpose(str, Enum):
     VPC_PEERING = "VPC_PEERING"
 
 
-class GlobalForwardingRuleIPProtocol(str, Enum):
+class GlobalForwardingRuleIpProtocol(str, Enum):
     """
     The IP protocol to which this rule applies.
 

--- a/sdk/python/pulumi_google_native/compute/beta/_inputs.py
+++ b/sdk/python/pulumi_google_native/compute/beta/_inputs.py
@@ -3965,7 +3965,7 @@ class FirewallAllowedItemArgs:
             pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> Optional[pulumi.Input[str]]:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -4008,7 +4008,7 @@ class FirewallDeniedItemArgs:
             pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> Optional[pulumi.Input[str]]:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -8484,32 +8484,20 @@ class OutlierDetectionArgs:
 @pulumi.input_type
 class PacketMirroringFilterArgs:
     def __init__(__self__, *,
-                 ip_protocols: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  cidr_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 direction: Optional[pulumi.Input['PacketMirroringFilterDirection']] = None):
+                 direction: Optional[pulumi.Input['PacketMirroringFilterDirection']] = None,
+                 ip_protocols: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cidr_ranges: IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param pulumi.Input['PacketMirroringFilterDirection'] direction: Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         """
-        if ip_protocols is not None:
-            pulumi.set(__self__, "ip_protocols", ip_protocols)
         if cidr_ranges is not None:
             pulumi.set(__self__, "cidr_ranges", cidr_ranges)
         if direction is not None:
             pulumi.set(__self__, "direction", direction)
-
-    @property
-    @pulumi.getter(name="IPProtocols")
-    def ip_protocols(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
-        """
-        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        """
-        return pulumi.get(self, "ip_protocols")
-
-    @ip_protocols.setter
-    def ip_protocols(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
-        pulumi.set(self, "ip_protocols", value)
+        if ip_protocols is not None:
+            pulumi.set(__self__, "ip_protocols", ip_protocols)
 
     @property
     @pulumi.getter(name="cidrRanges")
@@ -8534,6 +8522,18 @@ class PacketMirroringFilterArgs:
     @direction.setter
     def direction(self, value: Optional[pulumi.Input['PacketMirroringFilterDirection']]):
         pulumi.set(self, "direction", value)
+
+    @property
+    @pulumi.getter(name="ipProtocols")
+    def ip_protocols(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        """
+        return pulumi.get(self, "ip_protocols")
+
+    @ip_protocols.setter
+    def ip_protocols(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "ip_protocols", value)
 
 
 @pulumi.input_type

--- a/sdk/python/pulumi_google_native/compute/beta/forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/beta/forwarding_rule.py
@@ -18,12 +18,12 @@ class ForwardingRuleArgs:
     def __init__(__self__, *,
                  project: pulumi.Input[str],
                  region: pulumi.Input[str],
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -41,6 +41,12 @@ class ForwardingRuleArgs:
                  target: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ForwardingRule resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -56,7 +62,7 @@ class ForwardingRuleArgs:
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['ForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['ForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -66,12 +72,6 @@ class ForwardingRuleArgs:
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['ForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -142,10 +142,6 @@ class ForwardingRuleArgs:
         """
         pulumi.set(__self__, "project", project)
         pulumi.set(__self__, "region", region)
-        if ip_address is not None:
-            pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol is not None:
-            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if all_ports is not None:
             pulumi.set(__self__, "all_ports", all_ports)
         if allow_global_access is not None:
@@ -154,6 +150,10 @@ class ForwardingRuleArgs:
             pulumi.set(__self__, "backend_service", backend_service)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if ip_address is not None:
+            pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol is not None:
+            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version is not None:
             pulumi.set(__self__, "ip_version", ip_version)
         if is_mirroring_collector is not None:
@@ -204,53 +204,6 @@ class ForwardingRuleArgs:
         pulumi.set(self, "region", value)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> Optional[pulumi.Input[str]]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @ip_address.setter
-    def ip_address(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "ip_address", value)
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> Optional[pulumi.Input['ForwardingRuleIPProtocol']]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @ip_protocol.setter
-    def ip_protocol(self, value: Optional[pulumi.Input['ForwardingRuleIPProtocol']]):
-        pulumi.set(self, "ip_protocol", value)
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> Optional[pulumi.Input[bool]]:
         """
@@ -299,6 +252,53 @@ class ForwardingRuleArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> Optional[pulumi.Input[str]]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @ip_address.setter
+    def ip_address(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "ip_address", value)
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> Optional[pulumi.Input['ForwardingRuleIpProtocol']]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
+
+    @ip_protocol.setter
+    def ip_protocol(self, value: Optional[pulumi.Input['ForwardingRuleIpProtocol']]):
+        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -534,12 +534,12 @@ class ForwardingRule(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -563,6 +563,12 @@ class ForwardingRule(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -578,7 +584,7 @@ class ForwardingRule(pulumi.CustomResource):
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['ForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['ForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -588,12 +594,6 @@ class ForwardingRule(pulumi.CustomResource):
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['ForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -686,12 +686,12 @@ class ForwardingRule(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -721,12 +721,12 @@ class ForwardingRule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ForwardingRuleArgs.__new__(ForwardingRuleArgs)
 
-            __props__.__dict__["ip_address"] = ip_address
-            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["all_ports"] = all_ports
             __props__.__dict__["allow_global_access"] = allow_global_access
             __props__.__dict__["backend_service"] = backend_service
             __props__.__dict__["description"] = description
+            __props__.__dict__["ip_address"] = ip_address
+            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["ip_version"] = ip_version
             __props__.__dict__["is_mirroring_collector"] = is_mirroring_collector
             __props__.__dict__["labels"] = labels
@@ -777,14 +777,14 @@ class ForwardingRule(pulumi.CustomResource):
 
         __props__ = ForwardingRuleArgs.__new__(ForwardingRuleArgs)
 
-        __props__.__dict__["ip_address"] = None
-        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["all_ports"] = None
         __props__.__dict__["allow_global_access"] = None
         __props__.__dict__["backend_service"] = None
         __props__.__dict__["creation_timestamp"] = None
         __props__.__dict__["description"] = None
         __props__.__dict__["fingerprint"] = None
+        __props__.__dict__["ip_address"] = None
+        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["ip_version"] = None
         __props__.__dict__["is_mirroring_collector"] = None
         __props__.__dict__["kind"] = None
@@ -806,45 +806,6 @@ class ForwardingRule(pulumi.CustomResource):
         __props__.__dict__["subnetwork"] = None
         __props__.__dict__["target"] = None
         return ForwardingRule(resource_name, opts=opts, __props__=__props__)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> pulumi.Output[str]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> pulumi.Output[str]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="allPorts")
@@ -897,6 +858,45 @@ class ForwardingRule(pulumi.CustomResource):
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> pulumi.Output[str]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> pulumi.Output[str]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")

--- a/sdk/python/pulumi_google_native/compute/beta/get_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/beta/get_forwarding_rule.py
@@ -17,13 +17,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetForwardingRuleResult:
-    def __init__(__self__, ip_address=None, ip_protocol=None, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
-        if ip_address and not isinstance(ip_address, str):
-            raise TypeError("Expected argument 'ip_address' to be a str")
-        pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol and not isinstance(ip_protocol, str):
-            raise TypeError("Expected argument 'ip_protocol' to be a str")
-        pulumi.set(__self__, "ip_protocol", ip_protocol)
+    def __init__(__self__, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_address=None, ip_protocol=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
         if all_ports and not isinstance(all_ports, bool):
             raise TypeError("Expected argument 'all_ports' to be a bool")
         pulumi.set(__self__, "all_ports", all_ports)
@@ -42,6 +36,12 @@ class GetForwardingRuleResult:
         if fingerprint and not isinstance(fingerprint, str):
             raise TypeError("Expected argument 'fingerprint' to be a str")
         pulumi.set(__self__, "fingerprint", fingerprint)
+        if ip_address and not isinstance(ip_address, str):
+            raise TypeError("Expected argument 'ip_address' to be a str")
+        pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol and not isinstance(ip_protocol, str):
+            raise TypeError("Expected argument 'ip_protocol' to be a str")
+        pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version and not isinstance(ip_version, str):
             raise TypeError("Expected argument 'ip_version' to be a str")
         pulumi.set(__self__, "ip_version", ip_version)
@@ -104,45 +104,6 @@ class GetForwardingRuleResult:
         pulumi.set(__self__, "target", target)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> str:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> str:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> bool:
         """
@@ -193,6 +154,45 @@ class GetForwardingRuleResult:
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> str:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> str:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -416,14 +416,14 @@ class AwaitableGetForwardingRuleResult(GetForwardingRuleResult):
         if False:
             yield self
         return GetForwardingRuleResult(
-            ip_address=self.ip_address,
-            ip_protocol=self.ip_protocol,
             all_ports=self.all_ports,
             allow_global_access=self.allow_global_access,
             backend_service=self.backend_service,
             creation_timestamp=self.creation_timestamp,
             description=self.description,
             fingerprint=self.fingerprint,
+            ip_address=self.ip_address,
+            ip_protocol=self.ip_protocol,
             ip_version=self.ip_version,
             is_mirroring_collector=self.is_mirroring_collector,
             kind=self.kind,
@@ -464,14 +464,14 @@ def get_forwarding_rule(forwarding_rule: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('google-native:compute/beta:getForwardingRule', __args__, opts=opts, typ=GetForwardingRuleResult).value
 
     return AwaitableGetForwardingRuleResult(
-        ip_address=__ret__.ip_address,
-        ip_protocol=__ret__.ip_protocol,
         all_ports=__ret__.all_ports,
         allow_global_access=__ret__.allow_global_access,
         backend_service=__ret__.backend_service,
         creation_timestamp=__ret__.creation_timestamp,
         description=__ret__.description,
         fingerprint=__ret__.fingerprint,
+        ip_address=__ret__.ip_address,
+        ip_protocol=__ret__.ip_protocol,
         ip_version=__ret__.ip_version,
         is_mirroring_collector=__ret__.is_mirroring_collector,
         kind=__ret__.kind,

--- a/sdk/python/pulumi_google_native/compute/beta/get_global_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/beta/get_global_forwarding_rule.py
@@ -17,13 +17,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetGlobalForwardingRuleResult:
-    def __init__(__self__, ip_address=None, ip_protocol=None, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
-        if ip_address and not isinstance(ip_address, str):
-            raise TypeError("Expected argument 'ip_address' to be a str")
-        pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol and not isinstance(ip_protocol, str):
-            raise TypeError("Expected argument 'ip_protocol' to be a str")
-        pulumi.set(__self__, "ip_protocol", ip_protocol)
+    def __init__(__self__, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_address=None, ip_protocol=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
         if all_ports and not isinstance(all_ports, bool):
             raise TypeError("Expected argument 'all_ports' to be a bool")
         pulumi.set(__self__, "all_ports", all_ports)
@@ -42,6 +36,12 @@ class GetGlobalForwardingRuleResult:
         if fingerprint and not isinstance(fingerprint, str):
             raise TypeError("Expected argument 'fingerprint' to be a str")
         pulumi.set(__self__, "fingerprint", fingerprint)
+        if ip_address and not isinstance(ip_address, str):
+            raise TypeError("Expected argument 'ip_address' to be a str")
+        pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol and not isinstance(ip_protocol, str):
+            raise TypeError("Expected argument 'ip_protocol' to be a str")
+        pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version and not isinstance(ip_version, str):
             raise TypeError("Expected argument 'ip_version' to be a str")
         pulumi.set(__self__, "ip_version", ip_version)
@@ -104,45 +104,6 @@ class GetGlobalForwardingRuleResult:
         pulumi.set(__self__, "target", target)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> str:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> str:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> bool:
         """
@@ -193,6 +154,45 @@ class GetGlobalForwardingRuleResult:
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> str:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> str:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -416,14 +416,14 @@ class AwaitableGetGlobalForwardingRuleResult(GetGlobalForwardingRuleResult):
         if False:
             yield self
         return GetGlobalForwardingRuleResult(
-            ip_address=self.ip_address,
-            ip_protocol=self.ip_protocol,
             all_ports=self.all_ports,
             allow_global_access=self.allow_global_access,
             backend_service=self.backend_service,
             creation_timestamp=self.creation_timestamp,
             description=self.description,
             fingerprint=self.fingerprint,
+            ip_address=self.ip_address,
+            ip_protocol=self.ip_protocol,
             ip_version=self.ip_version,
             is_mirroring_collector=self.is_mirroring_collector,
             kind=self.kind,
@@ -462,14 +462,14 @@ def get_global_forwarding_rule(forwarding_rule: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('google-native:compute/beta:getGlobalForwardingRule', __args__, opts=opts, typ=GetGlobalForwardingRuleResult).value
 
     return AwaitableGetGlobalForwardingRuleResult(
-        ip_address=__ret__.ip_address,
-        ip_protocol=__ret__.ip_protocol,
         all_ports=__ret__.all_ports,
         allow_global_access=__ret__.allow_global_access,
         backend_service=__ret__.backend_service,
         creation_timestamp=__ret__.creation_timestamp,
         description=__ret__.description,
         fingerprint=__ret__.fingerprint,
+        ip_address=__ret__.ip_address,
+        ip_protocol=__ret__.ip_protocol,
         ip_version=__ret__.ip_version,
         is_mirroring_collector=__ret__.is_mirroring_collector,
         kind=__ret__.kind,

--- a/sdk/python/pulumi_google_native/compute/beta/global_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/beta/global_forwarding_rule.py
@@ -17,12 +17,12 @@ __all__ = ['GlobalForwardingRuleArgs', 'GlobalForwardingRule']
 class GlobalForwardingRuleArgs:
     def __init__(__self__, *,
                  project: pulumi.Input[str],
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -40,6 +40,12 @@ class GlobalForwardingRuleArgs:
                  target: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a GlobalForwardingRule resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -55,7 +61,7 @@ class GlobalForwardingRuleArgs:
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['GlobalForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['GlobalForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -65,12 +71,6 @@ class GlobalForwardingRuleArgs:
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['GlobalForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -140,10 +140,6 @@ class GlobalForwardingRuleArgs:
                If the network specified is in auto subnet mode, this field is optional. However, if the network is in custom subnet mode, a subnetwork must be specified.
         """
         pulumi.set(__self__, "project", project)
-        if ip_address is not None:
-            pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol is not None:
-            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if all_ports is not None:
             pulumi.set(__self__, "all_ports", all_ports)
         if allow_global_access is not None:
@@ -152,6 +148,10 @@ class GlobalForwardingRuleArgs:
             pulumi.set(__self__, "backend_service", backend_service)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if ip_address is not None:
+            pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol is not None:
+            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version is not None:
             pulumi.set(__self__, "ip_version", ip_version)
         if is_mirroring_collector is not None:
@@ -191,53 +191,6 @@ class GlobalForwardingRuleArgs:
     @project.setter
     def project(self, value: pulumi.Input[str]):
         pulumi.set(self, "project", value)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> Optional[pulumi.Input[str]]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @ip_address.setter
-    def ip_address(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "ip_address", value)
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @ip_protocol.setter
-    def ip_protocol(self, value: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']]):
-        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="allPorts")
@@ -288,6 +241,53 @@ class GlobalForwardingRuleArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> Optional[pulumi.Input[str]]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @ip_address.setter
+    def ip_address(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "ip_address", value)
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
+
+    @ip_protocol.setter
+    def ip_protocol(self, value: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']]):
+        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -523,12 +523,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -551,6 +551,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -566,7 +572,7 @@ class GlobalForwardingRule(pulumi.CustomResource):
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['GlobalForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['GlobalForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -576,12 +582,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['GlobalForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -674,12 +674,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -708,12 +708,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = GlobalForwardingRuleArgs.__new__(GlobalForwardingRuleArgs)
 
-            __props__.__dict__["ip_address"] = ip_address
-            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["all_ports"] = all_ports
             __props__.__dict__["allow_global_access"] = allow_global_access
             __props__.__dict__["backend_service"] = backend_service
             __props__.__dict__["description"] = description
+            __props__.__dict__["ip_address"] = ip_address
+            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["ip_version"] = ip_version
             __props__.__dict__["is_mirroring_collector"] = is_mirroring_collector
             __props__.__dict__["labels"] = labels
@@ -762,14 +762,14 @@ class GlobalForwardingRule(pulumi.CustomResource):
 
         __props__ = GlobalForwardingRuleArgs.__new__(GlobalForwardingRuleArgs)
 
-        __props__.__dict__["ip_address"] = None
-        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["all_ports"] = None
         __props__.__dict__["allow_global_access"] = None
         __props__.__dict__["backend_service"] = None
         __props__.__dict__["creation_timestamp"] = None
         __props__.__dict__["description"] = None
         __props__.__dict__["fingerprint"] = None
+        __props__.__dict__["ip_address"] = None
+        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["ip_version"] = None
         __props__.__dict__["is_mirroring_collector"] = None
         __props__.__dict__["kind"] = None
@@ -791,45 +791,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
         __props__.__dict__["subnetwork"] = None
         __props__.__dict__["target"] = None
         return GlobalForwardingRule(resource_name, opts=opts, __props__=__props__)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> pulumi.Output[str]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> pulumi.Output[str]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="allPorts")
@@ -882,6 +843,45 @@ class GlobalForwardingRule(pulumi.CustomResource):
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> pulumi.Output[str]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> pulumi.Output[str]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")

--- a/sdk/python/pulumi_google_native/compute/beta/outputs.py
+++ b/sdk/python/pulumi_google_native/compute/beta/outputs.py
@@ -4241,7 +4241,7 @@ class FirewallAllowedItemResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocol":
+        if key == "ipProtocol":
             suggest = "ip_protocol"
 
         if suggest:
@@ -4268,7 +4268,7 @@ class FirewallAllowedItemResponse(dict):
         pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> str:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -4291,7 +4291,7 @@ class FirewallDeniedItemResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocol":
+        if key == "ipProtocol":
             suggest = "ip_protocol"
 
         if suggest:
@@ -4318,7 +4318,7 @@ class FirewallDeniedItemResponse(dict):
         pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> str:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -9669,10 +9669,10 @@ class PacketMirroringFilterResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocols":
-            suggest = "ip_protocols"
-        elif key == "cidrRanges":
+        if key == "cidrRanges":
             suggest = "cidr_ranges"
+        elif key == "ipProtocols":
+            suggest = "ip_protocols"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in PacketMirroringFilterResponse. Access the value via the '{suggest}' property getter instead.")
@@ -9686,25 +9686,17 @@ class PacketMirroringFilterResponse(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
-                 ip_protocols: Sequence[str],
                  cidr_ranges: Sequence[str],
-                 direction: str):
+                 direction: str,
+                 ip_protocols: Sequence[str]):
         """
-        :param Sequence[str] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param Sequence[str] cidr_ranges: IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param str direction: Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
+        :param Sequence[str] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         """
-        pulumi.set(__self__, "ip_protocols", ip_protocols)
         pulumi.set(__self__, "cidr_ranges", cidr_ranges)
         pulumi.set(__self__, "direction", direction)
-
-    @property
-    @pulumi.getter(name="IPProtocols")
-    def ip_protocols(self) -> Sequence[str]:
-        """
-        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        """
-        return pulumi.get(self, "ip_protocols")
+        pulumi.set(__self__, "ip_protocols", ip_protocols)
 
     @property
     @pulumi.getter(name="cidrRanges")
@@ -9721,6 +9713,14 @@ class PacketMirroringFilterResponse(dict):
         Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
         """
         return pulumi.get(self, "direction")
+
+    @property
+    @pulumi.getter(name="ipProtocols")
+    def ip_protocols(self) -> Sequence[str]:
+        """
+        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        """
+        return pulumi.get(self, "ip_protocols")
 
 
 @pulumi.output_type

--- a/sdk/python/pulumi_google_native/compute/v1/_enums.py
+++ b/sdk/python/pulumi_google_native/compute/v1/_enums.py
@@ -39,7 +39,7 @@ __all__ = [
     'FirewallDirection',
     'FirewallLogConfigMetadata',
     'FirewallPolicyRuleDirection',
-    'ForwardingRuleIPProtocol',
+    'ForwardingRuleIpProtocol',
     'ForwardingRuleIpVersion',
     'ForwardingRuleLoadBalancingScheme',
     'ForwardingRuleNetworkTier',
@@ -48,7 +48,7 @@ __all__ = [
     'GlobalAddressIpVersion',
     'GlobalAddressNetworkTier',
     'GlobalAddressPurpose',
-    'GlobalForwardingRuleIPProtocol',
+    'GlobalForwardingRuleIpProtocol',
     'GlobalForwardingRuleIpVersion',
     'GlobalForwardingRuleLoadBalancingScheme',
     'GlobalForwardingRuleNetworkTier',
@@ -530,7 +530,7 @@ class FirewallPolicyRuleDirection(str, Enum):
     INGRESS = "INGRESS"
 
 
-class ForwardingRuleIPProtocol(str, Enum):
+class ForwardingRuleIpProtocol(str, Enum):
     """
     The IP protocol to which this rule applies.
 
@@ -659,7 +659,7 @@ class GlobalAddressPurpose(str, Enum):
     VPC_PEERING = "VPC_PEERING"
 
 
-class GlobalForwardingRuleIPProtocol(str, Enum):
+class GlobalForwardingRuleIpProtocol(str, Enum):
     """
     The IP protocol to which this rule applies.
 

--- a/sdk/python/pulumi_google_native/compute/v1/_inputs.py
+++ b/sdk/python/pulumi_google_native/compute/v1/_inputs.py
@@ -3734,7 +3734,7 @@ class FirewallAllowedItemArgs:
             pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> Optional[pulumi.Input[str]]:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -3777,7 +3777,7 @@ class FirewallDeniedItemArgs:
             pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> Optional[pulumi.Input[str]]:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -8066,32 +8066,20 @@ class OutlierDetectionArgs:
 @pulumi.input_type
 class PacketMirroringFilterArgs:
     def __init__(__self__, *,
-                 ip_protocols: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  cidr_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 direction: Optional[pulumi.Input['PacketMirroringFilterDirection']] = None):
+                 direction: Optional[pulumi.Input['PacketMirroringFilterDirection']] = None,
+                 ip_protocols: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cidr_ranges: IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param pulumi.Input['PacketMirroringFilterDirection'] direction: Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         """
-        if ip_protocols is not None:
-            pulumi.set(__self__, "ip_protocols", ip_protocols)
         if cidr_ranges is not None:
             pulumi.set(__self__, "cidr_ranges", cidr_ranges)
         if direction is not None:
             pulumi.set(__self__, "direction", direction)
-
-    @property
-    @pulumi.getter(name="IPProtocols")
-    def ip_protocols(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
-        """
-        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        """
-        return pulumi.get(self, "ip_protocols")
-
-    @ip_protocols.setter
-    def ip_protocols(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
-        pulumi.set(self, "ip_protocols", value)
+        if ip_protocols is not None:
+            pulumi.set(__self__, "ip_protocols", ip_protocols)
 
     @property
     @pulumi.getter(name="cidrRanges")
@@ -8116,6 +8104,18 @@ class PacketMirroringFilterArgs:
     @direction.setter
     def direction(self, value: Optional[pulumi.Input['PacketMirroringFilterDirection']]):
         pulumi.set(self, "direction", value)
+
+    @property
+    @pulumi.getter(name="ipProtocols")
+    def ip_protocols(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        """
+        return pulumi.get(self, "ip_protocols")
+
+    @ip_protocols.setter
+    def ip_protocols(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "ip_protocols", value)
 
 
 @pulumi.input_type

--- a/sdk/python/pulumi_google_native/compute/v1/forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/v1/forwarding_rule.py
@@ -18,12 +18,12 @@ class ForwardingRuleArgs:
     def __init__(__self__, *,
                  project: pulumi.Input[str],
                  region: pulumi.Input[str],
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -41,6 +41,12 @@ class ForwardingRuleArgs:
                  target: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ForwardingRule resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -56,7 +62,7 @@ class ForwardingRuleArgs:
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['ForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['ForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -66,12 +72,6 @@ class ForwardingRuleArgs:
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['ForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -142,10 +142,6 @@ class ForwardingRuleArgs:
         """
         pulumi.set(__self__, "project", project)
         pulumi.set(__self__, "region", region)
-        if ip_address is not None:
-            pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol is not None:
-            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if all_ports is not None:
             pulumi.set(__self__, "all_ports", all_ports)
         if allow_global_access is not None:
@@ -154,6 +150,10 @@ class ForwardingRuleArgs:
             pulumi.set(__self__, "backend_service", backend_service)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if ip_address is not None:
+            pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol is not None:
+            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version is not None:
             pulumi.set(__self__, "ip_version", ip_version)
         if is_mirroring_collector is not None:
@@ -204,53 +204,6 @@ class ForwardingRuleArgs:
         pulumi.set(self, "region", value)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> Optional[pulumi.Input[str]]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @ip_address.setter
-    def ip_address(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "ip_address", value)
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> Optional[pulumi.Input['ForwardingRuleIPProtocol']]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @ip_protocol.setter
-    def ip_protocol(self, value: Optional[pulumi.Input['ForwardingRuleIPProtocol']]):
-        pulumi.set(self, "ip_protocol", value)
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> Optional[pulumi.Input[bool]]:
         """
@@ -299,6 +252,53 @@ class ForwardingRuleArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> Optional[pulumi.Input[str]]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @ip_address.setter
+    def ip_address(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "ip_address", value)
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> Optional[pulumi.Input['ForwardingRuleIpProtocol']]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
+
+    @ip_protocol.setter
+    def ip_protocol(self, value: Optional[pulumi.Input['ForwardingRuleIpProtocol']]):
+        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -534,12 +534,12 @@ class ForwardingRule(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -563,6 +563,12 @@ class ForwardingRule(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -578,7 +584,7 @@ class ForwardingRule(pulumi.CustomResource):
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['ForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['ForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -588,12 +594,6 @@ class ForwardingRule(pulumi.CustomResource):
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['ForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -686,12 +686,12 @@ class ForwardingRule(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['ForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['ForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -721,12 +721,12 @@ class ForwardingRule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ForwardingRuleArgs.__new__(ForwardingRuleArgs)
 
-            __props__.__dict__["ip_address"] = ip_address
-            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["all_ports"] = all_ports
             __props__.__dict__["allow_global_access"] = allow_global_access
             __props__.__dict__["backend_service"] = backend_service
             __props__.__dict__["description"] = description
+            __props__.__dict__["ip_address"] = ip_address
+            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["ip_version"] = ip_version
             __props__.__dict__["is_mirroring_collector"] = is_mirroring_collector
             __props__.__dict__["labels"] = labels
@@ -777,14 +777,14 @@ class ForwardingRule(pulumi.CustomResource):
 
         __props__ = ForwardingRuleArgs.__new__(ForwardingRuleArgs)
 
-        __props__.__dict__["ip_address"] = None
-        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["all_ports"] = None
         __props__.__dict__["allow_global_access"] = None
         __props__.__dict__["backend_service"] = None
         __props__.__dict__["creation_timestamp"] = None
         __props__.__dict__["description"] = None
         __props__.__dict__["fingerprint"] = None
+        __props__.__dict__["ip_address"] = None
+        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["ip_version"] = None
         __props__.__dict__["is_mirroring_collector"] = None
         __props__.__dict__["kind"] = None
@@ -806,45 +806,6 @@ class ForwardingRule(pulumi.CustomResource):
         __props__.__dict__["subnetwork"] = None
         __props__.__dict__["target"] = None
         return ForwardingRule(resource_name, opts=opts, __props__=__props__)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> pulumi.Output[str]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> pulumi.Output[str]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="allPorts")
@@ -897,6 +858,45 @@ class ForwardingRule(pulumi.CustomResource):
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> pulumi.Output[str]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> pulumi.Output[str]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")

--- a/sdk/python/pulumi_google_native/compute/v1/get_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/v1/get_forwarding_rule.py
@@ -17,13 +17,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetForwardingRuleResult:
-    def __init__(__self__, ip_address=None, ip_protocol=None, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
-        if ip_address and not isinstance(ip_address, str):
-            raise TypeError("Expected argument 'ip_address' to be a str")
-        pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol and not isinstance(ip_protocol, str):
-            raise TypeError("Expected argument 'ip_protocol' to be a str")
-        pulumi.set(__self__, "ip_protocol", ip_protocol)
+    def __init__(__self__, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_address=None, ip_protocol=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
         if all_ports and not isinstance(all_ports, bool):
             raise TypeError("Expected argument 'all_ports' to be a bool")
         pulumi.set(__self__, "all_ports", all_ports)
@@ -42,6 +36,12 @@ class GetForwardingRuleResult:
         if fingerprint and not isinstance(fingerprint, str):
             raise TypeError("Expected argument 'fingerprint' to be a str")
         pulumi.set(__self__, "fingerprint", fingerprint)
+        if ip_address and not isinstance(ip_address, str):
+            raise TypeError("Expected argument 'ip_address' to be a str")
+        pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol and not isinstance(ip_protocol, str):
+            raise TypeError("Expected argument 'ip_protocol' to be a str")
+        pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version and not isinstance(ip_version, str):
             raise TypeError("Expected argument 'ip_version' to be a str")
         pulumi.set(__self__, "ip_version", ip_version)
@@ -104,45 +104,6 @@ class GetForwardingRuleResult:
         pulumi.set(__self__, "target", target)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> str:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> str:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> bool:
         """
@@ -193,6 +154,45 @@ class GetForwardingRuleResult:
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> str:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> str:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -416,14 +416,14 @@ class AwaitableGetForwardingRuleResult(GetForwardingRuleResult):
         if False:
             yield self
         return GetForwardingRuleResult(
-            ip_address=self.ip_address,
-            ip_protocol=self.ip_protocol,
             all_ports=self.all_ports,
             allow_global_access=self.allow_global_access,
             backend_service=self.backend_service,
             creation_timestamp=self.creation_timestamp,
             description=self.description,
             fingerprint=self.fingerprint,
+            ip_address=self.ip_address,
+            ip_protocol=self.ip_protocol,
             ip_version=self.ip_version,
             is_mirroring_collector=self.is_mirroring_collector,
             kind=self.kind,
@@ -464,14 +464,14 @@ def get_forwarding_rule(forwarding_rule: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('google-native:compute/v1:getForwardingRule', __args__, opts=opts, typ=GetForwardingRuleResult).value
 
     return AwaitableGetForwardingRuleResult(
-        ip_address=__ret__.ip_address,
-        ip_protocol=__ret__.ip_protocol,
         all_ports=__ret__.all_ports,
         allow_global_access=__ret__.allow_global_access,
         backend_service=__ret__.backend_service,
         creation_timestamp=__ret__.creation_timestamp,
         description=__ret__.description,
         fingerprint=__ret__.fingerprint,
+        ip_address=__ret__.ip_address,
+        ip_protocol=__ret__.ip_protocol,
         ip_version=__ret__.ip_version,
         is_mirroring_collector=__ret__.is_mirroring_collector,
         kind=__ret__.kind,

--- a/sdk/python/pulumi_google_native/compute/v1/get_global_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/v1/get_global_forwarding_rule.py
@@ -17,13 +17,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetGlobalForwardingRuleResult:
-    def __init__(__self__, ip_address=None, ip_protocol=None, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
-        if ip_address and not isinstance(ip_address, str):
-            raise TypeError("Expected argument 'ip_address' to be a str")
-        pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol and not isinstance(ip_protocol, str):
-            raise TypeError("Expected argument 'ip_protocol' to be a str")
-        pulumi.set(__self__, "ip_protocol", ip_protocol)
+    def __init__(__self__, all_ports=None, allow_global_access=None, backend_service=None, creation_timestamp=None, description=None, fingerprint=None, ip_address=None, ip_protocol=None, ip_version=None, is_mirroring_collector=None, kind=None, label_fingerprint=None, labels=None, load_balancing_scheme=None, metadata_filters=None, name=None, network=None, network_tier=None, port_range=None, ports=None, psc_connection_id=None, region=None, self_link=None, service_directory_registrations=None, service_label=None, service_name=None, subnetwork=None, target=None):
         if all_ports and not isinstance(all_ports, bool):
             raise TypeError("Expected argument 'all_ports' to be a bool")
         pulumi.set(__self__, "all_ports", all_ports)
@@ -42,6 +36,12 @@ class GetGlobalForwardingRuleResult:
         if fingerprint and not isinstance(fingerprint, str):
             raise TypeError("Expected argument 'fingerprint' to be a str")
         pulumi.set(__self__, "fingerprint", fingerprint)
+        if ip_address and not isinstance(ip_address, str):
+            raise TypeError("Expected argument 'ip_address' to be a str")
+        pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol and not isinstance(ip_protocol, str):
+            raise TypeError("Expected argument 'ip_protocol' to be a str")
+        pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version and not isinstance(ip_version, str):
             raise TypeError("Expected argument 'ip_version' to be a str")
         pulumi.set(__self__, "ip_version", ip_version)
@@ -104,45 +104,6 @@ class GetGlobalForwardingRuleResult:
         pulumi.set(__self__, "target", target)
 
     @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> str:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> str:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @property
     @pulumi.getter(name="allPorts")
     def all_ports(self) -> bool:
         """
@@ -193,6 +154,45 @@ class GetGlobalForwardingRuleResult:
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> str:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> str:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -416,14 +416,14 @@ class AwaitableGetGlobalForwardingRuleResult(GetGlobalForwardingRuleResult):
         if False:
             yield self
         return GetGlobalForwardingRuleResult(
-            ip_address=self.ip_address,
-            ip_protocol=self.ip_protocol,
             all_ports=self.all_ports,
             allow_global_access=self.allow_global_access,
             backend_service=self.backend_service,
             creation_timestamp=self.creation_timestamp,
             description=self.description,
             fingerprint=self.fingerprint,
+            ip_address=self.ip_address,
+            ip_protocol=self.ip_protocol,
             ip_version=self.ip_version,
             is_mirroring_collector=self.is_mirroring_collector,
             kind=self.kind,
@@ -462,14 +462,14 @@ def get_global_forwarding_rule(forwarding_rule: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('google-native:compute/v1:getGlobalForwardingRule', __args__, opts=opts, typ=GetGlobalForwardingRuleResult).value
 
     return AwaitableGetGlobalForwardingRuleResult(
-        ip_address=__ret__.ip_address,
-        ip_protocol=__ret__.ip_protocol,
         all_ports=__ret__.all_ports,
         allow_global_access=__ret__.allow_global_access,
         backend_service=__ret__.backend_service,
         creation_timestamp=__ret__.creation_timestamp,
         description=__ret__.description,
         fingerprint=__ret__.fingerprint,
+        ip_address=__ret__.ip_address,
+        ip_protocol=__ret__.ip_protocol,
         ip_version=__ret__.ip_version,
         is_mirroring_collector=__ret__.is_mirroring_collector,
         kind=__ret__.kind,

--- a/sdk/python/pulumi_google_native/compute/v1/global_forwarding_rule.py
+++ b/sdk/python/pulumi_google_native/compute/v1/global_forwarding_rule.py
@@ -17,12 +17,12 @@ __all__ = ['GlobalForwardingRuleArgs', 'GlobalForwardingRule']
 class GlobalForwardingRuleArgs:
     def __init__(__self__, *,
                  project: pulumi.Input[str],
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -40,6 +40,12 @@ class GlobalForwardingRuleArgs:
                  target: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a GlobalForwardingRule resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -55,7 +61,7 @@ class GlobalForwardingRuleArgs:
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['GlobalForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['GlobalForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -65,12 +71,6 @@ class GlobalForwardingRuleArgs:
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['GlobalForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -140,10 +140,6 @@ class GlobalForwardingRuleArgs:
                If the network specified is in auto subnet mode, this field is optional. However, if the network is in custom subnet mode, a subnetwork must be specified.
         """
         pulumi.set(__self__, "project", project)
-        if ip_address is not None:
-            pulumi.set(__self__, "ip_address", ip_address)
-        if ip_protocol is not None:
-            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if all_ports is not None:
             pulumi.set(__self__, "all_ports", all_ports)
         if allow_global_access is not None:
@@ -152,6 +148,10 @@ class GlobalForwardingRuleArgs:
             pulumi.set(__self__, "backend_service", backend_service)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if ip_address is not None:
+            pulumi.set(__self__, "ip_address", ip_address)
+        if ip_protocol is not None:
+            pulumi.set(__self__, "ip_protocol", ip_protocol)
         if ip_version is not None:
             pulumi.set(__self__, "ip_version", ip_version)
         if is_mirroring_collector is not None:
@@ -191,53 +191,6 @@ class GlobalForwardingRuleArgs:
     @project.setter
     def project(self, value: pulumi.Input[str]):
         pulumi.set(self, "project", value)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> Optional[pulumi.Input[str]]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @ip_address.setter
-    def ip_address(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "ip_address", value)
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
-
-    @ip_protocol.setter
-    def ip_protocol(self, value: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']]):
-        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="allPorts")
@@ -288,6 +241,53 @@ class GlobalForwardingRuleArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> Optional[pulumi.Input[str]]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @ip_address.setter
+    def ip_address(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "ip_address", value)
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
+
+    @ip_protocol.setter
+    def ip_protocol(self, value: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']]):
+        pulumi.set(self, "ip_protocol", value)
 
     @property
     @pulumi.getter(name="ipVersion")
@@ -523,12 +523,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -551,6 +551,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
+               
+               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
+        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
+        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
+        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] ip_address: IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
                
                If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
@@ -566,7 +572,7 @@ class GlobalForwardingRule(pulumi.CustomResource):
                Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
                
                For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        :param pulumi.Input['GlobalForwardingRuleIPProtocol'] ip_protocol: The IP protocol to which this rule applies.
+        :param pulumi.Input['GlobalForwardingRuleIpProtocol'] ip_protocol: The IP protocol to which this rule applies.
                
                For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
                
@@ -576,12 +582,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
                - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
                - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
                - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        :param pulumi.Input[bool] all_ports: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
-               
-               When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-        :param pulumi.Input[bool] allow_global_access: This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-        :param pulumi.Input[str] backend_service: Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-        :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input['GlobalForwardingRuleIpVersion'] ip_version: The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
         :param pulumi.Input[bool] is_mirroring_collector: Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
@@ -674,12 +674,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 ip_address: Optional[pulumi.Input[str]] = None,
-                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIPProtocol']] = None,
                  all_ports: Optional[pulumi.Input[bool]] = None,
                  allow_global_access: Optional[pulumi.Input[bool]] = None,
                  backend_service: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 ip_address: Optional[pulumi.Input[str]] = None,
+                 ip_protocol: Optional[pulumi.Input['GlobalForwardingRuleIpProtocol']] = None,
                  ip_version: Optional[pulumi.Input['GlobalForwardingRuleIpVersion']] = None,
                  is_mirroring_collector: Optional[pulumi.Input[bool]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -708,12 +708,12 @@ class GlobalForwardingRule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = GlobalForwardingRuleArgs.__new__(GlobalForwardingRuleArgs)
 
-            __props__.__dict__["ip_address"] = ip_address
-            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["all_ports"] = all_ports
             __props__.__dict__["allow_global_access"] = allow_global_access
             __props__.__dict__["backend_service"] = backend_service
             __props__.__dict__["description"] = description
+            __props__.__dict__["ip_address"] = ip_address
+            __props__.__dict__["ip_protocol"] = ip_protocol
             __props__.__dict__["ip_version"] = ip_version
             __props__.__dict__["is_mirroring_collector"] = is_mirroring_collector
             __props__.__dict__["labels"] = labels
@@ -762,14 +762,14 @@ class GlobalForwardingRule(pulumi.CustomResource):
 
         __props__ = GlobalForwardingRuleArgs.__new__(GlobalForwardingRuleArgs)
 
-        __props__.__dict__["ip_address"] = None
-        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["all_ports"] = None
         __props__.__dict__["allow_global_access"] = None
         __props__.__dict__["backend_service"] = None
         __props__.__dict__["creation_timestamp"] = None
         __props__.__dict__["description"] = None
         __props__.__dict__["fingerprint"] = None
+        __props__.__dict__["ip_address"] = None
+        __props__.__dict__["ip_protocol"] = None
         __props__.__dict__["ip_version"] = None
         __props__.__dict__["is_mirroring_collector"] = None
         __props__.__dict__["kind"] = None
@@ -791,45 +791,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
         __props__.__dict__["subnetwork"] = None
         __props__.__dict__["target"] = None
         return GlobalForwardingRule(resource_name, opts=opts, __props__=__props__)
-
-    @property
-    @pulumi.getter(name="IPAddress")
-    def ip_address(self) -> pulumi.Output[str]:
-        """
-        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
-
-        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
-
-        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
-        - projects/project_id/regions/region/addresses/address-name 
-        - regions/region/addresses/address-name 
-        - global/addresses/address-name 
-        - address-name  
-
-        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-
-        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
-
-        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-        """
-        return pulumi.get(self, "ip_address")
-
-    @property
-    @pulumi.getter(name="IPProtocol")
-    def ip_protocol(self) -> pulumi.Output[str]:
-        """
-        The IP protocol to which this rule applies.
-
-        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
-
-        The valid IP protocols are different for different load balancing products:  
-        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
-        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
-        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
-        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
-        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-        """
-        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="allPorts")
@@ -882,6 +843,45 @@ class GlobalForwardingRule(pulumi.CustomResource):
         To see the latest fingerprint, make a get() request to retrieve a ForwardingRule.
         """
         return pulumi.get(self, "fingerprint")
+
+    @property
+    @pulumi.getter(name="ipAddress")
+    def ip_address(self) -> pulumi.Output[str]:
+        """
+        IP address that this forwarding rule serves. When a client sends traffic to this IP address, the forwarding rule directs the traffic to the target that you specify in the forwarding rule.
+
+        If you don't specify a reserved IP address, an ephemeral IP address is assigned. Methods for specifying an IP address:
+
+        * IPv4 dotted decimal, as in `100.1.2.3` * Full URL, as in https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name * Partial URL or by name, as in:  
+        - projects/project_id/regions/region/addresses/address-name 
+        - regions/region/addresses/address-name 
+        - global/addresses/address-name 
+        - address-name  
+
+        The loadBalancingScheme and the forwarding rule's target determine the type of IP address that you can use. For detailed information, refer to [IP address specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+        Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
+
+        For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
+        """
+        return pulumi.get(self, "ip_address")
+
+    @property
+    @pulumi.getter(name="ipProtocol")
+    def ip_protocol(self) -> pulumi.Output[str]:
+        """
+        The IP protocol to which this rule applies.
+
+        For protocol forwarding, valid options are TCP, UDP, ESP, AH, SCTP and ICMP.
+
+        The valid IP protocols are different for different load balancing products:  
+        - Internal TCP/UDP Load Balancing: The load balancing scheme is INTERNAL, and one of TCP, UDP or ALL is valid. 
+        - Traffic Director: The load balancing scheme is INTERNAL_SELF_MANAGED, and only TCP is valid.  
+        - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid. 
+        - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid. 
+        - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
+        """
+        return pulumi.get(self, "ip_protocol")
 
     @property
     @pulumi.getter(name="ipVersion")

--- a/sdk/python/pulumi_google_native/compute/v1/outputs.py
+++ b/sdk/python/pulumi_google_native/compute/v1/outputs.py
@@ -3999,7 +3999,7 @@ class FirewallAllowedItemResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocol":
+        if key == "ipProtocol":
             suggest = "ip_protocol"
 
         if suggest:
@@ -4026,7 +4026,7 @@ class FirewallAllowedItemResponse(dict):
         pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> str:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -4049,7 +4049,7 @@ class FirewallDeniedItemResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocol":
+        if key == "ipProtocol":
             suggest = "ip_protocol"
 
         if suggest:
@@ -4076,7 +4076,7 @@ class FirewallDeniedItemResponse(dict):
         pulumi.set(__self__, "ports", ports)
 
     @property
-    @pulumi.getter(name="IPProtocol")
+    @pulumi.getter(name="ipProtocol")
     def ip_protocol(self) -> str:
         """
         The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
@@ -9242,10 +9242,10 @@ class PacketMirroringFilterResponse(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "IPProtocols":
-            suggest = "ip_protocols"
-        elif key == "cidrRanges":
+        if key == "cidrRanges":
             suggest = "cidr_ranges"
+        elif key == "ipProtocols":
+            suggest = "ip_protocols"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in PacketMirroringFilterResponse. Access the value via the '{suggest}' property getter instead.")
@@ -9259,25 +9259,17 @@ class PacketMirroringFilterResponse(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
-                 ip_protocols: Sequence[str],
                  cidr_ranges: Sequence[str],
-                 direction: str):
+                 direction: str,
+                 ip_protocols: Sequence[str]):
         """
-        :param Sequence[str] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param Sequence[str] cidr_ranges: IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         :param str direction: Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
+        :param Sequence[str] ip_protocols: Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
         """
-        pulumi.set(__self__, "ip_protocols", ip_protocols)
         pulumi.set(__self__, "cidr_ranges", cidr_ranges)
         pulumi.set(__self__, "direction", direction)
-
-    @property
-    @pulumi.getter(name="IPProtocols")
-    def ip_protocols(self) -> Sequence[str]:
-        """
-        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-        """
-        return pulumi.get(self, "ip_protocols")
+        pulumi.set(__self__, "ip_protocols", ip_protocols)
 
     @property
     @pulumi.getter(name="cidrRanges")
@@ -9294,6 +9286,14 @@ class PacketMirroringFilterResponse(dict):
         Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
         """
         return pulumi.get(self, "direction")
+
+    @property
+    @pulumi.getter(name="ipProtocols")
+    def ip_protocols(self) -> Sequence[str]:
+        """
+        Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
+        """
+        return pulumi.get(self, "ip_protocols")
 
 
 @pulumi.output_type

--- a/sdk/python/pulumi_google_native/storage/v1/get_notification.py
+++ b/sdk/python/pulumi_google_native/storage/v1/get_notification.py
@@ -43,7 +43,7 @@ class GetNotificationResult:
         pulumi.set(__self__, "topic", topic)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="customAttributes")
     def custom_attributes(self) -> Mapping[str, str]:
         """
         An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
@@ -59,7 +59,7 @@ class GetNotificationResult:
         return pulumi.get(self, "etag")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="eventTypes")
     def event_types(self) -> Sequence[str]:
         """
         If present, only send notifications about listed event types. If empty, sent notifications for all event types.
@@ -75,7 +75,7 @@ class GetNotificationResult:
         return pulumi.get(self, "kind")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="objectNamePrefix")
     def object_name_prefix(self) -> str:
         """
         If present, only apply this notification configuration to object names that begin with this prefix.
@@ -83,7 +83,7 @@ class GetNotificationResult:
         return pulumi.get(self, "object_name_prefix")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="payloadFormat")
     def payload_format(self) -> str:
         """
         The desired content of the Payload.

--- a/sdk/python/pulumi_google_native/storage/v1/notification.py
+++ b/sdk/python/pulumi_google_native/storage/v1/notification.py
@@ -71,7 +71,7 @@ class NotificationArgs:
         pulumi.set(self, "bucket", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="customAttributes")
     def custom_attributes(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
         An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
@@ -95,7 +95,7 @@ class NotificationArgs:
         pulumi.set(self, "etag", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="eventTypes")
     def event_types(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
         If present, only send notifications about listed event types. If empty, sent notifications for all event types.
@@ -131,7 +131,7 @@ class NotificationArgs:
         pulumi.set(self, "kind", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="objectNamePrefix")
     def object_name_prefix(self) -> Optional[pulumi.Input[str]]:
         """
         If present, only apply this notification configuration to object names that begin with this prefix.
@@ -143,7 +143,7 @@ class NotificationArgs:
         pulumi.set(self, "object_name_prefix", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="payloadFormat")
     def payload_format(self) -> Optional[pulumi.Input[str]]:
         """
         The desired content of the Payload.
@@ -325,7 +325,7 @@ class Notification(pulumi.CustomResource):
         return Notification(resource_name, opts=opts, __props__=__props__)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="customAttributes")
     def custom_attributes(self) -> pulumi.Output[Mapping[str, str]]:
         """
         An optional list of additional attributes to attach to each Cloud PubSub message published for this notification subscription.
@@ -341,7 +341,7 @@ class Notification(pulumi.CustomResource):
         return pulumi.get(self, "etag")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="eventTypes")
     def event_types(self) -> pulumi.Output[Sequence[str]]:
         """
         If present, only send notifications about listed event types. If empty, sent notifications for all event types.
@@ -357,7 +357,7 @@ class Notification(pulumi.CustomResource):
         return pulumi.get(self, "kind")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="objectNamePrefix")
     def object_name_prefix(self) -> pulumi.Output[str]:
         """
         If present, only apply this notification configuration to object names that begin with this prefix.
@@ -365,7 +365,7 @@ class Notification(pulumi.CustomResource):
         return pulumi.get(self, "object_name_prefix")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="payloadFormat")
     def payload_format(self) -> pulumi.Output[str]:
         """
         The desired content of the Payload.


### PR DESCRIPTION
I noticed that some properties aren't capitalized correctly so I extended our codegen to do so