### PR TITLE
Fix naming of projectId property on the Project resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Fix Project resource projectId property in SDKs.
 
 ## 0.10.1 (2021-12-22)
 Bug fixes:

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,13 @@ generate_schema::
 	echo "Finished generating schema."
 
 codegen::
-	(cd provider && go build -a -o $(WORKING_DIR)/bin/$(CODEGEN) $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(CODEGEN))
+	(cd provider && go build -o $(WORKING_DIR)/bin/$(CODEGEN) $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(CODEGEN))
 
 provider::
-	(cd provider && go build -a -o $(WORKING_DIR)/bin/$(PROVIDER) $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(PROVIDER))
+	(cd provider && go build -o $(WORKING_DIR)/bin/$(PROVIDER) $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(PROVIDER))
+
+debug_provider::
+	(cd provider && go install -gcflags="all=-N -l" $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(PROVIDER))
 
 test_provider::
 	(cd provider && go test -v $(PROVIDER_PKGS))

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -744,7 +744,7 @@ func (g *packageGenerator) genProperties(typeName string, typeSchema *discovery.
 	}
 	for _, name := range codegen.SortedKeys(typeSchema.Properties) {
 		value := typeSchema.Properties[name]
-		sdkName := apiPropNameToSdkName(name)
+		sdkName := apiPropNameToSdkName(typeName, name)
 
 		if isDeprecated(value.Description) {
 			continue

--- a/provider/pkg/gen/utilities.go
+++ b/provider/pkg/gen/utilities.go
@@ -4,12 +4,13 @@ package gen
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/gedex/inflector"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"regexp"
-	"strings"
 )
 
 var s = codegen.NewStringSet()
@@ -33,7 +34,10 @@ func apiParamNameToSdkName(name string) string {
 
 // apiPropNameToSdkName returns an SDK name for a given API property name.
 // In particular, it converts pluralized ID names to singular ID names.
-func apiPropNameToSdkName(name string) string {
+func apiPropNameToSdkName(typeName string, name string) string {
+	if typeName == "Project" && name == "projectId" {
+		return name
+	}
 	switch name {
 	case "projectId", "locationId", "managedZoneId", "zoneId":
 		return name[:len(name)-2]

--- a/provider/pkg/gen/utilities_test.go
+++ b/provider/pkg/gen/utilities_test.go
@@ -40,7 +40,7 @@ var apiPropToSdkNames = map[string]string{
 
 func TestApiPropNameToSdkName(t *testing.T) {
 	for name, expected := range apiPropToSdkNames {
-		actual := apiPropNameToSdkName(name)
+		actual := apiPropNameToSdkName("typeName", name)
 		assert.Equal(t, expected, actual)
 	}
 }

--- a/provider/pkg/gen/utilities_test.go
+++ b/provider/pkg/gen/utilities_test.go
@@ -43,6 +43,8 @@ func TestApiPropNameToSdkName(t *testing.T) {
 		actual := apiPropNameToSdkName("typeName", name)
 		assert.Equal(t, expected, actual)
 	}
+
+	assert.Equal(t, "projectId", apiPropNameToSdkName("Project", "projectId"))
 }
 
 var namePropertyPatternsValid = map[string]string{

--- a/sdk/dotnet/CloudResourceManager/V1/GetProject.cs
+++ b/sdk/dotnet/CloudResourceManager/V1/GetProject.cs
@@ -73,7 +73,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1
         /// <summary>
         /// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         /// </summary>
-        public readonly string Project;
+        public readonly string ProjectId;
         /// <summary>
         /// The number uniquely identifying the project. Example: `415104041262` Read-only.
         /// </summary>
@@ -91,7 +91,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1
 
             Outputs.ResourceIdResponse parent,
 
-            string project,
+            string projectId,
 
             string projectNumber)
         {
@@ -100,7 +100,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1
             LifecycleState = lifecycleState;
             Name = name;
             Parent = parent;
-            Project = project;
+            ProjectId = projectId;
             ProjectNumber = projectNumber;
         }
     }

--- a/sdk/dotnet/CloudResourceManager/V1/Project.cs
+++ b/sdk/dotnet/CloudResourceManager/V1/Project.cs
@@ -48,8 +48,8 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1
         /// <summary>
         /// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         /// </summary>
-        [Output("project")]
-        public Output<string> ProjectValue { get; private set; } = null!;
+        [Output("projectId")]
+        public Output<string> ProjectId { get; private set; } = null!;
 
         /// <summary>
         /// The number uniquely identifying the project. Example: `415104041262` Read-only.
@@ -141,8 +141,8 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1
         /// <summary>
         /// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         /// </summary>
-        [Input("project")]
-        public Input<string>? Project { get; set; }
+        [Input("projectId")]
+        public Input<string>? ProjectId { get; set; }
 
         /// <summary>
         /// The number uniquely identifying the project. Example: `415104041262` Read-only.

--- a/sdk/dotnet/CloudResourceManager/V1Beta1/GetProject.cs
+++ b/sdk/dotnet/CloudResourceManager/V1Beta1/GetProject.cs
@@ -73,7 +73,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1Beta1
         /// <summary>
         /// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         /// </summary>
-        public readonly string Project;
+        public readonly string ProjectId;
         /// <summary>
         /// The number uniquely identifying the project. Example: `415104041262` Read-only.
         /// </summary>
@@ -91,7 +91,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1Beta1
 
             Outputs.ResourceIdResponse parent,
 
-            string project,
+            string projectId,
 
             string projectNumber)
         {
@@ -100,7 +100,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1Beta1
             LifecycleState = lifecycleState;
             Name = name;
             Parent = parent;
-            Project = project;
+            ProjectId = projectId;
             ProjectNumber = projectNumber;
         }
     }

--- a/sdk/dotnet/CloudResourceManager/V1Beta1/Project.cs
+++ b/sdk/dotnet/CloudResourceManager/V1Beta1/Project.cs
@@ -48,8 +48,8 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1Beta1
         /// <summary>
         /// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         /// </summary>
-        [Output("project")]
-        public Output<string> ProjectValue { get; private set; } = null!;
+        [Output("projectId")]
+        public Output<string> ProjectId { get; private set; } = null!;
 
         /// <summary>
         /// The number uniquely identifying the project. Example: `415104041262` Read-only.
@@ -141,8 +141,8 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V1Beta1
         /// <summary>
         /// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         /// </summary>
-        [Input("project")]
-        public Input<string>? Project { get; set; }
+        [Input("projectId")]
+        public Input<string>? ProjectId { get; set; }
 
         /// <summary>
         /// The number uniquely identifying the project. Example: `415104041262` Read-only.

--- a/sdk/dotnet/CloudResourceManager/V3/GetProject.cs
+++ b/sdk/dotnet/CloudResourceManager/V3/GetProject.cs
@@ -81,7 +81,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
         /// <summary>
         /// Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         /// </summary>
-        public readonly string Project;
+        public readonly string ProjectId;
         /// <summary>
         /// The project lifecycle state.
         /// </summary>
@@ -107,7 +107,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
 
             string parent,
 
-            string project,
+            string projectId,
 
             string state,
 
@@ -120,7 +120,7 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
             Labels = labels;
             Name = name;
             Parent = parent;
-            Project = project;
+            ProjectId = projectId;
             State = state;
             UpdateTime = updateTime;
         }

--- a/sdk/dotnet/CloudResourceManager/V3/Project.cs
+++ b/sdk/dotnet/CloudResourceManager/V3/Project.cs
@@ -61,8 +61,8 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
         /// <summary>
         /// Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         /// </summary>
-        [Output("project")]
-        public Output<string> ProjectValue { get; private set; } = null!;
+        [Output("projectId")]
+        public Output<string> ProjectId { get; private set; } = null!;
 
         /// <summary>
         /// The project lifecycle state.
@@ -148,8 +148,8 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
         /// <summary>
         /// Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         /// </summary>
-        [Input("project")]
-        public Input<string>? Project { get; set; }
+        [Input("projectId")]
+        public Input<string>? ProjectId { get; set; }
 
         public ProjectArgs()
         {

--- a/sdk/go/google/cloudresourcemanager/v1/getProject.go
+++ b/sdk/go/google/cloudresourcemanager/v1/getProject.go
@@ -36,7 +36,7 @@ type LookupProjectResult struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent.
 	Parent ResourceIdResponse `pulumi:"parent"`
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project string `pulumi:"project"`
+	ProjectId string `pulumi:"projectId"`
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber string `pulumi:"projectNumber"`
 }
@@ -98,8 +98,8 @@ func (o LookupProjectResultOutput) Parent() ResourceIdResponseOutput {
 }
 
 // The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-func (o LookupProjectResultOutput) Project() pulumi.StringOutput {
-	return o.ApplyT(func(v LookupProjectResult) string { return v.Project }).(pulumi.StringOutput)
+func (o LookupProjectResultOutput) ProjectId() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupProjectResult) string { return v.ProjectId }).(pulumi.StringOutput)
 }
 
 // The number uniquely identifying the project. Example: `415104041262` Read-only.

