### PR TITLE
Refactor metadata

### DIFF
--- a/examples/gke-ts/index.ts
+++ b/examples/gke-ts/index.ts
@@ -17,7 +17,7 @@
 import * as google from "@pulumi/google-native";
 
 // TODO: Determine this dynamically once https://github.com/pulumi/pulumi-google-native/issues/166 is done.
-const engineVersion = "1.21.6-gke.1500";
+const engineVersion = "1.21.6-gke.1503";
 
 const nodeConfig: google.types.input.container.v1.NodeConfigArgs = {
     machineType: "n1-standard-2",

--- a/provider/cmd/pulumi-gen-google-native/main.go
+++ b/provider/cmd/pulumi-gen-google-native/main.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 
@@ -115,7 +127,7 @@ func emitDiscoveryFiles(outDir string) error {
 		}
 
 		fileName := fmt.Sprintf("%s.json", strings.ReplaceAll(item.Id, ":", "_"))
-		err := copyJsonFile(item.DiscoveryRestUrl, outDir, fileName)
+		err := copyJSONFile(item.DiscoveryRestUrl, outDir, fileName)
 		if err != nil {
 			return errors.Wrapf(err, "writing %s", fileName)
 		}
@@ -124,7 +136,8 @@ func emitDiscoveryFiles(outDir string) error {
 	return nil
 }
 
-func copyJsonFile(url, outDir, path string) error {
+func copyJSONFile(url, outDir, path string) error {
+	// nolint: gosec
 	resp, err := http.Get(url)
 	if err != nil {
 		return err

--- a/provider/cmd/pulumi-resource-google-native/main.go
+++ b/provider/cmd/pulumi-resource-google-native/main.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 

--- a/provider/pkg/gen/compression.go
+++ b/provider/pkg/gen/compression.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package gen
 
@@ -31,7 +43,7 @@ func DecompressSchema(compressedSchema []byte) ([]byte, error) {
 		return nil, errors.Wrap(err, "expand compressed schema")
 	}
 	uncompressedBuf := bytes.Buffer{}
-	if _, err = io.Copy(&uncompressedBuf, uncompressed); err != nil {
+	if _, err = io.CopyN(&uncompressedBuf, uncompressed, 1024); err != nil {
 		return nil, err
 	}
 	if err = uncompressed.Close(); err != nil {

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -130,7 +130,7 @@ var autonameOverrides = map[string]string{
 }
 
 // csharpNamespaceOverrides is a map of canonical C# namespaces per lowercase module name. It only lists the ones
-// that aren't successfully infered from the discovery document.
+// that aren't successfully inferred from the discovery document.
 var csharpNamespaceOverrides = map[string]string{
 	"billingbudgets":       "BillingBudgets",
 	"cloudkms":             "CloudKMS",

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -330,16 +330,41 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	inputProperties := map[string]schema.PropertySpec{}
 	requiredInputProperties := codegen.NewStringSet()
 
-	createPath := dd.createMethod.FlatPath
-	if createPath == "" {
-		createPath = dd.createMethod.Path
+	methodPath := func(method *discovery.RestMethod) string {
+		if method == nil {
+			return ""
+		}
+		if len(method.FlatPath) > 0 {
+			return method.FlatPath
+		}
+		return method.Path
 	}
+	createPath := methodPath(dd.createMethod)
 
 	resourceMeta := resources.CloudAPIResource{
-		BaseUrl:    g.rest.BaseUrl,
-		CreatePath: createPath,
-		CreateVerb: dd.createMethod.HttpMethod,
-		NoDelete:   dd.deleteMethod == nil,
+		RootUrl: g.rest.RootUrl,
+		Create: resources.CloudAPIOperation{
+			Endpoint: resources.CloudAPIEndpoint{
+				Template: methodPath(dd.createMethod),
+			},
+			Verb: dd.createMethod.HttpMethod,
+		},
+		Delete: resources.CloudAPIOperation{
+			Endpoint: resources.CloudAPIEndpoint{
+				Template: methodPath(dd.deleteMethod),
+			},
+		},
+		Read: resources.CloudAPIOperation{
+			Endpoint: resources.CloudAPIEndpoint{
+				Template: methodPath(dd.getMethod),
+			},
+			Verb: dd.getMethod.HttpMethod,
+		},
+		Update: resources.CloudAPIOperation{
+			Endpoint: resources.CloudAPIEndpoint{
+				Template: methodPath(dd.getMethod),
+			},
+		},
 	}
 	patternParams := codegen.NewStringSet()
 
@@ -351,14 +376,14 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		}
 
 		p := resources.CloudAPIResourceParam{
-			Name:     name,
-			Location: "query",
+			Name: name,
+			Kind: "query",
 		}
 		sdkName := ToLowerCamel(name)
 		if sdkName != name {
 			p.SdkName = sdkName
 		}
-		resourceMeta.CreateParams = append(resourceMeta.CreateParams, p)
+		resourceMeta.Create.Endpoint.Values = append(resourceMeta.Create.Endpoint.Values, p)
 		patternParams.Add(sdkName)
 
 		inputProperties[sdkName] = schema.PropertySpec{
@@ -380,14 +405,14 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		inputProperties[sdkName] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{Type: "string"},
 		}
-		param := resources.CloudAPIResourceParam{
-			Name:     name,
-			Location: "path",
+		p := resources.CloudAPIResourceParam{
+			Name: name,
+			Kind: "path",
 		}
 		if sdkName != name {
-			param.SdkName = sdkName
+			p.SdkName = sdkName
 		}
-		resourceMeta.CreateParams = append(resourceMeta.CreateParams, param)
+		resourceMeta.Create.Endpoint.Values = append(resourceMeta.Create.Endpoint.Values, p)
 		patternParams.Add(sdkName)
 		requiredInputProperties.Add(sdkName)
 	}
@@ -418,10 +443,10 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		for name := range bodyBag.requiredSpecs {
 			requiredInputProperties.Add(name)
 		}
-		resourceMeta.CreateProperties = bodyBag.properties
+		resourceMeta.Create.SDKProperties = bodyBag.properties
 
 		if dd.updateMethod != nil {
-			resourceMeta.UpdateVerb = dd.updateMethod.HttpMethod
+			resourceMeta.Update.Verb = dd.updateMethod.HttpMethod
 			var updateFlatten string
 			updateRequest := g.rest.Schemas[dd.updateMethod.Request.Ref]
 			if dd.updateMethod.Request.Ref != dd.getMethod.Response.Ref {
@@ -432,7 +457,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 					}
 				}
 			}
-			resourceMeta.UpdateProperties = map[string]resources.CloudAPIProperty{}
+			resourceMeta.Update.SDKProperties = map[string]resources.CloudAPIProperty{}
 			updateBag, err := g.genProperties(typeName, &updateRequest, updateFlatten, false, nil)
 			if err != nil {
 				return err
@@ -440,7 +465,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 
 			for name, value := range updateBag.properties {
 				if _, has := bodyBag.properties[name]; has {
-					resourceMeta.UpdateProperties[name] = value
+					resourceMeta.Update.SDKProperties[name] = value
 				} else {
 					// TODO: do we need to handle masks?
 					if !strings.HasSuffix(name, "Mask") {
@@ -468,15 +493,13 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		for _, p := range []string{"selfLink", "self"} {
 			if _, has := response.Properties[p]; has {
 				resourceMeta.IdProperty = p
+				break
 			}
 		}
 
 		// Option 2: the provider has to manually build it from the GET method path.
 		if resourceMeta.IdProperty == "" {
-			idPath := dd.getMethod.FlatPath
-			if idPath == "" {
-				idPath = dd.getMethod.Path
-			}
+			idPath := methodPath(dd.getMethod)
 			queryParams := url.Values{}
 			for param, details := range dd.getMethod.Parameters {
 				if details.Location != "query" || !details.Required {
@@ -497,6 +520,16 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 				fmt.Printf("Failed to build ID params for resource %s: %v\n", resourceTok, err)
 				return nil
 			}
+			resourceMeta.Read.Endpoint.Template = idPath
+			var idVals []resources.CloudAPIResourceParam
+			for k, v := range v {
+				idVals = append(idVals, resources.CloudAPIResourceParam{
+					Name:    k,
+					SdkName: v,
+					Kind:    "path",
+				})
+			}
+			resourceMeta.Read.Endpoint.Values = idVals
 			resourceMeta.IdPath = idPath
 			resourceMeta.IdParams = v
 		}
@@ -505,13 +538,20 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	// Detect resources that support media upload as mark them as such.
 	if dd.createMethod.MediaUpload != nil && dd.createMethod.MediaUpload.Protocols != nil &&
 		dd.createMethod.MediaUpload.Protocols.Simple != nil {
-		resourceMeta.CreatePath = resources.CombineUrl(g.rest.RootUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
+		resourceMeta.Create.Endpoint.Template = resources.CombineUrl(
+			g.rest.RootUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
 		resourceMeta.AssetUpload = true
 		inputProperties["source"] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{
 				Ref: "pulumi.json#/Asset",
 			},
 		}
+	}
+
+	// TODO: add delete support
+	if dd.deleteMethod != nil {
+		resourceMeta.Delete.Endpoint.Template = resourceMeta.IdPath
+		resourceMeta.Delete.Verb = dd.deleteMethod.HttpMethod
 	}
 
 	description := dd.createMethod.Description
@@ -531,7 +571,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		}
 	}
 
-	if resourceMeta.NoDelete {
+	if resourceMeta.Delete.Undefined() {
 		description += "\nNote - this resource's API doesn't support deletion. When deleted, the resource will persist\n" +
 			"on Google Cloud even though it will be deleted from Pulumi state."
 	}
@@ -572,7 +612,9 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 		httpMethod = "GET"
 	}
 	functionMeta := resources.CloudAPIFunction{
-		Url:  resources.CombineUrl(g.rest.BaseUrl, getPath),
+		Url: resources.CloudAPIEndpoint{
+			Template: resources.CombineUrl(g.rest.BaseUrl, getPath),
+		},
 		Verb: httpMethod,
 	}
 
@@ -584,14 +626,14 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 		}
 
 		p := resources.CloudAPIResourceParam{
-			Name:     name,
-			Location: "query",
+			Name: name,
+			Kind: "query",
 		}
 		sdkName := ToLowerCamel(name)
 		if sdkName != name {
 			p.SdkName = sdkName
 		}
-		functionMeta.Params = append(functionMeta.Params, p)
+		functionMeta.Url.Values = append(functionMeta.Url.Values, p)
 
 		inputProperties[sdkName] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{Type: "string"},
@@ -612,14 +654,14 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 		inputProperties[sdkName] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{Type: "string"},
 		}
-		param := resources.CloudAPIResourceParam{
-			Name:     name,
-			Location: "path",
+		p := resources.CloudAPIResourceParam{
+			Name: name,
+			Kind: "path",
 		}
 		if sdkName != name {
-			param.SdkName = sdkName
+			p.SdkName = sdkName
 		}
-		functionMeta.Params = append(functionMeta.Params, param)
+		functionMeta.Url.Values = append(functionMeta.Url.Values, p)
 		requiredInputProperties.Add(sdkName)
 	}
 

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -522,10 +522,10 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 			}
 			resourceMeta.Read.Endpoint.Template = idPath
 			var idVals []resources.CloudAPIResourceParam
-			for k, v := range v {
+			for _, k := range codegen.SortedKeys(v) {
 				idVals = append(idVals, resources.CloudAPIResourceParam{
 					Name:    k,
-					SdkName: v,
+					SdkName: v[k],
 					Kind:    "path",
 				})
 			}
@@ -700,7 +700,12 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 
 // buildIdParams creates a map of parameters that are needed to build resource IDs from an ID path template.
 // Keys are API parameter names, values are SDK property names (that may be equal to keys, or not).
-func (g *packageGenerator) buildIdParams(typeName string, idPath string, inputProperties map[string]schema.PropertySpec, response *discovery.JsonSchema) (map[string]string, error) {
+func (g *packageGenerator) buildIdParams(
+	typeName string,
+	idPath string,
+	inputProperties map[string]schema.PropertySpec,
+	response *discovery.JsonSchema,
+) (map[string]string, error) {
 	result := map[string]string{}
 
 	u, err := url.Parse(idPath)

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -531,7 +531,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 			}
 			resourceMeta.Read.Endpoint.Values = idVals
 			resourceMeta.IDPath = idPath
-			resourceMeta.IDParams = v
+			resourceMeta.IDParams = vals
 		}
 	}
 

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -539,7 +539,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	if dd.createMethod.MediaUpload != nil && dd.createMethod.MediaUpload.Protocols != nil &&
 		dd.createMethod.MediaUpload.Protocols.Simple != nil {
 		resourceMeta.Create.Endpoint.Template = resources.CombineURL(
-			g.rest.RootUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
+			g.rest.BaseUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
 		resourceMeta.AssetUpload = true
 		inputProperties["source"] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -342,7 +342,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	createPath := methodPath(dd.createMethod)
 
 	resourceMeta := resources.CloudAPIResource{
-		RootURL: g.rest.RootUrl,
+		RootURL: g.rest.BaseUrl,
 		Create: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
 				Template: methodPath(dd.createMethod),

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -345,24 +345,24 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		RootURL: g.rest.BaseUrl,
 		Create: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: methodPath(dd.createMethod),
+				Template: g.rest.BaseUrl + methodPath(dd.createMethod),
 			},
 			Verb: dd.createMethod.HttpMethod,
 		},
 		Delete: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: methodPath(dd.deleteMethod),
+				Template: g.rest.BaseUrl + methodPath(dd.deleteMethod),
 			},
 		},
 		Read: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: methodPath(dd.getMethod),
+				Template: g.rest.BaseUrl + methodPath(dd.getMethod),
 			},
 			Verb: dd.getMethod.HttpMethod,
 		},
 		Update: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: methodPath(dd.getMethod),
+				Template: g.rest.BaseUrl + methodPath(dd.getMethod),
 			},
 		},
 	}

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -515,17 +515,17 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 				}
 			}
 
