### PR TITLE
Use TypeScript package from Yarn, not global

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,10 @@ generate_nodejs::
 	$(WORKING_DIR)/bin/$(CODEGEN) nodejs ${VERSION}
 
 build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:: TSC := $(shell which tsc)
 build_nodejs::
 	cd ${PACKDIR}/nodejs/ && \
 		yarn install && \
-		node --max-old-space-size=4096 $(TSC) --diagnostics && \
+		node --max-old-space-size=4096 ./node_modules/.bin/tsc --diagnostics && \
 		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 


### PR DESCRIPTION
The `tsc` command on line 52 would always use a globally installed TypeScript, regardless of the one installed by yarn on the previous line.

Replaces #297 to run tests