### PR TITLE
Improve replacement detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ CHANGELOG
 ## HEAD (Unreleased)
 
 - Use the appropriate HTTP verbs for invokes [#175](https://github.com/pulumi/pulumi-google-native/pull/175)
+
 - Avoid resetting project IAM policy on deletion [#175](https://github.com/pulumi/pulumi-google-native/pull/175)
+
+- Improve replacement detection [#181](https://github.com/pulumi/pulumi-google-native/pull/181)
 
 ## 0.6.0 (2021-07-24)
 


### PR DESCRIPTION
Improves the logic for replacement detection. Use cases that I tested it with:

- A new property is added to the resource definition that should cause a replacement
- A property is deleted from the resource definition that should cause a replacement
- A property SDK name doesn't match its API name
- A property that is a part of a resource ID is changed (a URL parameter)

It also touched the default value calculation for the last use case above. Fix #170 