-			v, err := g.buildIdParams(typeName, idPath, inputProperties, &response)
+			vals, err := g.buildIdParams(typeName, idPath, inputProperties, &response)
 			if err != nil {
 				fmt.Printf("Failed to build ID params for resource %s: %v\n", resourceTok, err)
 				return nil
 			}
 			resourceMeta.Read.Endpoint.Template = idPath
 			var idVals []resources.CloudAPIResourceParam
-			for _, k := range codegen.SortedKeys(v) {
+			for _, k := range codegen.SortedKeys(vals) {
 				idVals = append(idVals, resources.CloudAPIResourceParam{
 					Name:    k,
-					SdkName: v[k],
+					SdkName: vals[k],
 					Kind:    "path",
 				})
 			}
@@ -535,7 +535,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		}
 	}
 
-	// Detect resources that support media upload as mark them as such.
+	// Detect resources that support media upload and mark them as such.
 	if dd.createMethod.MediaUpload != nil && dd.createMethod.MediaUpload.Protocols != nil &&
 		dd.createMethod.MediaUpload.Protocols.Simple != nil {
 		resourceMeta.Create.Endpoint.Template = resources.CombineURL(

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -341,28 +341,29 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	}
 	createPath := methodPath(dd.createMethod)
 
+	baseURL := resources.CombineURL(g.rest.RootUrl, g.rest.BasePath)
 	resourceMeta := resources.CloudAPIResource{
 		RootURL: g.rest.BaseUrl,
 		Create: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: g.rest.BaseUrl + methodPath(dd.createMethod),
+				Template: resources.CombineURL(baseURL, methodPath(dd.createMethod)),
 			},
 			Verb: dd.createMethod.HttpMethod,
 		},
 		Delete: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: g.rest.BaseUrl + methodPath(dd.deleteMethod),