--- a/sdk/go/google/cloudresourcemanager/v1/project.go
+++ b/sdk/go/google/cloudresourcemanager/v1/project.go
@@ -25,7 +25,7 @@ type Project struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent.
 	Parent ResourceIdResponseOutput `pulumi:"parent"`
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project pulumi.StringOutput `pulumi:"project"`
+	ProjectId pulumi.StringOutput `pulumi:"projectId"`
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber pulumi.StringOutput `pulumi:"projectNumber"`
 }
@@ -80,7 +80,7 @@ type projectArgs struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent.
 	Parent *ResourceId `pulumi:"parent"`
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project *string `pulumi:"project"`
+	ProjectId *string `pulumi:"projectId"`
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber *string `pulumi:"projectNumber"`
 }
@@ -98,7 +98,7 @@ type ProjectArgs struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent.
 	Parent ResourceIdPtrInput
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project pulumi.StringPtrInput
+	ProjectId pulumi.StringPtrInput
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber pulumi.StringPtrInput
 }

--- a/sdk/go/google/cloudresourcemanager/v1beta1/getProject.go
+++ b/sdk/go/google/cloudresourcemanager/v1beta1/getProject.go
@@ -36,7 +36,7 @@ type LookupProjectResult struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent. Read-write.
 	Parent ResourceIdResponse `pulumi:"parent"`
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project string `pulumi:"project"`
+	ProjectId string `pulumi:"projectId"`
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber string `pulumi:"projectNumber"`
 }
