### PR TITLE
Disable response body dump

### DIFF
--- a/examples/gke-ts/index.ts
+++ b/examples/gke-ts/index.ts
@@ -3,7 +3,7 @@
 import * as google from "@pulumi/google-native";
 
 // TODO: Determine this dynamically once https://github.com/pulumi/pulumi-google-native/issues/166 is done.
-const engineVersion = "1.20.9-gke.1001";
+const engineVersion = "1.20.10-gke.1600";
 
 const nodeConfig: google.types.input.container.v1.NodeConfigArgs = {
     machineType: "n1-standard-2",

--- a/provider/pkg/googleclient/http.go
+++ b/provider/pkg/googleclient/http.go
@@ -111,7 +111,9 @@ func (c *GoogleClient) RequestWithTimeout(method, rawurl string, body map[string
 		return nil, err
 	}
 
-	debugResp, _ := httputil.DumpResponse(res, true)
+	// TODO: Re-enable response dump when https://github.com/golang/go/issues/49366 fix
+	// propagates to our current Go version.
+	debugResp, _ := httputil.DumpResponse(res, false)
 	logging.V(9).Infof(responseFormat, res.Request.Method, res.Request.URL, prettyPrintJsonLines(debugResp))
 
 	if err := googleapi.CheckResponse(res); err != nil {
@@ -191,7 +193,9 @@ func (c *GoogleClient) UploadWithTimeout(method, rawurl string, metadata map[str
 		return nil, err
 	}
 
-	debugResp, _ := httputil.DumpResponse(res, true)
+	// TODO: Re-enable response dump when https://github.com/golang/go/issues/49366 fix
+	// propagates to our current Go version.
+	debugResp, _ := httputil.DumpResponse(res, false)
 	logging.V(9).Infof(responseFormat, res.Request.Method, res.Request.URL, prettyPrintJsonLines(debugResp))
 
 	if err := googleapi.CheckResponse(res); err != nil {


### PR DESCRIPTION
Fix #234 (well, rather work around it with a temporary measure)

It turns out that the build failure was caused by CI updating to Go 1.16.10 (from 1.16.9) which shipped a breaking bug https://github.com/golang/go/issues/49366 That bug makes `httputil.DumpResponse` fail for HTTP/2 responses.

In the spirit of the simplest possible fix of P1, I've disabled dumping the response for now. It looks like they want to backport the fix to 1.16.11 - so we can probably wait for that one to release. Tracked in https://github.com/golang/go/issues/49558