+				Template: resources.CombineURL(baseURL, methodPath(dd.deleteMethod)),
 			},
 		},
 		Read: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: g.rest.BaseUrl + methodPath(dd.getMethod),
+				Template: resources.CombineURL(baseURL, methodPath(dd.getMethod)),
 			},
 			Verb: dd.getMethod.HttpMethod,
 		},
 		Update: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: g.rest.BaseUrl + methodPath(dd.getMethod),
+				Template: resources.CombineURL(baseURL, methodPath(dd.getMethod)),
 			},
 		},
 	}
@@ -539,7 +540,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	if dd.createMethod.MediaUpload != nil && dd.createMethod.MediaUpload.Protocols != nil &&
 		dd.createMethod.MediaUpload.Protocols.Simple != nil {
 		resourceMeta.Create.Endpoint.Template = resources.CombineURL(
-			g.rest.BaseUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
+			g.rest.RootUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
 		resourceMeta.AssetUpload = true
 		inputProperties["source"] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -342,7 +342,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	createPath := methodPath(dd.createMethod)
 
 	resourceMeta := resources.CloudAPIResource{
-		RootUrl: g.rest.RootUrl,
+		RootURL: g.rest.RootUrl,
 		Create: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
 				Template: methodPath(dd.createMethod),
@@ -492,13 +492,13 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		// Option 1: it's directly returned from the API in the "self" property.
 		for _, p := range []string{"selfLink", "self"} {
 			if _, has := response.Properties[p]; has {
-				resourceMeta.IdProperty = p
+				resourceMeta.IDProperty = p
 				break
 			}
 		}
 
 		// Option 2: the provider has to manually build it from the GET method path.
-		if resourceMeta.IdProperty == "" {
+		if resourceMeta.IDProperty == "" {
 			idPath := methodPath(dd.getMethod)
 			queryParams := url.Values{}
 			for param, details := range dd.getMethod.Parameters {
@@ -530,15 +530,15 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 				})
 			}
 			resourceMeta.Read.Endpoint.Values = idVals
-			resourceMeta.IdPath = idPath
-			resourceMeta.IdParams = v
+			resourceMeta.IDPath = idPath
+			resourceMeta.IDParams = v
 		}
 	}
 
 	// Detect resources that support media upload as mark them as such.
 	if dd.createMethod.MediaUpload != nil && dd.createMethod.MediaUpload.Protocols != nil &&
 		dd.createMethod.MediaUpload.Protocols.Simple != nil {
-		resourceMeta.Create.Endpoint.Template = resources.CombineUrl(
+		resourceMeta.Create.Endpoint.Template = resources.CombineURL(
 			g.rest.RootUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
 		resourceMeta.AssetUpload = true
 		inputProperties["source"] = schema.PropertySpec{
@@ -550,7 +550,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 
 	// TODO: add delete support
 	if dd.deleteMethod != nil {
-		resourceMeta.Delete.Endpoint.Template = resourceMeta.IdPath
+		resourceMeta.Delete.Endpoint.Template = resourceMeta.IDPath
 		resourceMeta.Delete.Verb = dd.deleteMethod.HttpMethod
 	}
 
@@ -612,8 +612,8 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 		httpMethod = "GET"
 	}
 	functionMeta := resources.CloudAPIFunction{
-		Url: resources.CloudAPIEndpoint{
-			Template: resources.CombineUrl(g.rest.BaseUrl, getPath),
+		URL: resources.CloudAPIEndpoint{
+			Template: resources.CombineURL(g.rest.BaseUrl, getPath),
 		},
 		Verb: httpMethod,
 	}
@@ -633,7 +633,7 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 		if sdkName != name {
 			p.SdkName = sdkName
 		}
-		functionMeta.Url.Values = append(functionMeta.Url.Values, p)
+		functionMeta.URL.Values = append(functionMeta.URL.Values, p)
 
 		inputProperties[sdkName] = schema.PropertySpec{
 			TypeSpec: schema.TypeSpec{Type: "string"},
@@ -661,7 +661,7 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 		if sdkName != name {
 			p.SdkName = sdkName
 		}
-		functionMeta.Url.Values = append(functionMeta.Url.Values, p)
+		functionMeta.URL.Values = append(functionMeta.URL.Values, p)
 		requiredInputProperties.Add(sdkName)
 	}
 

--- a/provider/pkg/gen/utilities.go
+++ b/provider/pkg/gen/utilities.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package gen
 
@@ -12,8 +24,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
-
-var s = codegen.NewStringSet()
 
 // apiParamNameToSdkName returns an SDK name for a given API parameter name.
 // In particular, it converts pluralized ID names to singular ID names.
@@ -49,6 +59,7 @@ func apiPropNameToSdkName(typeName string, name string) string {
 // propertyFormatRegexes is a list of regular expressions to match property formats in property descriptions.
 var propertyFormatRegexes = []*regexp.Regexp{
 	// Example: "The resource name in the format `foo/*`"
+	// nolint: lll
 	regexp.MustCompile(`(?:Format|format|form|forms|formatted|pattern|Example|example|e\.g\.|such|Structured)(?: (?:of|is|as|like|will be))?[^\w]+(\w+(?:/[\w\{\}\*-\[\]]*)+)`),
 	// Example: "Must be in `projects/{project}/locations/{location}/triggers/{trigger}` format"
 	regexp.MustCompile(`in[^\w]+(\w+(?:/[\w\{\}\*-\[\]]*)+)[^\w]+format`),

--- a/provider/pkg/gen/utilities_test.go
+++ b/provider/pkg/gen/utilities_test.go
@@ -1,12 +1,26 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+// nolint: lll
 package gen
 
 import (
+	"testing"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var apiParamToSdkNames = map[string]string{

--- a/provider/pkg/googleclient/credentials.go
+++ b/provider/pkg/googleclient/credentials.go
@@ -1,4 +1,16 @@
-// Copyright 2021, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package googleclient
 
@@ -128,7 +140,8 @@ func getCredentials(ctx context.Context, c Config) (*google.Credentials, error) 
 				return nil, err
 			}
 
-			glog.V(9).Info("Authenticating using configured Google JSON Credentials and Impersonate Service Account...")
+			glog.V(9).Info("" +
+				"Authenticating using configured Google JSON Credentials and Impersonate Service Account...")
 			glog.V(9).Infof("   -- Scopes: %s", c.Scopes)
 			return creds, nil
 		}
@@ -159,7 +172,9 @@ func getCredentials(ctx context.Context, c Config) (*google.Credentials, error) 
 
 	defaultTS, err := google.DefaultTokenSource(context.Background(), c.Scopes...)
 	if err != nil {
-		return nil, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
+		return nil, fmt.Errorf("Attempted to load application default credentials since neither "+
+			"`credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your "+
+			"gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
 	}
 	return &google.Credentials{
 		TokenSource: defaultTS,

--- a/provider/pkg/googleclient/credentials.go
+++ b/provider/pkg/googleclient/credentials.go
@@ -140,7 +140,7 @@ func getCredentials(ctx context.Context, c Config) (*google.Credentials, error) 
 				return nil, err
 			}
 
-			glog.V(9).Info("" +
+			glog.V(9).Info(
 				"Authenticating using configured Google JSON Credentials and Impersonate Service Account...")
 			glog.V(9).Infof("   -- Scopes: %s", c.Scopes)
 			return creds, nil

--- a/provider/pkg/googleclient/http_test.go
+++ b/provider/pkg/googleclient/http_test.go
@@ -1,4 +1,16 @@
-// Copyright 2021, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package googleclient
 

--- a/provider/pkg/googleclient/mockTokenSource_test.go
+++ b/provider/pkg/googleclient/mockTokenSource_test.go
@@ -1,4 +1,16 @@
-// Copyright 2021, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package googleclient
 

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package provider
 
@@ -11,7 +23,7 @@ import (
 func getInputsFromState(res resources.CloudAPIResource, state resource.PropertyMap) resource.PropertyMap {
 	inputsMap := map[string]interface{}{}
 	stateMap := state.Mappable()
-	for name, prop := range res.CreateProperties {
+	for name, prop := range res.Create.SDKProperties {
 		parent := stateMap
 		if prop.Container != "" {
 			container, ok := stateMap[prop.Container].(map[string]interface{})

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -1,23 +1,38 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package provider
 
 import (
+	"testing"
+
 	"github.com/pulumi/pulumi-google-native/provider/pkg/resources"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetInputsFromState(t *testing.T) {
 	res := resources.CloudAPIResource{
-		CreateProperties: map[string]resources.CloudAPIProperty{
-			"p1": {},
-			"p2": {
-				Container: "c1",
-			},
-			"p3": {
-				SdkName: "p3sdk",
+		Create: resources.CloudAPIOperation{
+			SDKProperties: map[string]resources.CloudAPIProperty{
+				"p1": {},
+				"p2": {
+					Container: "c1",
+				},
+				"p3": {
+					SdkName: "p3sdk",
+				},
 			},
 		},
 	}
@@ -26,13 +41,13 @@ func TestGetInputsFromState(t *testing.T) {
 		"c1": map[string]interface{}{
 			"p2": "v2",
 		},
-		"p3": 123.456,
+		"p3":      123.456,
 		"output1": "should-be-ignored",
 	})
 	actual := getInputsFromState(res, state).Mappable()
 	expected := map[string]interface{}{
-		"p1": "v1",
-		"p2": "v2",
+		"p1":    "v1",
+		"p2":    "v2",
 		"p3sdk": 123.456,
 	}
 	assert.Equal(t, expected, actual)

--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -25,17 +25,21 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-func calculateResourceId(res resources.CloudAPIResource, inputs map[string]interface{}, outputs map[string]interface{}) (string, error) {
-	if res.IdProperty != "" {
-		v, ok := outputs[res.IdProperty].(string)
+func calculateResourceID(
+	res resources.CloudAPIResource,
+	inputs map[string]interface{},
+	outputs map[string]interface{},
+) (string, error) {
+	if res.IDProperty != "" {
+		v, ok := outputs[res.IDProperty].(string)
 		if !ok {
-			return "", errors.Errorf("ID property %q not found", res.IdProperty)
+			return "", errors.Errorf("ID property %q not found", res.IDProperty)
 		}
-		return strings.TrimPrefix(v, res.RootUrl), nil
+		return strings.TrimPrefix(v, res.RootURL), nil
 	}
 
-	id := res.IdPath
-	idParams := res.IdParams
+	id := res.IDPath
+	idParams := res.IDParams
 	for name, alias := range idParams {
 		var propValue string
 		if v, has := evalPropertyValue(inputs, alias); has {
@@ -78,16 +82,20 @@ func evalPropertyValue(values map[string]interface{}, path string) (string, bool
 	return "", false
 }
 
-// buildCreateUrl composes the URL to invoke to create a resource with given inputs.
-func buildCreateUrl(res resources.CloudAPIResource, inputs resource.PropertyMap) (string, error) {
-	return buildUrl(res.Create.Endpoint.Template, res.Create.Endpoint.Values, inputs)
+// buildCreateURL composes the URL to invoke to create a resource with given inputs.
+func buildCreateURL(res resources.CloudAPIResource, inputs resource.PropertyMap) (string, error) {
+	return buildURL(res.Create.Endpoint.Template, res.Create.Endpoint.Values, inputs)
 }
 
-func buildFunctionUrl(res resources.CloudAPIFunction, inputs resource.PropertyMap) (string, error) {
-	return buildUrl(res.Url.Template, res.Url.Values, inputs)
+func buildFunctionURL(res resources.CloudAPIFunction, inputs resource.PropertyMap) (string, error) {
+	return buildURL(res.URL.Template, res.URL.Values, inputs)
 }
 
-func buildUrl(uriTemplate string, params []resources.CloudAPIResourceParam, inputs resource.PropertyMap) (string, error) {
+func buildURL(
+	uriTemplate string,
+	params []resources.CloudAPIResourceParam,
+	inputs resource.PropertyMap,
+) (string, error) {
 	queryMap := map[string]string{}
 	uriString := uriTemplate
 	for _, param := range params {

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCalculateResourceId_IdProperty(t *testing.T) {
 	res := resources.CloudAPIResource{
-		BaseUrl:    "https://myapi.google.com",
+		RootUrl:    "https://myapi.google.com",
 		IdProperty: "selfLink",
 	}
 	inputs := map[string]interface{}{
@@ -30,7 +30,7 @@ func TestCalculateResourceId_IdProperty(t *testing.T) {
 
 func TestCalculateResourceId_IdPath(t *testing.T) {
 	res := resources.CloudAPIResource{
-		BaseUrl: "https://myapi.google.com",
+		RootUrl: "https://myapi.google.com",
 		IdPath:  "/v1/myparent/{parentsId}/myresource/{myresourcesId}",
 		IdParams: map[string]string{
 			"parentsId":     "parentId",

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package provider
 
@@ -12,8 +24,8 @@ import (
 
 func TestCalculateResourceId_IdProperty(t *testing.T) {
 	res := resources.CloudAPIResource{
-		RootUrl:    "https://myapi.google.com",
-		IdProperty: "selfLink",
+		RootURL:    "https://myapi.google.com",
+		IDProperty: "selfLink",
 	}
 	inputs := map[string]interface{}{
 		"name": "foo",
@@ -23,16 +35,16 @@ func TestCalculateResourceId_IdProperty(t *testing.T) {
 		"name":     "foo",
 		"selfLink": "https://myapi.google.com" + expected,
 	}
-	actual, err := calculateResourceId(res, inputs, outputs)
+	actual, err := calculateResourceID(res, inputs, outputs)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
 
 func TestCalculateResourceId_IdPath(t *testing.T) {
 	res := resources.CloudAPIResource{
-		RootUrl: "https://myapi.google.com",
-		IdPath:  "/v1/myparent/{parentsId}/myresource/{myresourcesId}",
-		IdParams: map[string]string{
+		RootURL: "https://myapi.google.com",
+		IDPath:  "/v1/myparent/{parentsId}/myresource/{myresourcesId}",
+		IDParams: map[string]string{
 			"parentsId":     "parentId",
 			"myresourcesId": "reference.name",
 		},
@@ -45,7 +57,7 @@ func TestCalculateResourceId_IdPath(t *testing.T) {
 			"name": "myparent/foo/myresource/bar",
 		},
 	}
-	actual, err := calculateResourceId(res, inputs, outputs)
+	actual, err := calculateResourceID(res, inputs, outputs)
 	assert.NoError(t, err)
 	assert.Equal(t, "/v1/myparent/foo/myresource/bar", actual)
 }

--- a/provider/pkg/provider/log.go
+++ b/provider/pkg/provider/log.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package provider
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -103,12 +103,15 @@ func (p *googleCloudProvider) Configure(ctx context.Context,
 
 	p.setLoggingContext(ctx)
 
-	impersonateServiceAccountDelegatesString := p.getConfig("impersonateServiceAccountDelegates", "")
+	impersonateServiceAccountDelegatesString := p.getConfig(
+		"impersonateServiceAccountDelegates", "")
 	var impersonateServiceAccountDelegates []string
 	if impersonateServiceAccountDelegatesString != "" {
 		err := json.Unmarshal([]byte(impersonateServiceAccountDelegatesString), &impersonateServiceAccountDelegates)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal %q as Impersonate Service Account Delegates", impersonateServiceAccountDelegatesString)
+			return nil, errors.Wrapf(err,
+				"failed to unmarshal %q as Impersonate Service Account Delegates",
+				impersonateServiceAccountDelegatesString)
 		}
 	}
 
@@ -122,11 +125,12 @@ func (p *googleCloudProvider) Configure(ctx context.Context,
 	}
 
 	appendUserAgent := p.getConfig("appendUserAgent", "GOOGLE_APPEND_USER_AGENT")
+	impersonateServiceAccount := p.getConfig("impersonateServiceAccount", "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT")
 
 	config := googleclient.Config{
 		Credentials:                        p.getConfig("credentials", "GOOGLE_CREDENTIALS"),
 		AccessToken:                        p.getConfig("accessToken", "GOOGLE_OAUTH_ACCESS_TOKEN"),
-		ImpersonateServiceAccount:          p.getConfig("impersonateServiceAccount", "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"),
+		ImpersonateServiceAccount:          impersonateServiceAccount,
 		ImpersonateServiceAccountDelegates: impersonateServiceAccountDelegates,
 		Scopes:                             scopes,
 		PulumiVersion:                      getPulumiVersion(),
@@ -162,7 +166,7 @@ func (p *googleCloudProvider) Invoke(_ context.Context, req *rpc.InvokeRequest) 
 	}
 
 	// Apply default config values.
-	for _, param := range inv.Url.Values {
+	for _, param := range inv.URL.Values {
 		sdkName := param.Name
 		if param.SdkName != "" {
 			sdkName = param.SdkName
@@ -176,7 +180,7 @@ func (p *googleCloudProvider) Invoke(_ context.Context, req *rpc.InvokeRequest) 
 		}
 	}
 
-	uri, err := buildFunctionUrl(inv, args)
+	uri, err := buildFunctionURL(inv, args)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +259,9 @@ func (p *googleCloudProvider) Check(_ context.Context, req *rpc.CheckRequest) (*
 			if value, ok := p.getDefaultValue(key, configName, olds); ok {
 				news[key] = *value
 			} else {
-				reason := fmt.Sprintf("missing required property '%s'. Either set it explicitly or configure it with 'pulumi config set google-native:%s <value>'.", sdkName, configName)
+				reason := fmt.Sprintf(
+					"missing required property '%s'. Either set it explicitly or configure it with "+
+						"'pulumi config set google-native:%s <value>'.", sdkName, configName)
 				failures = append(failures, &rpc.CheckFailure{
 					Reason: reason,
 				})
@@ -290,7 +296,11 @@ func (p *googleCloudProvider) Check(_ context.Context, req *rpc.CheckRequest) (*
 }
 
 // Get a default project name for the given inputs.
-func (p *googleCloudProvider) getDefaultValue(key resource.PropertyKey, configName string, olds resource.PropertyMap) (*resource.PropertyValue, bool) {
+func (p *googleCloudProvider) getDefaultValue(
+	key resource.PropertyKey,
+	configName string,
+	olds resource.PropertyMap,
+) (*resource.PropertyValue, bool) {
 	// 1. Check if old inputs define the value.
 	if v, ok := olds[key]; ok {
 		return &v, true
@@ -394,7 +404,7 @@ func (p *googleCloudProvider) Create(ctx context.Context, req *rpc.CreateRequest
 		return nil, errors.Errorf("resource %q not found", resourceKey)
 	}
 
-	uri, err := buildCreateUrl(res, inputs)
+	uri, err := buildCreateURL(res, inputs)
 	if err != nil {
 		return nil, err
 	}
@@ -424,14 +434,14 @@ func (p *googleCloudProvider) Create(ctx context.Context, req *rpc.CreateRequest
 		}
 	}
 
-	resp, err := p.waitForResourceOpCompletion(res.RootUrl, op)
+	resp, err := p.waitForResourceOpCompletion(res.RootURL, op)
 	if err != nil {
 		if resp == nil {
 			return nil, errors.Wrapf(err, "waiting for completion")
 		}
 		// A partial failure may have occurred because we got an error and a response.
 		// Try reading the resource state and return a partial error if there is some.
-		id, idErr := calculateResourceId(res, inputsMap, resp)
+		id, idErr := calculateResourceID(res, inputsMap, resp)
 		if idErr != nil {
 			return nil, errors.Wrapf(err, "waiting for completion / calculate ID %s", idErr)
 		}
@@ -454,8 +464,11 @@ func (p *googleCloudProvider) Create(ctx context.Context, req *rpc.CreateRequest
 		checkpointObject(inputs, resp),
 		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepSecrets: true, SkipNulls: true},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal checkpoint: %w", err)
+	}
 
-	id, err := calculateResourceId(res, inputsMap, resp)
+	id, err := calculateResourceID(res, inputsMap, resp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "calculating resource ID")
 	}
@@ -477,7 +490,10 @@ func (p *googleCloudProvider) prepareAPIInputs(
 // a success or a failure of provisioning.
 // Note that both a response and an error can be returned in case of a partially-failed deployment
 // (e.g., resource is created but failed to initialize to completion).
-func (p *googleCloudProvider) waitForResourceOpCompletion(baseUrl string, resp map[string]interface{}) (map[string]interface{}, error) {
+func (p *googleCloudProvider) waitForResourceOpCompletion(
+	baseURL string,
+	resp map[string]interface{},
+) (map[string]interface{}, error) {
 	retryPolicy := backoff.Backoff{
 		Min:    1 * time.Second,
 		Max:    15 * time.Second,
@@ -503,7 +519,8 @@ func (p *googleCloudProvider) waitForResourceOpCompletion(baseUrl string, resp m
 			if response, has := resp["response"].(map[string]interface{}); has {
 				return response, err
 			}
-			if operationType, has := resp["operationType"].(string); has && strings.Contains(strings.ToLower(operationType), "delete") {
+			if operationType, has := resp["operationType"].(string); has &&
+				strings.Contains(strings.ToLower(operationType), "delete") {
 				return resp, err
 			}
 			// Check if there's a target link.
@@ -527,22 +544,22 @@ func (p *googleCloudProvider) waitForResourceOpCompletion(baseUrl string, resp m
 			return resp, nil
 		}
 
-		var pollUri string
+		var pollURI string
 		if selfLink, has := resp["selfLink"].(string); has && hasStatus {
-			pollUri = selfLink
+			pollURI = selfLink
 		} else {
 			if name, has := resp["name"].(string); has && strings.HasPrefix(name, "operations/") {
-				pollUri = fmt.Sprintf("%s/v1/%s", baseUrl, name)
+				pollURI = fmt.Sprintf("%s/v1/%s", baseURL, name)
 			}
 		}
 
-		if pollUri == "" {
+		if pollURI == "" {
 			return resp, nil
 		}
 
 		time.Sleep(retryPolicy.Duration())
 
-		op, err := p.client.RequestWithTimeout("GET", pollUri, nil, 0)
+		op, err := p.client.RequestWithTimeout("GET", pollURI, nil, 0)
 		if err != nil {
 			return nil, errors.Wrapf(err, "polling operation status")
 		}
@@ -562,7 +579,7 @@ func (p *googleCloudProvider) Read(_ context.Context, req *rpc.ReadRequest) (*rp
 	}
 
 	id := req.GetId()
-	uri := res.ResourceUrl(id)
+	uri := res.ResourceURL(id)
 
 	// Retrieve the old state.
 	oldState, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{
@@ -587,20 +604,19 @@ func (p *googleCloudProvider) Read(_ context.Context, req *rpc.ReadRequest) (*rp
 	newStateProps := resource.NewPropertyMapFromMap(newState)
 	if inputs == nil {
 		return nil, status.Error(codes.Unimplemented, "Import is not yet implemented")
-	} else {
-		// It's hard to infer the changes in the inputs shape based on the outputs without false positives.
-		// The current approach is complicated but it's aimed to minimize the noise while refreshing:
-		// 0. We have "old" inputs and outputs before refresh and "new" outputs read from API.
-		// 1. Project old outputs to their corresponding input shape (exclude read-only properties).
-		oldInputProjection := getInputsFromState(res, oldState)
-		// 2. Project new outputs to their corresponding input shape (exclude read-only properties).
-		newInputProjection := getInputsFromState(res, newStateProps)
-		// 3. Calculate the difference between two projections. This should give us actual significant changes
-		// that happened in Google Cloud between the last resource update and its current state.
-		diff := oldInputProjection.Diff(newInputProjection)
-		// 4. Apply this difference to the actual inputs (not a projection) that we have in state.
-		inputs = applyDiff(inputs, diff)
 	}
+	// It's hard to infer the changes in the inputs shape based on the outputs without false positives.
+	// The current approach is complicated but it's aimed to minimize the noise while refreshing:
+	// 0. We have "old" inputs and outputs before refresh and "new" outputs read from API.
+	// 1. Project old outputs to their corresponding input shape (exclude read-only properties).
+	oldInputProjection := getInputsFromState(res, oldState)
+	// 2. Project new outputs to their corresponding input shape (exclude read-only properties).
+	newInputProjection := getInputsFromState(res, newStateProps)
+	// 3. Calculate the difference between two projections. This should give us actual significant changes
+	// that happened in Google Cloud between the last resource update and its current state.
+	diff := oldInputProjection.Diff(newInputProjection)
+	// 4. Apply this difference to the actual inputs (not a projection) that we have in state.
+	inputs = applyDiff(inputs, diff)
 
 	// Store both outputs and inputs into the state checkpoint.
 	checkpoint, err := plugin.MarshalProperties(
@@ -652,7 +668,7 @@ func (p *googleCloudProvider) Update(_ context.Context, req *rpc.UpdateRequest) 
 
 	body := p.prepareAPIInputs(inputs, oldState, res.Update.SDKProperties)
 
-	uri := res.ResourceUrl(req.GetId())
+	uri := res.ResourceURL(req.GetId())
 	if strings.HasSuffix(uri, ":getIamPolicy") {
 		uri = strings.ReplaceAll(uri, ":getIamPolicy", ":setIamPolicy")
 	}
@@ -662,7 +678,7 @@ func (p *googleCloudProvider) Update(_ context.Context, req *rpc.UpdateRequest) 
 		return nil, fmt.Errorf("error sending request: %s: %q %+v", err, uri, body)
 	}
 
-	resp, err := p.waitForResourceOpCompletion(res.RootUrl, op)
+	resp, err := p.waitForResourceOpCompletion(res.RootURL, op)
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for completion")
 	}
@@ -682,6 +698,9 @@ func (p *googleCloudProvider) Update(_ context.Context, req *rpc.UpdateRequest) 
 		checkpointObject(newInputs, resp),
 		plugin.MarshalOptions{Label: fmt.Sprintf("%s.response", label), KeepSecrets: true, SkipNulls: true},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal checkpoint: %w", err)
+	}
 
 	return &rpc.UpdateResponse{
 		Properties: outputs,
@@ -698,7 +717,7 @@ func (p *googleCloudProvider) Delete(_ context.Context, req *rpc.DeleteRequest) 
 		return nil, errors.Errorf("resource %q not found", resourceKey)
 	}
 
-	uri := res.ResourceUrl(req.GetId())
+	uri := res.ResourceURL(req.GetId())
 
 	if res.Delete.Undefined() {
 		// At the time of writing, the classic GCP provider has the same behavior and warning for 10 resources.
@@ -708,15 +727,12 @@ func (p *googleCloudProvider) Delete(_ context.Context, req *rpc.DeleteRequest) 
 		return &empty.Empty{}, nil
 	}
 
-	// TODO: special handling for CryptoKey
-	//p.client.RequestWithTimeout("POST", "v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:destroy")
-
 	resp, err := p.client.RequestWithTimeout("DELETE", uri, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("error sending request: %s", err)
 	}
 
-	_, err = p.waitForResourceOpCompletion(res.RootUrl, resp)
+	_, err = p.waitForResourceOpCompletion(res.RootURL, resp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for completion")
 	}
@@ -774,11 +790,10 @@ func (p *googleCloudProvider) getPartnerName() string {
 	result := p.getConfig("partnerName", "GOOGLE_PARTNER_NAME")
 	if result != "" {
 		return result
-	} else {
-		disablePartner := p.getConfig("disablePartnerName", "GOOGLE_DISABLE_PARTNER_NAME")
-		if disablePartner == "true" {
-			return ""
-		}
+	}
+	disablePartner := p.getConfig("disablePartnerName", "GOOGLE_DISABLE_PARTNER_NAME")
+	if disablePartner == "true" {
+		return ""
 	}
 	return "Pulumi"
 }

--- a/provider/pkg/provider/serve.go
+++ b/provider/pkg/provider/serve.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package provider
 

--- a/provider/pkg/resources/convert.go
+++ b/provider/pkg/resources/convert.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package resources
 
@@ -6,8 +18,6 @@ import (
 	"reflect"
 	"strings"
 )
-
-const body = "body"
 
 // SdkShapeConverter providers functions to convert between HTTP request/response shapes and
 // Pulumi SDK shapes (with flattening, renaming, etc.).

--- a/provider/pkg/resources/convert.go
+++ b/provider/pkg/resources/convert.go
@@ -25,9 +25,16 @@ type SdkShapeConverter struct {
 	Types map[string]CloudAPIType
 }
 
-type convertPropValues func(props map[string]CloudAPIProperty, inputs, state map[string]interface{}) map[string]interface{}
+type convertPropValues func(
+	props map[string]CloudAPIProperty,
+	inputs, state map[string]interface{},
+) map[string]interface{}
 
-func (k *SdkShapeConverter) convertPropValue(prop *CloudAPIProperty, value, state interface{}, convertMap convertPropValues) interface{} {
+func (k *SdkShapeConverter) convertPropValue(
+	prop *CloudAPIProperty,
+	value, state interface{},
+	convertMap convertPropValues,
+) interface{} {
 	if value == nil {
 		return nil
 	}

--- a/provider/pkg/resources/convert_test.go
+++ b/provider/pkg/resources/convert_test.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package resources
 
@@ -53,38 +65,42 @@ var resourceMap = &CloudAPIMetadata{
 	},
 	Resources: map[string]CloudAPIResource{
 		"r1": {
-			CreateProperties: map[string]CloudAPIProperty{
-				"name": {},
-				"x-threshold": {
-					SdkName: "threshold",
-				},
-				"structure": {
-					Ref: "#/types/google-native:testing:Structure",
-				},
-				"p1": {
-					Container: "properties",
-				},
-				"p2": {
-					Container: "properties",
-				},
-				"more": {
-					Container: "properties",
-					Ref:       "#/types/google-native:testing:More",
-				},
-				"tags":         {},
-				"untypedArray": {},
-				"untypedDict": {
-					Ref: "pulumi.json#/Any",
+			Create: CloudAPIOperation{
+				SDKProperties: map[string]CloudAPIProperty{
+					"name": {},
+					"x-threshold": {
+						SdkName: "threshold",
+					},
+					"structure": {
+						Ref: "#/types/google-native:testing:Structure",
+					},
+					"p1": {
+						Container: "properties",
+					},
+					"p2": {
+						Container: "properties",
+					},
+					"more": {
+						Container: "properties",
+						Ref:       "#/types/google-native:testing:More",
+					},
+					"tags":         {},
+					"untypedArray": {},
+					"untypedDict": {
+						Ref: "pulumi.json#/Any",
+					},
 				},
 			},
-			UpdateProperties: map[string]CloudAPIProperty{
-				"more": {
-					Container: "properties",
-					Ref:       "#/types/google-native:testing:More",
-				},
-				"tags": {},
-				"tagsFingerprint": {
-					CopyFromOutputs: true,
+			Update: CloudAPIOperation{
+				SDKProperties: map[string]CloudAPIProperty{
+					"more": {
+						Container: "properties",
+						Ref:       "#/types/google-native:testing:More",
+					},
+					"tags": {},
+					"tagsFingerprint": {
+						CopyFromOutputs: true,
+					},
 				},
 			},
 		},
@@ -201,7 +217,7 @@ var sampleAPIUpdatePackage = map[string]interface{}{
 }
 
 func TestSdkPropertiesToRequestBody(t *testing.T) {
-	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	bodyProperties := resourceMap.Resources["r1"].Create.SDKProperties
 	data := c.SdkPropertiesToRequestBody(bodyProperties, sampleSdkProps, nil)
 	assert.Equal(t, sampleAPIPackage, data)
 }
@@ -237,7 +253,7 @@ func TestSdkPropertiesToRequestBodyWithState(t *testing.T) {
 			"key1": "value1",
 		},
 	}
-	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	bodyProperties := resourceMap.Resources["r1"].Create.SDKProperties
 	data := c.SdkPropertiesToRequestBody(bodyProperties, sampleSdkProps, state)
 	assert.Equal(t, sampleAPIPackage, data)
 }
@@ -257,7 +273,7 @@ func TestSdkPropertiesToRequestBodyEmptyCollections(t *testing.T) {
 			},
 		},
 	}
-	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	bodyProperties := resourceMap.Resources["r1"].Create.SDKProperties
 	actualBody := c.SdkPropertiesToRequestBody(bodyProperties, emptyCollectionData, nil)
 	assert.Equal(t, expectedBody, actualBody)
 }
@@ -277,13 +293,13 @@ func TestSdkPropertiesToRequestBodyNilCollections(t *testing.T) {
 			},
 		},
 	}
-	bodyProperties := resourceMap.Resources["r1"].CreateProperties
+	bodyProperties := resourceMap.Resources["r1"].Create.SDKProperties
 	actualBody := c.SdkPropertiesToRequestBody(bodyProperties, nilCollectionData, nil)
 	assert.Equal(t, expectedBody, actualBody)
 }
 
 func TestSdkPropertiesToRequestBodyCopyOutputs(t *testing.T) {
-	bodyProperties := resourceMap.Resources["r1"].UpdateProperties
+	bodyProperties := resourceMap.Resources["r1"].Update.SDKProperties
 	data := c.SdkPropertiesToRequestBody(bodyProperties, sampleSdkProps, sampleSdkState)
 	assert.Equal(t, sampleAPIUpdatePackage, data)
 }

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -72,19 +72,19 @@ type CloudAPIResource struct {
 	Update CloudAPIOperation `json:"update,omitempty"`
 	Delete CloudAPIOperation `json:"delete,omitempty"`
 
-	// RootUrl is the root URL of the REST API.
+	// RootURL is the root URL of the REST API.
 	// Example: `https://cloudkms.googleapis.com/`
-	RootUrl     string `json:"rootUrl"`
+	RootURL     string `json:"rootUrl"`
 	AssetUpload bool   `json:"assetUpload,omitempty"`
 	// TODO: abstract ID property details
-	// IdProperty contains the name of the output property that represents resource ID (a self link).
+	// IDProperty contains the name of the output property that represents resource ID (a self link).
 	// Example: `selfLink`
-	IdProperty string `json:"idProperty,omitempty"`
-	// IdPath is the template for building resource ID with ID parameter values. It should only
-	// be defined if IdProperty is missing.
+	IDProperty string `json:"idProperty,omitempty"`
+	// IDPath is the template for building resource ID with ID parameter values. It should only
+	// be defined if IDProperty is missing.
 	// Example: `projects/{project}/global/backendBuckets/{resource}/getIamPolicy`
-	IdPath   string            `json:"idPath,omitempty"`
-	IdParams map[string]string `json:"idParams,omitempty"`
+	IDPath   string            `json:"idPath,omitempty"`
+	IDParams map[string]string `json:"idParams,omitempty"`
 	// AutoNamePattern contains a string pattern when a default name should be automatically generated if a user hasn't
 	// explicitly specified one.
 	// Example: `projects/{project}/locations/{location}/functions/{name}`
@@ -93,7 +93,7 @@ type CloudAPIResource struct {
 
 // CloudAPIFunction is a function in Google Cloud REST API.
 type CloudAPIFunction struct {
-	Url  CloudAPIEndpoint `json:"url"`
+	URL  CloudAPIEndpoint `json:"url"`
 	Verb string           `json:"verb"`
 }
 
@@ -109,17 +109,17 @@ type CloudAPIResourceParam struct {
 	Kind string `json:"kind"`
 }
 
-// ResourceUrl returns the resource API URL by joining the base URL with the resource path.
-func (r *CloudAPIResource) ResourceUrl(path string) string {
-	return CombineUrl(r.RootUrl, path)
+// ResourceURL returns the resource API URL by joining the base URL with the resource path.
+func (r *CloudAPIResource) ResourceURL(path string) string {
+	return CombineURL(r.RootURL, path)
 }
 
-// CombineUrl concats a base URL of the service with a path of an endpoint.
-func CombineUrl(baseUrl, path string) string {
+// CombineURL concatenates a base URL of the service with a path of an endpoint.
+func CombineURL(baseURL, path string) string {
 	if strings.HasPrefix(path, "https://") {
 		return path
 	}
-	return fmt.Sprintf("%s/%s", strings.TrimRight(baseUrl, "/"), strings.TrimLeft(path, "/"))
+	return fmt.Sprintf("%s/%s", strings.TrimRight(baseURL, "/"), strings.TrimLeft(path, "/"))
 }
 
 // CloudAPIProperty is a property of a body of an API call payload.

--- a/provider/pkg/version/version.go
+++ b/provider/pkg/version/version.go
@@ -1,4 +1,16 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package version
 


### PR DESCRIPTION
This change refactors the resource metadata used by the provider to perform resource operations. The previous layout assumed that certain REST operations worked the same across the SDK, while the new layout explicitly includes information for every CRUD operation.