@@ -98,8 +98,8 @@ func (o LookupProjectResultOutput) Parent() ResourceIdResponseOutput {
 }
 
 // The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-func (o LookupProjectResultOutput) Project() pulumi.StringOutput {
-	return o.ApplyT(func(v LookupProjectResult) string { return v.Project }).(pulumi.StringOutput)
+func (o LookupProjectResultOutput) ProjectId() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupProjectResult) string { return v.ProjectId }).(pulumi.StringOutput)
 }
 
 // The number uniquely identifying the project. Example: `415104041262` Read-only.

--- a/sdk/go/google/cloudresourcemanager/v1beta1/project.go
+++ b/sdk/go/google/cloudresourcemanager/v1beta1/project.go
@@ -25,7 +25,7 @@ type Project struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent. Read-write.
 	Parent ResourceIdResponseOutput `pulumi:"parent"`
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project pulumi.StringOutput `pulumi:"project"`
+	ProjectId pulumi.StringOutput `pulumi:"projectId"`
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber pulumi.StringOutput `pulumi:"projectNumber"`
 }
@@ -80,7 +80,7 @@ type projectArgs struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent. Read-write.
 	Parent *ResourceId `pulumi:"parent"`
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project *string `pulumi:"project"`
+	ProjectId *string `pulumi:"projectId"`
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber  *string `pulumi:"projectNumber"`
 	UseLegacyStack *string `pulumi:"useLegacyStack"`
@@ -99,7 +99,7 @@ type ProjectArgs struct {
 	// An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent. Read-write.
 	Parent ResourceIdPtrInput
 	// The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
-	Project pulumi.StringPtrInput
+	ProjectId pulumi.StringPtrInput
 	// The number uniquely identifying the project. Example: `415104041262` Read-only.
 	ProjectNumber  pulumi.StringPtrInput
 	UseLegacyStack pulumi.StringPtrInput

--- a/sdk/go/google/cloudresourcemanager/v3/getProject.go
+++ b/sdk/go/google/cloudresourcemanager/v3/getProject.go
@@ -40,7 +40,7 @@ type LookupProjectResult struct {
 	// Optional. A reference to a parent Resource. eg., `organizations/123` or `folders/876`.
 	Parent string `pulumi:"parent"`
 	// Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
-	Project string `pulumi:"project"`
+	ProjectId string `pulumi:"projectId"`
 	// The project lifecycle state.
 	State string `pulumi:"state"`
 	// The most recent time this resource was modified.
@@ -114,8 +114,8 @@ func (o LookupProjectResultOutput) Parent() pulumi.StringOutput {
 }
 
 // Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
-func (o LookupProjectResultOutput) Project() pulumi.StringOutput {
-	return o.ApplyT(func(v LookupProjectResult) string { return v.Project }).(pulumi.StringOutput)
+func (o LookupProjectResultOutput) ProjectId() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupProjectResult) string { return v.ProjectId }).(pulumi.StringOutput)
 }
 
 // The project lifecycle state.

