### PR TITLE
Disable unconditional replaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ CHANGELOG
 
 Bug fixes:
 
-- Disable unconditional replaces
+- Disable unconditional replaces. No replaces will be triggered by the provider
+  at this time. Use the `replaceOnChanges` resource option to trigger a
+  replacement operation manually.
   [#185](https://github.com/pulumi/pulumi-google-native/issues/185)
 
 ## 0.9.0 (2021-11-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-(None)
+Bug fixes:
+
+- Disable unconditional replaces
+  [#185](https://github.com/pulumi/pulumi-google-native/issues/185)
 
 ## 0.9.0 (2021-11-24)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -322,7 +322,7 @@ func (p *googleCloudProvider) Diff(_ context.Context, req *rpc.DiffRequest) (*rp
 	logging.V(9).Infof("%s executing", label)
 
 	resourceKey := string(urn.Type())
-	res, ok := p.resourceMap.Resources[resourceKey]
+	_, ok := p.resourceMap.Resources[resourceKey]
 	if !ok {
 		return nil, errors.Errorf("resource %q not found", resourceKey)
 	}
@@ -353,32 +353,7 @@ func (p *googleCloudProvider) Diff(_ context.Context, req *rpc.DiffRequest) (*rp
 		return &rpc.DiffResponse{Changes: rpc.DiffResponse_DIFF_NONE}, nil
 	}
 
-	var replaces []string
-	for _, p := range res.CreateParams {
-		sdkName := p.Name
-		if p.SdkName != "" {
-			sdkName = p.SdkName
-		}
-		replaces = append(replaces, sdkName)
-	}
-	for name, prop := range res.CreateProperties {
-		if _, has := res.UpdateProperties[name]; !has {
-			sdkName := name
-			if prop.SdkName != "" {
-				sdkName = prop.SdkName
-			}
-			replaces = append(replaces, sdkName)
-		}
-	}
-
-	// Uploads are only supported for create methods, not updates.
-	if res.AssetUpload {
-		if _, ok := diff.Updates[resource.PropertyKey("source")]; ok {
-			replaces = append(replaces, "source")
-		}
-	}
-
-	return &rpc.DiffResponse{Changes: rpc.DiffResponse_DIFF_UNKNOWN, Replaces: replaces, DeleteBeforeReplace: true}, nil
+	return &rpc.DiffResponse{Changes: rpc.DiffResponse_DIFF_UNKNOWN, DeleteBeforeReplace: true}, nil
 }
 
 // Create allocates a new instance of the provided resource and returns its unique ID afterwards.


### PR DESCRIPTION
It is semantically wrong to statically populate the `Replaces` property of a Diff response with all the properties that require replacement for a given resource type. This PR removes this, which means we will detect _no_ replacements. I think this is a better type of error than unneeded replacements. 

Similar to https://github.com/pulumi/pulumi-aws-native/pull/205

Fix #185
Fix #217
Fix #232
Fix #243