### PR TITLE
Avoid duplicate go module names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ build_go::
 	cd sdk/ && go build github.com/pulumi/pulumi-google-native/sdk/go/google/...
 
 clean::
-	rm -rf sdk/nodejs && mkdir sdk/nodejs && touch sdk/nodejs/go.mod
-	rm -rf sdk/python && mkdir sdk/python && touch sdk/python/go.mod && cp README.md sdk/python
-	rm -rf sdk/dotnet && mkdir sdk/dotnet && touch sdk/dotnet/go.mod
+	rm -rf sdk/nodejs && mkdir sdk/nodejs && echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.16" > 'sdk/nodejs/go.mod'
+	rm -rf sdk/python && mkdir sdk/python && echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.16" > 'sdk/python/go.mod' && cp README.md sdk/python
+	rm -rf sdk/dotnet && mkdir sdk/dotnet && echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.16" > 'sdk/dotnet/go.mod'
 	rm -rf sdk/go/google
 
 install_dotnet_sdk::

--- a/sdk/dotnet/go.mod
+++ b/sdk/dotnet/go.mod
@@ -1,0 +1,3 @@
+module fake_dotnet_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/nodejs/go.mod
+++ b/sdk/nodejs/go.mod
@@ -1,0 +1,3 @@
+module fake_nodejs_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/python/go.mod
+++ b/sdk/python/go.mod
@@ -1,0 +1,3 @@
+module fake_python_module // Exclude this directory from Go tools
+
+go 1.16


### PR DESCRIPTION
gopls complains at duplicate modules within the same workspace so make fake module names unique. This should make the project able to be opened in VSCode and other editors with no custom settings.