### PR TITLE
Fix a panic when an array property is updated to a larger number of elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 
 - Update dependencies to pulumi/pulumi 3.7.0
+
 - Refresh credentials for client if backing credentials are expired. [#156](https://github.com/pulumi/pulumi-google-native/pull/156)
 
 - Allow for shorthand property values instead of duplicating project, zone, etc.
@@ -11,6 +12,9 @@ CHANGELOG
 
 - Populate `project`, `location`, `zone` properties automatically from config values
   [#94](https://github.com/pulumi/pulumi-google-native/issues/94)
+
+- Fix a panic when an array property is updated to a larger number of elements
+  [#160](https://github.com/pulumi/pulumi-google-native/issues/160)
 
 ---
 

--- a/provider/pkg/resources/convert.go
+++ b/provider/pkg/resources/convert.go
@@ -65,7 +65,11 @@ func (k *SdkShapeConverter) convertPropValue(prop *CloudAPIProperty, value, stat
 		}
 
 		for i := 0; i < s.Len(); i++ {
-			result = append(result, k.convertPropValue(prop.Items, s.Index(i).Interface(), stateSlice[i], convertMap))
+			var stateItem interface{}
+			if len(stateSlice) > i {
+				stateItem = stateSlice[i]
+			}
+			result = append(result, k.convertPropValue(prop.Items, s.Index(i).Interface(), stateItem, convertMap))
 		}
 		return result
 	}

--- a/provider/pkg/resources/convert_test.go
+++ b/provider/pkg/resources/convert_test.go
@@ -206,6 +206,42 @@ func TestSdkPropertiesToRequestBody(t *testing.T) {
 	assert.Equal(t, sampleAPIPackage, data)
 }
 
+func TestSdkPropertiesToRequestBodyWithState(t *testing.T) {
+	// State has fewer elements in collections and different values to test
+	// that converter is prepared for this kind of changes.
+	state := map[string]interface{}{
+		"name":      "MyResource",
+		"threshold": 456,
+		"structure": map[string]interface{}{
+			"v1": "value1old",
+			"v4": false,
+		},
+		"p1": "prop1old",
+		"p2": "prop2old",
+		"p3": "prop3old",
+		"more": map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{"bbb": "333"},
+			},
+			"itemsMap": map[string]interface{}{
+				"key1": map[string]interface{}{"Aaa": "444"},
+			},
+		},
+		"tags": map[string]interface{}{
+			"application": "another",
+		},
+		"untypedArray": []interface{}{
+			map[string]interface{}{"key1": "value2"},
+		},
+		"untypedDict": map[string]interface{}{
+			"key1": "value1",
+		},
+	}
+	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	data := c.SdkPropertiesToRequestBody(bodyProperties, sampleSdkProps, state)
+	assert.Equal(t, sampleAPIPackage, data)
+}
+
 func TestSdkPropertiesToRequestBodyEmptyCollections(t *testing.T) {
 	var emptyCollectionData = map[string]interface{}{
 		"more": map[string]interface{}{


### PR DESCRIPTION
Fix the panic in https://github.com/pulumi/pulumi-google-native/issues/160

It doesn't really fix the scenario though because the next error I get is 

```
error sending request: googleapi: Error 400: Invalid value for field 'resource': 
'{  "name": "bla-4a6a8c1",  "description": "Edge Security Policy",  "rule": [{    
"priority": 1000,  ...'. Rules cannot be updated with patch, please use addRule, 
removeRule, or patchRule instead., invalid: "https://www.googleapis.com/compute/beta/projects/pulumi-development/global/securityPolicies/bla-4a6a8c1" 
map[description:Edge Security Policy fingerprint:CSn77VRIOVI= labelFingerprint:42WmSpB8rSM= name:bla-4a6a8c1 rules:[map[action:allow match:map[config:map[srcIpRanges:[0.0.0.0 1.1.1.1]] versionedExpr:SRC_IPS_V1] priority:1000] map[action:deny(403) match:map[config:map[srcIpRanges:[*]] versionedExpr:SRC_IPS_V1] priority:2.147483647e+09]] type:CLOUD_ARMOR_EDGE]
```

but that's another story.