### PR TITLE
Workflow to update pulumi/pulumi automatically

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,0 +1,74 @@
+name: weekly-pulumi-update
+"on":
+  pull_request:
+    branches:
+      - master
+#  schedule:
+#    - cron: 35 12 * * 4
+  workflow_dispatch: {}
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+jobs:
+  update-go-mod:
+    name: Update Go mods
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goversion: [1.17.x]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.goversion }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/setup-pulumi@v2
+      - name: Preparing Git Branch
+        run: |
+          git config --local user.email "bot@pulumi.com"
+          git config --local user.name "pulumi-bot"
+          git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
+      - name: Update pulumi/pulumi
+        id: gomod
+        run: |
+          cd provider
+          go get github.com/pulumi/pulumi/pkg/v3
+          go get github.com/pulumi/pulumi/sdk/v3
+          go mod download
+          go mod tidy
+          cd ..
+          git update-index -q --refresh
+          if ! git diff-files --quiet; then
+            echo ::set-output name=changes::1
+          fi
+      - name: Build codegen binaries
+        if: steps.gomod.outputs.changes != 0
+        run: make codegen
+      - name: Build Schema + SDKs
+        if: steps.gomod.outputs.changes != 0
+        run: make local_generate
+      - name: Commit changes
+        if: steps.gomod.outputs.changes != 0
+        run: |
+          git add .
+          git commit -m "Regenerating SDK based on updated modules
+          git push origin update-pulumi/${{ github.run_id }}-${{ github.run_number }}
+      - name: Open a pull request
+        if: steps.gomod.outputs.changes != 0
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "update-pulumi/${{ github.run_id }}-${{ github.run_number }}"
+          destination_branch: "master"
+          pr_title: "Automated pulumi/pulumi"
+          pr_label: "automation/merge"
+          pr_allow_empty: true
+          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.gomod.outputs.changes != 0
         run: |
           git add .
-          git commit -m "Regenerating SDK based on updated modules
+          git commit -m "Regenerating SDK based on updated modules"
           git push origin update-pulumi/${{ github.run_id }}-${{ github.run_number }}
       - name: Open a pull request
         if: steps.gomod.outputs.changes != 0

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,10 +1,7 @@
 name: weekly-pulumi-update
 "on":
-  pull_request:
-    branches:
-      - master
-#  schedule:
-#    - cron: 35 12 * * 4
+  schedule:
+    - cron: 35 12 * * 4
   workflow_dispatch: {}
 
 env:
@@ -68,7 +65,7 @@ jobs:
         with:
           source_branch: "update-pulumi/${{ github.run_id }}-${{ github.run_number }}"
           destination_branch: "master"
-          pr_title: "Automated pulumi/pulumi"
+          pr_title: "Automated pulumi/pulumi upgrade"
           pr_label: "automation/merge"
           pr_allow_empty: true
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -56,8 +56,16 @@ jobs:
       - name: Commit changes
         if: steps.gomod.outputs.changes != 0
         run: |
+          git add sdk/nodejs
+          git commit -m "Regenerating Node.js SDK based on updated modules"
+          git add sdk/python
+          git commit -m "Regenerating Python SDK based on updated modules"
+          git add sdk/dotnet
+          git commit -m "Regenerating .NET SDK based on updated modules"
+          git add sdk/go
+          git commit -m "Regenerating Go SDK based on updated modules"
           git add .
-          git commit -m "Regenerating SDK based on updated modules"
+          git commit -m "Updated modules"
           git push origin update-pulumi/${{ github.run_id }}-${{ github.run_number }}
       - name: Open a pull request
         if: steps.gomod.outputs.changes != 0


### PR DESCRIPTION
 Automation hook that would open PR in native providers on every pulumi/pulumi release. For starters, it runs every week (on Thursday - I think we release pulumi on Wed), pulls the latest Go mod and opens a PR if there is any change.

Sample run: https://github.com/pulumi/pulumi-google-native/runs/4593367718?check_suite_focus=true
Sample PR: https://github.com/pulumi/pulumi-google-native/pull/262

If accepted, I'll add the same file to all other native providers.