--- a/sdk/go/google/cloudresourcemanager/v3/project.go
+++ b/sdk/go/google/cloudresourcemanager/v3/project.go
@@ -30,7 +30,7 @@ type Project struct {
 	// Optional. A reference to a parent Resource. eg., `organizations/123` or `folders/876`.
 	Parent pulumi.StringOutput `pulumi:"parent"`
 	// Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
-	Project pulumi.StringOutput `pulumi:"project"`
+	ProjectId pulumi.StringOutput `pulumi:"projectId"`
 	// The project lifecycle state.
 	State pulumi.StringOutput `pulumi:"state"`
 	// The most recent time this resource was modified.
@@ -83,7 +83,7 @@ type projectArgs struct {
 	// Optional. A reference to a parent Resource. eg., `organizations/123` or `folders/876`.
 	Parent *string `pulumi:"parent"`
 	// Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
-	Project *string `pulumi:"project"`
+	ProjectId *string `pulumi:"projectId"`
 }
 
 // The set of arguments for constructing a Project resource.
@@ -95,7 +95,7 @@ type ProjectArgs struct {
 	// Optional. A reference to a parent Resource. eg., `organizations/123` or `folders/876`.
 	Parent pulumi.StringPtrInput
 	// Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
-	Project pulumi.StringPtrInput
+	ProjectId pulumi.StringPtrInput
 }
 
 func (ProjectArgs) ElementType() reflect.Type {

--- a/sdk/nodejs/cloudresourcemanager/v1/getProject.ts
+++ b/sdk/nodejs/cloudresourcemanager/v1/getProject.ts
@@ -50,7 +50,7 @@ export interface GetProjectResult {
     /**
      * The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
      */
-    readonly project: string;
+    readonly projectId: string;
     /**
      * The number uniquely identifying the project. Example: `415104041262` Read-only.
      */

--- a/sdk/nodejs/cloudresourcemanager/v1/project.ts
+++ b/sdk/nodejs/cloudresourcemanager/v1/project.ts
@@ -58,7 +58,7 @@ export class Project extends pulumi.CustomResource {
     /**
      * The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
      */
-    public readonly project!: pulumi.Output<string>;
+    public readonly projectId!: pulumi.Output<string>;
     /**
      * The number uniquely identifying the project. Example: `415104041262` Read-only.
      */
@@ -80,7 +80,7 @@ export class Project extends pulumi.CustomResource {
             resourceInputs["lifecycleState"] = args ? args.lifecycleState : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["parent"] = args ? args.parent : undefined;
-            resourceInputs["project"] = args ? args.project : undefined;
+            resourceInputs["projectId"] = args ? args.projectId : undefined;
             resourceInputs["projectNumber"] = args ? args.projectNumber : undefined;
         } else {
             resourceInputs["createTime"] = undefined /*out*/;
@@ -88,7 +88,7 @@ export class Project extends pulumi.CustomResource {
             resourceInputs["lifecycleState"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["parent"] = undefined /*out*/;
-            resourceInputs["project"] = undefined /*out*/;
+            resourceInputs["projectId"] = undefined /*out*/;
             resourceInputs["projectNumber"] = undefined /*out*/;
         }
         if (!opts.version) {
@@ -125,7 +125,7 @@ export interface ProjectArgs {
     /**
      * The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
      */
-    project?: pulumi.Input<string>;
+    projectId?: pulumi.Input<string>;
     /**
      * The number uniquely identifying the project. Example: `415104041262` Read-only.
      */

--- a/sdk/nodejs/cloudresourcemanager/v1beta1/getProject.ts
+++ b/sdk/nodejs/cloudresourcemanager/v1beta1/getProject.ts
@@ -50,7 +50,7 @@ export interface GetProjectResult {
     /**
      * The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
      */
-    readonly project: string;
+    readonly projectId: string;
     /**
      * The number uniquely identifying the project. Example: `415104041262` Read-only.
      */

--- a/sdk/nodejs/cloudresourcemanager/v1beta1/project.ts
+++ b/sdk/nodejs/cloudresourcemanager/v1beta1/project.ts
@@ -58,7 +58,7 @@ export class Project extends pulumi.CustomResource {
     /**
      * The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
      */
-    public readonly project!: pulumi.Output<string>;
+    public readonly projectId!: pulumi.Output<string>;
     /**
      * The number uniquely identifying the project. Example: `415104041262` Read-only.
      */
@@ -80,7 +80,7 @@ export class Project extends pulumi.CustomResource {
             resourceInputs["lifecycleState"] = args ? args.lifecycleState : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["parent"] = args ? args.parent : undefined;
-            resourceInputs["project"] = args ? args.project : undefined;
+            resourceInputs["projectId"] = args ? args.projectId : undefined;
             resourceInputs["projectNumber"] = args ? args.projectNumber : undefined;
             resourceInputs["useLegacyStack"] = args ? args.useLegacyStack : undefined;
         } else {
@@ -89,7 +89,7 @@ export class Project extends pulumi.CustomResource {
             resourceInputs["lifecycleState"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["parent"] = undefined /*out*/;
-            resourceInputs["project"] = undefined /*out*/;
+            resourceInputs["projectId"] = undefined /*out*/;
             resourceInputs["projectNumber"] = undefined /*out*/;
         }
         if (!opts.version) {
@@ -126,7 +126,7 @@ export interface ProjectArgs {
     /**
      * The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
      */
-    project?: pulumi.Input<string>;
+    projectId?: pulumi.Input<string>;
     /**
      * The number uniquely identifying the project. Example: `415104041262` Read-only.
      */

--- a/sdk/nodejs/cloudresourcemanager/v3/getProject.ts
+++ b/sdk/nodejs/cloudresourcemanager/v3/getProject.ts
@@ -57,7 +57,7 @@ export interface GetProjectResult {
     /**
      * Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
      */
-    readonly project: string;
+    readonly projectId: string;
     /**
      * The project lifecycle state.
      */

--- a/sdk/nodejs/cloudresourcemanager/v3/project.ts
+++ b/sdk/nodejs/cloudresourcemanager/v3/project.ts
@@ -66,7 +66,7 @@ export class Project extends pulumi.CustomResource {
     /**
      * Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
      */
-    public readonly project!: pulumi.Output<string>;
+    public readonly projectId!: pulumi.Output<string>;
     /**
      * The project lifecycle state.
      */
@@ -90,7 +90,7 @@ export class Project extends pulumi.CustomResource {
             resourceInputs["displayName"] = args ? args.displayName : undefined;
             resourceInputs["labels"] = args ? args.labels : undefined;
             resourceInputs["parent"] = args ? args.parent : undefined;
-            resourceInputs["project"] = args ? args.project : undefined;
+            resourceInputs["projectId"] = args ? args.projectId : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["deleteTime"] = undefined /*out*/;
             resourceInputs["etag"] = undefined /*out*/;
@@ -105,7 +105,7 @@ export class Project extends pulumi.CustomResource {
             resourceInputs["labels"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["parent"] = undefined /*out*/;
-            resourceInputs["project"] = undefined /*out*/;
+            resourceInputs["projectId"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
         }
@@ -135,5 +135,5 @@ export interface ProjectArgs {
     /**
      * Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
      */
-    project?: pulumi.Input<string>;
+    projectId?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v1/get_project.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v1/get_project.py
@@ -18,7 +18,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetProjectResult:
-    def __init__(__self__, create_time=None, labels=None, lifecycle_state=None, name=None, parent=None, project=None, project_number=None):
+    def __init__(__self__, create_time=None, labels=None, lifecycle_state=None, name=None, parent=None, project_id=None, project_number=None):
         if create_time and not isinstance(create_time, str):
             raise TypeError("Expected argument 'create_time' to be a str")
         pulumi.set(__self__, "create_time", create_time)
@@ -34,9 +34,9 @@ class GetProjectResult:
         if parent and not isinstance(parent, dict):
             raise TypeError("Expected argument 'parent' to be a dict")
         pulumi.set(__self__, "parent", parent)
-        if project and not isinstance(project, str):
-            raise TypeError("Expected argument 'project' to be a str")
-        pulumi.set(__self__, "project", project)
+        if project_id and not isinstance(project_id, str):
+            raise TypeError("Expected argument 'project_id' to be a str")
+        pulumi.set(__self__, "project_id", project_id)
         if project_number and not isinstance(project_number, str):
             raise TypeError("Expected argument 'project_number' to be a str")
         pulumi.set(__self__, "project_number", project_number)
@@ -82,12 +82,12 @@ class GetProjectResult:
         return pulumi.get(self, "parent")
 
     @property
-    @pulumi.getter
-    def project(self) -> str:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> str:
         """
         The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
     @property
     @pulumi.getter(name="projectNumber")
@@ -109,7 +109,7 @@ class AwaitableGetProjectResult(GetProjectResult):
             lifecycle_state=self.lifecycle_state,
             name=self.name,
             parent=self.parent,
-            project=self.project,
+            project_id=self.project_id,
             project_number=self.project_number)
 
 
@@ -132,7 +132,7 @@ def get_project(project: Optional[str] = None,
         lifecycle_state=__ret__.lifecycle_state,
         name=__ret__.name,
         parent=__ret__.parent,
-        project=__ret__.project,
+        project_id=__ret__.project_id,
         project_number=__ret__.project_number)
 
 

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v1/project.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v1/project.py
@@ -21,7 +21,7 @@ class ProjectArgs:
                  lifecycle_state: Optional[pulumi.Input['ProjectLifecycleState']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input['ResourceIdArgs']] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  project_number: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Project resource.
@@ -30,7 +30,7 @@ class ProjectArgs:
         :param pulumi.Input['ProjectLifecycleState'] lifecycle_state: The Project lifecycle state. Read-only.
         :param pulumi.Input[str] name: The optional user-assigned display name of the Project. When present it must be between 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: `My Project` Read-write.
         :param pulumi.Input['ResourceIdArgs'] parent: An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent.
-        :param pulumi.Input[str] project: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
+        :param pulumi.Input[str] project_id: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         :param pulumi.Input[str] project_number: The number uniquely identifying the project. Example: `415104041262` Read-only.
         """
         if create_time is not None:
@@ -43,8 +43,8 @@ class ProjectArgs:
             pulumi.set(__self__, "name", name)
         if parent is not None:
             pulumi.set(__self__, "parent", parent)
-        if project is not None:
-            pulumi.set(__self__, "project", project)
+        if project_id is not None:
+            pulumi.set(__self__, "project_id", project_id)
         if project_number is not None:
             pulumi.set(__self__, "project_number", project_number)
 
@@ -109,16 +109,16 @@ class ProjectArgs:
         pulumi.set(self, "parent", value)
 
     @property
-    @pulumi.getter
-    def project(self) -> Optional[pulumi.Input[str]]:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> Optional[pulumi.Input[str]]:
         """
         The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
-    @project.setter
-    def project(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "project", value)
+    @project_id.setter
+    def project_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "project_id", value)
 
     @property
     @pulumi.getter(name="projectNumber")
@@ -143,7 +143,7 @@ class Project(pulumi.CustomResource):
                  lifecycle_state: Optional[pulumi.Input['ProjectLifecycleState']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input[pulumi.InputType['ResourceIdArgs']]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  project_number: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -156,7 +156,7 @@ class Project(pulumi.CustomResource):
         :param pulumi.Input['ProjectLifecycleState'] lifecycle_state: The Project lifecycle state. Read-only.
         :param pulumi.Input[str] name: The optional user-assigned display name of the Project. When present it must be between 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: `My Project` Read-write.
         :param pulumi.Input[pulumi.InputType['ResourceIdArgs']] parent: An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent.
-        :param pulumi.Input[str] project: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
+        :param pulumi.Input[str] project_id: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         :param pulumi.Input[str] project_number: The number uniquely identifying the project. Example: `415104041262` Read-only.
         """
         ...
@@ -188,7 +188,7 @@ class Project(pulumi.CustomResource):
                  lifecycle_state: Optional[pulumi.Input['ProjectLifecycleState']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input[pulumi.InputType['ResourceIdArgs']]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  project_number: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:
@@ -207,7 +207,7 @@ class Project(pulumi.CustomResource):
             __props__.__dict__["lifecycle_state"] = lifecycle_state
             __props__.__dict__["name"] = name
             __props__.__dict__["parent"] = parent
-            __props__.__dict__["project"] = project
+            __props__.__dict__["project_id"] = project_id
             __props__.__dict__["project_number"] = project_number
         super(Project, __self__).__init__(
             'google-native:cloudresourcemanager/v1:Project',
@@ -236,7 +236,7 @@ class Project(pulumi.CustomResource):
         __props__.__dict__["lifecycle_state"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["parent"] = None
-        __props__.__dict__["project"] = None
+        __props__.__dict__["project_id"] = None
         __props__.__dict__["project_number"] = None
         return Project(resource_name, opts=opts, __props__=__props__)
 
@@ -281,12 +281,12 @@ class Project(pulumi.CustomResource):
         return pulumi.get(self, "parent")
 
     @property
-    @pulumi.getter
-    def project(self) -> pulumi.Output[str]:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> pulumi.Output[str]:
         """
         The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
     @property
     @pulumi.getter(name="projectNumber")

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v1beta1/get_project.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v1beta1/get_project.py
@@ -18,7 +18,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetProjectResult:
-    def __init__(__self__, create_time=None, labels=None, lifecycle_state=None, name=None, parent=None, project=None, project_number=None):
+    def __init__(__self__, create_time=None, labels=None, lifecycle_state=None, name=None, parent=None, project_id=None, project_number=None):
         if create_time and not isinstance(create_time, str):
             raise TypeError("Expected argument 'create_time' to be a str")
         pulumi.set(__self__, "create_time", create_time)
@@ -34,9 +34,9 @@ class GetProjectResult:
         if parent and not isinstance(parent, dict):
             raise TypeError("Expected argument 'parent' to be a dict")
         pulumi.set(__self__, "parent", parent)
-        if project and not isinstance(project, str):
-            raise TypeError("Expected argument 'project' to be a str")
-        pulumi.set(__self__, "project", project)
+        if project_id and not isinstance(project_id, str):
+            raise TypeError("Expected argument 'project_id' to be a str")
+        pulumi.set(__self__, "project_id", project_id)
         if project_number and not isinstance(project_number, str):
             raise TypeError("Expected argument 'project_number' to be a str")
         pulumi.set(__self__, "project_number", project_number)
@@ -82,12 +82,12 @@ class GetProjectResult:
         return pulumi.get(self, "parent")
 
     @property
-    @pulumi.getter
-    def project(self) -> str:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> str:
         """
         The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
     @property
     @pulumi.getter(name="projectNumber")
@@ -109,7 +109,7 @@ class AwaitableGetProjectResult(GetProjectResult):
             lifecycle_state=self.lifecycle_state,
             name=self.name,
             parent=self.parent,
-            project=self.project,
+            project_id=self.project_id,
             project_number=self.project_number)
 
 
@@ -132,7 +132,7 @@ def get_project(project: Optional[str] = None,
         lifecycle_state=__ret__.lifecycle_state,
         name=__ret__.name,
         parent=__ret__.parent,
-        project=__ret__.project,
+        project_id=__ret__.project_id,
         project_number=__ret__.project_number)
 
 

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v1beta1/project.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v1beta1/project.py
@@ -21,7 +21,7 @@ class ProjectArgs:
                  lifecycle_state: Optional[pulumi.Input['ProjectLifecycleState']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input['ResourceIdArgs']] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  project_number: Optional[pulumi.Input[str]] = None,
                  use_legacy_stack: Optional[pulumi.Input[str]] = None):
         """
@@ -31,7 +31,7 @@ class ProjectArgs:
         :param pulumi.Input['ProjectLifecycleState'] lifecycle_state: The Project lifecycle state. Read-only.
         :param pulumi.Input[str] name: The optional user-assigned display name of the Project. When present it must be between 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: `My Project` Read-write.
         :param pulumi.Input['ResourceIdArgs'] parent: An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent. Read-write.
-        :param pulumi.Input[str] project: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
+        :param pulumi.Input[str] project_id: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         :param pulumi.Input[str] project_number: The number uniquely identifying the project. Example: `415104041262` Read-only.
         """
         if create_time is not None:
@@ -44,8 +44,8 @@ class ProjectArgs:
             pulumi.set(__self__, "name", name)
         if parent is not None:
             pulumi.set(__self__, "parent", parent)
-        if project is not None:
-            pulumi.set(__self__, "project", project)
+        if project_id is not None:
+            pulumi.set(__self__, "project_id", project_id)
         if project_number is not None:
             pulumi.set(__self__, "project_number", project_number)
         if use_legacy_stack is not None:
@@ -112,16 +112,16 @@ class ProjectArgs:
         pulumi.set(self, "parent", value)
 
     @property
-    @pulumi.getter
-    def project(self) -> Optional[pulumi.Input[str]]:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> Optional[pulumi.Input[str]]:
         """
         The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
-    @project.setter
-    def project(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "project", value)
+    @project_id.setter
+    def project_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "project_id", value)
 
     @property
     @pulumi.getter(name="projectNumber")
@@ -155,7 +155,7 @@ class Project(pulumi.CustomResource):
                  lifecycle_state: Optional[pulumi.Input['ProjectLifecycleState']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input[pulumi.InputType['ResourceIdArgs']]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  project_number: Optional[pulumi.Input[str]] = None,
                  use_legacy_stack: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -169,7 +169,7 @@ class Project(pulumi.CustomResource):
         :param pulumi.Input['ProjectLifecycleState'] lifecycle_state: The Project lifecycle state. Read-only.
         :param pulumi.Input[str] name: The optional user-assigned display name of the Project. When present it must be between 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: `My Project` Read-write.
         :param pulumi.Input[pulumi.InputType['ResourceIdArgs']] parent: An optional reference to a parent Resource. Supported parent types include "organization" and "folder". Once set, the parent cannot be cleared. The `parent` can be set on creation or using the `UpdateProject` method; the end user must have the `resourcemanager.projects.create` permission on the parent. Read-write.
-        :param pulumi.Input[str] project: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
+        :param pulumi.Input[str] project_id: The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         :param pulumi.Input[str] project_number: The number uniquely identifying the project. Example: `415104041262` Read-only.
         """
         ...
@@ -201,7 +201,7 @@ class Project(pulumi.CustomResource):
                  lifecycle_state: Optional[pulumi.Input['ProjectLifecycleState']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input[pulumi.InputType['ResourceIdArgs']]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  project_number: Optional[pulumi.Input[str]] = None,
                  use_legacy_stack: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -221,7 +221,7 @@ class Project(pulumi.CustomResource):
             __props__.__dict__["lifecycle_state"] = lifecycle_state
             __props__.__dict__["name"] = name
             __props__.__dict__["parent"] = parent
-            __props__.__dict__["project"] = project
+            __props__.__dict__["project_id"] = project_id
             __props__.__dict__["project_number"] = project_number
             __props__.__dict__["use_legacy_stack"] = use_legacy_stack
         super(Project, __self__).__init__(
@@ -251,7 +251,7 @@ class Project(pulumi.CustomResource):
         __props__.__dict__["lifecycle_state"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["parent"] = None
-        __props__.__dict__["project"] = None
+        __props__.__dict__["project_id"] = None
         __props__.__dict__["project_number"] = None
         return Project(resource_name, opts=opts, __props__=__props__)
 
@@ -296,12 +296,12 @@ class Project(pulumi.CustomResource):
         return pulumi.get(self, "parent")
 
     @property
-    @pulumi.getter
-    def project(self) -> pulumi.Output[str]:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> pulumi.Output[str]:
         """
         The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` Read-only after creation.
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
     @property
     @pulumi.getter(name="projectNumber")

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v3/get_project.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v3/get_project.py
@@ -17,7 +17,7 @@ __all__ = [
 
 @pulumi.output_type
 class GetProjectResult:
-    def __init__(__self__, create_time=None, delete_time=None, display_name=None, etag=None, labels=None, name=None, parent=None, project=None, state=None, update_time=None):
+    def __init__(__self__, create_time=None, delete_time=None, display_name=None, etag=None, labels=None, name=None, parent=None, project_id=None, state=None, update_time=None):
         if create_time and not isinstance(create_time, str):
             raise TypeError("Expected argument 'create_time' to be a str")
         pulumi.set(__self__, "create_time", create_time)
@@ -39,9 +39,9 @@ class GetProjectResult:
         if parent and not isinstance(parent, str):
             raise TypeError("Expected argument 'parent' to be a str")
         pulumi.set(__self__, "parent", parent)
-        if project and not isinstance(project, str):
-            raise TypeError("Expected argument 'project' to be a str")
-        pulumi.set(__self__, "project", project)
+        if project_id and not isinstance(project_id, str):
+            raise TypeError("Expected argument 'project_id' to be a str")
+        pulumi.set(__self__, "project_id", project_id)
         if state and not isinstance(state, str):
             raise TypeError("Expected argument 'state' to be a str")
         pulumi.set(__self__, "state", state)
@@ -106,12 +106,12 @@ class GetProjectResult:
         return pulumi.get(self, "parent")
 
     @property
-    @pulumi.getter
-    def project(self) -> str:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> str:
         """
         Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
     @property
     @pulumi.getter
@@ -143,7 +143,7 @@ class AwaitableGetProjectResult(GetProjectResult):
             labels=self.labels,
             name=self.name,
             parent=self.parent,
-            project=self.project,
+            project_id=self.project_id,
             state=self.state,
             update_time=self.update_time)
 
@@ -169,7 +169,7 @@ def get_project(project: Optional[str] = None,
         labels=__ret__.labels,
         name=__ret__.name,
         parent=__ret__.parent,
-        project=__ret__.project,
+        project_id=__ret__.project_id,
         state=__ret__.state,
         update_time=__ret__.update_time)
 

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v3/project.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v3/project.py
@@ -16,13 +16,13 @@ class ProjectArgs:
                  display_name: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  parent: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None):
+                 project_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Project resource.
         :param pulumi.Input[str] display_name: Optional. A user-assigned display name of the project. When present it must be between 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: `My Project`
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. The labels associated with this project. Label keys must be between 1 and 63 characters long and must conform to the following regular expression: \[a-z\](\[-a-z0-9\]*\[a-z0-9\])?. Label values must be between 0 and 63 characters long and must conform to the regular expression (\[a-z\](\[-a-z0-9\]*\[a-z0-9\])?)?. No more than 256 labels can be associated with a given resource. Clients should store labels in a representation such as JSON that does not depend on specific characters being disallowed. Example: `"myBusinessDimension" : "businessValue"`
         :param pulumi.Input[str] parent: Optional. A reference to a parent Resource. eg., `organizations/123` or `folders/876`.
-        :param pulumi.Input[str] project: Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
+        :param pulumi.Input[str] project_id: Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         """
         if display_name is not None:
             pulumi.set(__self__, "display_name", display_name)
@@ -30,8 +30,8 @@ class ProjectArgs:
             pulumi.set(__self__, "labels", labels)
         if parent is not None:
             pulumi.set(__self__, "parent", parent)
-        if project is not None:
-            pulumi.set(__self__, "project", project)
+        if project_id is not None:
+            pulumi.set(__self__, "project_id", project_id)
 
     @property
     @pulumi.getter(name="displayName")
@@ -70,16 +70,16 @@ class ProjectArgs:
         pulumi.set(self, "parent", value)
 
     @property
-    @pulumi.getter
-    def project(self) -> Optional[pulumi.Input[str]]:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> Optional[pulumi.Input[str]]:
         """
         Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
-    @project.setter
-    def project(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "project", value)
+    @project_id.setter
+    def project_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "project_id", value)
 
 
 class Project(pulumi.CustomResource):
@@ -90,7 +90,7 @@ class Project(pulumi.CustomResource):
                  display_name: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  parent: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         Request that a new project be created. The result is an `Operation` which can be used to track the creation process. This process usually takes a few seconds, but can sometimes take much longer. The tracking `Operation` is automatically deleted after a few hours, so there is no need to call `DeleteOperation`.
@@ -101,7 +101,7 @@ class Project(pulumi.CustomResource):
         :param pulumi.Input[str] display_name: Optional. A user-assigned display name of the project. When present it must be between 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: `My Project`
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. The labels associated with this project. Label keys must be between 1 and 63 characters long and must conform to the following regular expression: \[a-z\](\[-a-z0-9\]*\[a-z0-9\])?. Label values must be between 0 and 63 characters long and must conform to the regular expression (\[a-z\](\[-a-z0-9\]*\[a-z0-9\])?)?. No more than 256 labels can be associated with a given resource. Clients should store labels in a representation such as JSON that does not depend on specific characters being disallowed. Example: `"myBusinessDimension" : "businessValue"`
         :param pulumi.Input[str] parent: Optional. A reference to a parent Resource. eg., `organizations/123` or `folders/876`.
-        :param pulumi.Input[str] project: Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
+        :param pulumi.Input[str] project_id: Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         """
         ...
     @overload
@@ -131,7 +131,7 @@ class Project(pulumi.CustomResource):
                  display_name: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  parent: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
@@ -147,7 +147,7 @@ class Project(pulumi.CustomResource):
             __props__.__dict__["display_name"] = display_name
             __props__.__dict__["labels"] = labels
             __props__.__dict__["parent"] = parent
-            __props__.__dict__["project"] = project
+            __props__.__dict__["project_id"] = project_id
             __props__.__dict__["create_time"] = None
             __props__.__dict__["delete_time"] = None
             __props__.__dict__["etag"] = None
@@ -183,7 +183,7 @@ class Project(pulumi.CustomResource):
         __props__.__dict__["labels"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["parent"] = None
-        __props__.__dict__["project"] = None
+        __props__.__dict__["project_id"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["update_time"] = None
         return Project(resource_name, opts=opts, __props__=__props__)
@@ -245,12 +245,12 @@ class Project(pulumi.CustomResource):
         return pulumi.get(self, "parent")
 
     @property
-    @pulumi.getter
-    def project(self) -> pulumi.Output[str]:
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> pulumi.Output[str]:
         """
         Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123`
         """
-        return pulumi.get(self, "project")
+        return pulumi.get(self, "project_id")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
Fixes #277 

We replace projectId with project elsewhere because we then build the full projectId dynamically within the provider. However the projectId within the actual Project resource type does not need auto-naming.

Not  committing the test example as it seems to take some time to actually delete the project which could cause issues in CI/CD.