### PR TITLE
Use schema information for all REST operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+Improvements:
+
+- Use schema information for all REST operations [#374](https://github.com/pulumi/pulumi-google-native/pull/374)
 
 ## 0.15.0 (2022-02-28)
 Improvements:

--- a/provider/pkg/gen/discovery.go
+++ b/provider/pkg/gen/discovery.go
@@ -66,9 +66,9 @@ func findResourcesImpl(docName, parentName string, rest map[string]discovery.Res
 				if createMethod == nil {
 					createMethod = &restMethod
 				}
-			case "update", "replaceService" /*special case for Cloud Run*/ :
-				updateMethod = &restMethod
 			case "patch":
+				updateMethod = &restMethod
+			case "update", "replaceService" /*special case for Cloud Run*/ :
 				if updateMethod == nil {
 					updateMethod = &restMethod
 				}

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -544,6 +544,8 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 				fmt.Printf("Failed to build ID params for resource %s: %v\n", resourceTok, err)
 				return nil
 			}
+			// TODO: This logic could be extracted into something more generic. Currently, the value computation
+			//       is always based on the GET method, so this may not be universally correct.
 			for _, k := range codegen.SortedKeys(vals) {
 				v := resources.CloudAPIResourceParam{
 					Name:    k,

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -330,43 +330,59 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 	inputProperties := map[string]schema.PropertySpec{}
 	requiredInputProperties := codegen.NewStringSet()
 
+	fullPath := func(method *discovery.RestMethod) string {
+		if method == nil {
+			return ""
+		}
+		var pathURL string
+		if len(method.FlatPath) > 0 {
+			pathURL = resources.AssembleURL(g.rest.RootUrl, g.rest.BasePath, method.FlatPath)
+		} else {
+			pathURL = resources.AssembleURL(g.rest.RootUrl, g.rest.BasePath, method.Path)
+		}
+
+		queryParams := url.Values{}
+		for param, details := range method.Parameters {
+			if details.Location != "query" || !details.Required {
+				continue
+			}
+			queryParams.Add(param, "{"+param+"}")
+		}
+		if len(queryParams) > 0 {
+			var err error
+			pathURL, err = url.QueryUnescape(pathURL + "?" + queryParams.Encode())
+			if err != nil {
+				fmt.Printf("Failed to unescape query params for resource: %s: %v\n", resourceTok, err)
+				return ""
+			}
+		}
+		return pathURL
+	}
 	methodPath := func(method *discovery.RestMethod) string {
 		if method == nil {
 			return ""
 		}
 		if len(method.FlatPath) > 0 {
-			return resources.AssembleURL(g.rest.RootUrl, g.rest.BasePath, method.FlatPath)
+			return method.FlatPath
 		}
 
-		return resources.AssembleURL(g.rest.RootUrl, g.rest.BasePath, method.Path)
+		return method.Path
 	}
-	createPath := methodPath(dd.createMethod)
+	createPath := fullPath(dd.createMethod)
 
-	baseURL := resources.CombineURL(g.rest.RootUrl, g.rest.BasePath)
 	resourceMeta := resources.CloudAPIResource{
 		RootURL: g.rest.BaseUrl,
 		Create: resources.CloudAPIOperation{
 			Endpoint: resources.CloudAPIEndpoint{
-				Template: methodPath(dd.createMethod),
+				Template: fullPath(dd.createMethod),
 			},
 			Verb: dd.createMethod.HttpMethod,
 		},
-		Delete: resources.CloudAPIOperation{
-			Endpoint: resources.CloudAPIEndpoint{
-				Template: resources.CombineURL(baseURL, methodPath(dd.deleteMethod)),
-			},
-		},
+		Delete: resources.CloudAPIOperation{},
 		Read: resources.CloudAPIOperation{
-			Endpoint: resources.CloudAPIEndpoint{
-				Template: resources.CombineURL(baseURL, methodPath(dd.getMethod)),
-			},
 			Verb: dd.getMethod.HttpMethod,
 		},
-		Update: resources.CloudAPIOperation{
-			Endpoint: resources.CloudAPIEndpoint{
-				Template: resources.CombineURL(baseURL, methodPath(dd.getMethod)),
-			},
-		},
+		Update: resources.CloudAPIOperation{},
 	}
 	patternParams := codegen.NewStringSet()
 
@@ -495,18 +511,24 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		for _, p := range []string{"selfLink", "self"} {
 			if _, has := response.Properties[p]; has {
 				resourceMeta.IDProperty = p
+				resourceMeta.Read.Endpoint.SelfLinkProperty = p
+				resourceMeta.Update.Endpoint.SelfLinkProperty = p
+				resourceMeta.Delete.Endpoint.SelfLinkProperty = p
 				break
 			}
 		}
 
 		// Option 2: the provider has to manually build it from the GET method path.
 		if resourceMeta.IDProperty == "" {
+			var idVals []resources.CloudAPIResourceParam
+			queryValNames := codegen.NewStringSet()
 			idPath := methodPath(dd.getMethod)
 			queryParams := url.Values{}
 			for param, details := range dd.getMethod.Parameters {
 				if details.Location != "query" || !details.Required {
 					continue
 				}
+				queryValNames.Add(param)
 				queryParams.Add(param, "{"+param+"}")
 			}
 			if len(queryParams) > 0 {
@@ -522,25 +544,46 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 				fmt.Printf("Failed to build ID params for resource %s: %v\n", resourceTok, err)
 				return nil
 			}
-			resourceMeta.Read.Endpoint.Template = idPath
-			var idVals []resources.CloudAPIResourceParam
 			for _, k := range codegen.SortedKeys(vals) {
-				idVals = append(idVals, resources.CloudAPIResourceParam{
+				v := resources.CloudAPIResourceParam{
 					Name:    k,
 					SdkName: vals[k],
 					Kind:    "path",
-				})
+				}
+				if queryValNames.Has(k) {
+					v.Kind = "query"
+				}
+				idVals = append(idVals, v)
 			}
-			resourceMeta.Read.Endpoint.Values = idVals
+			if p := fullPath(dd.getMethod); len(p) > 0 {
+				resourceMeta.Read.Endpoint.Template = p
+				resourceMeta.Read.Endpoint.Values = idVals
+			}
+			if p := fullPath(dd.updateMethod); len(p) > 0 {
+				resourceMeta.Update.Endpoint.Template = p
+				resourceMeta.Update.Endpoint.Values = idVals
+			}
+			if p := fullPath(dd.deleteMethod); len(p) > 0 {
+				resourceMeta.Delete.Endpoint.Template = p
+				resourceMeta.Delete.Endpoint.Values = idVals
+			}
 			resourceMeta.IDPath = idPath
 			resourceMeta.IDParams = vals
+		}
+	}
+
+	if d := dd.deleteMethod; d != nil {
+		if v := d.HttpMethod; len(v) > 0 {
+			resourceMeta.Delete.Verb = v
+		} else {
+			resourceMeta.Delete.Verb = "DELETE"
 		}
 	}
 
 	// Detect resources that support media upload and mark them as such.
 	if dd.createMethod.MediaUpload != nil && dd.createMethod.MediaUpload.Protocols != nil &&
 		dd.createMethod.MediaUpload.Protocols.Simple != nil {
-		resourceMeta.Create.Endpoint.Template = resources.CombineURL(
+		resourceMeta.Create.Endpoint.Template = resources.AssembleURL(
 			g.rest.RootUrl, dd.createMethod.MediaUpload.Protocols.Simple.Path)
 		resourceMeta.AssetUpload = true
 		inputProperties["source"] = schema.PropertySpec{
@@ -548,12 +591,6 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 				Ref: "pulumi.json#/Asset",
 			},
 		}
-	}
-
-	// TODO: add delete support
-	if dd.deleteMethod != nil {
-		resourceMeta.Delete.Endpoint.Template = resourceMeta.IDPath
-		resourceMeta.Delete.Verb = dd.deleteMethod.HttpMethod
 	}
 
 	description := dd.createMethod.Description
@@ -615,7 +652,7 @@ func (g *packageGenerator) genFunction(typeName string, dd discoveryDocumentReso
 	}
 	functionMeta := resources.CloudAPIFunction{
 		URL: resources.CloudAPIEndpoint{
-			Template: resources.CombineURL(g.rest.BaseUrl, getPath),
+			Template: resources.AssembleURL(g.rest.BaseUrl, getPath),
 		},
 		Verb: httpMethod,
 	}

--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -42,9 +42,9 @@ func calculateResourceID(
 	idParams := res.IDParams
 	for name, alias := range idParams {
 		var propValue string
-		if v, has := evalPropertyValue(inputs, alias); has {
+		if v, has := resources.EvalPropertyValue(inputs, alias); has {
 			propValue = v
-		} else if v, has := evalPropertyValue(outputs, alias); has {
+		} else if v, has := resources.EvalPropertyValue(outputs, alias); has {
 			propValue = v
 		}
 
@@ -60,26 +60,6 @@ func calculateResourceID(
 		id = strings.Replace(id, fmt.Sprintf("{%s}", name), propValue, 1)
 	}
 	return id, nil
-}
-
-func evalPropertyValue(values map[string]interface{}, path string) (string, bool) {
-	current := values
-	parts := strings.Split(path, ".")
-	for idx, part := range parts {
-		value := current[part]
-		if idx == len(parts)-1 {
-			if str, ok := value.(string); ok {
-				return str, true
-			}
-			return "", false
-		}
-		childMap, ok := value.(map[string]interface{})
-		if !ok {
-			return "", false
-		}
-		current = childMap
-	}
-	return "", false
 }
 
 // buildCreateURL composes the URL to invoke to create a resource with given inputs.

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -62,35 +62,6 @@ func TestCalculateResourceId_IdPath(t *testing.T) {
 	assert.Equal(t, "/v1/myparent/foo/myresource/bar", actual)
 }
 
-func TestEvalPropertyValue(t *testing.T) {
-	values := map[string]interface{}{
-		"a": "123",
-		"b": map[string]interface{}{
-			"c": map[string]interface{}{
-				"d": "456",
-			},
-		},
-		"notastring": 789,
-	}
-
-	a, has := evalPropertyValue(values, "a")
-	assert.True(t, has)
-	assert.Equal(t, "123", a)
-
-	_, has = evalPropertyValue(values, "unknown")
-	assert.False(t, has)
-
-	d, has := evalPropertyValue(values, "b.c.d")
-	assert.True(t, has)
-	assert.Equal(t, "456", d)
-
-	_, has = evalPropertyValue(values, "b.unknown.d")
-	assert.False(t, has)
-
-	_, has = evalPropertyValue(values, "notastring")
-	assert.False(t, has)
-}
-
 func TestGetDefaultName_Generated(t *testing.T) {
 	urn := resource.URN("urn:pulumi:dev::test::test-provider:testModule:TestResource::myName")
 	olds := resource.NewPropertyMapFromMap(map[string]interface{}{})

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -677,7 +677,6 @@ func (p *googleCloudProvider) Update(_ context.Context, req *rpc.UpdateRequest) 
 	if err != nil {
 		return nil, err
 	}
-	//uri := res.ResourceURL(req.GetId())
 
 	if strings.HasSuffix(uri, ":getIamPolicy") {
 		uri = strings.ReplaceAll(uri, ":getIamPolicy", ":setIamPolicy")

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -15,9 +15,7 @@
 package resources
 
 import (
-	"bytes"
 	"fmt"
-	"net/http"
 	"strings"
 )
 
@@ -48,7 +46,7 @@ func (e CloudAPIEndpoint) URI(
 	if len(e.SelfLinkProperty) > 0 {
 		v, ok := outputs[e.SelfLinkProperty].(string)
 		if !ok {
-			return "", fmt.Errorf("ID property %q not found", e.SelfLinkProperty)
+			return "", fmt.Errorf("selfLink property %q not found", e.SelfLinkProperty)
 		}
 		return v, nil
 	}
@@ -105,24 +103,10 @@ type CloudAPIOperation struct {
 	SDKProperties map[string]CloudAPIProperty `json:"sdkProperties,omitempty"`
 	// Verb is the REST verb to use for API calls.
 	Verb string `json:"verb,omitempty"`
-
-	// Optional handler function for more complex operations.
-	// If a handler is defined, the endpoint and verb are ignored.
-	// TODO: probably need resource state -- figure this out later
-	//Handler func() error `json:"handler,omitempty"`
 }
 
 func (o CloudAPIOperation) Undefined() bool {
 	return len(o.Verb) == 0
-}
-
-func (o CloudAPIOperation) Request() (*http.Request, error) {
-	// TODO: refactor logic from http.RequestWithTimeout
-	// TODO: expand endpoint template
-	// TODO: marshal body
-	body := bytes.Buffer{}
-	endpoint := ""
-	return http.NewRequest(o.Verb, endpoint, &body)
 }
 
 // CloudAPIResource is a resource in the Google Cloud REST API.
@@ -136,7 +120,6 @@ type CloudAPIResource struct {
 	// Example: `https://cloudkms.googleapis.com/`
 	RootURL     string `json:"rootUrl"`
 	AssetUpload bool   `json:"assetUpload,omitempty"`
-	// TODO: abstract ID property details
 	// IDProperty contains the name of the output property that represents resource ID (a self link).
 	// Example: `selfLink`
 	IDProperty string `json:"idProperty,omitempty"`

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -55,9 +55,9 @@ func (e CloudAPIEndpoint) URI(
 	idParams := e.Values
 	for _, param := range idParams {
 		var propValue string
-		if v, has := evalPropertyValue(inputs, param.SdkName); has {
+		if v, has := EvalPropertyValue(inputs, param.SdkName); has {
 			propValue = v
-		} else if v, has := evalPropertyValue(outputs, param.SdkName); has {
+		} else if v, has := EvalPropertyValue(outputs, param.SdkName); has {
 			propValue = v
 		}
 
@@ -75,7 +75,7 @@ func (e CloudAPIEndpoint) URI(
 	return id, nil
 }
 
-func evalPropertyValue(values map[string]interface{}, path string) (string, bool) {
+func EvalPropertyValue(values map[string]interface{}, path string) (string, bool) {
 	current := values
 	parts := strings.Split(path, ".")
 	for idx, part := range parts {

--- a/provider/pkg/resources/resources_test.go
+++ b/provider/pkg/resources/resources_test.go
@@ -15,9 +15,54 @@
 package resources
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestCalculateResourceId_IdProperty(t *testing.T) {
+	endpoint := CloudAPIEndpoint{
+		SelfLinkProperty: "selfLink",
+	}
+	inputs := map[string]interface{}{
+		"name": "foo",
+	}
+	expected := "https://myapi.google.com/v1/myresource/foo"
+	outputs := map[string]interface{}{
+		"name":     "foo",
+		"selfLink": "https://myapi.google.com/v1/myresource/foo",
+	}
+	actual, err := endpoint.URI(inputs, outputs)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestCalculateResourceId_IdPath(t *testing.T) {
+	endpoint := CloudAPIEndpoint{
+		Template: "/v1/myparent/{parentsId}/myresource/{myresourcesId}",
+		Values: []CloudAPIResourceParam{
+			{
+				Name:    "parentsId",
+				SdkName: "parentId",
+			},
+			{
+				Name:    "myresourcesId",
+				SdkName: "reference.name",
+			},
+		},
+	}
+	inputs := map[string]interface{}{
+		"parentId": "foo",
+	}
+	outputs := map[string]interface{}{
+		"reference": map[string]interface{}{
+			"name": "myparent/foo/myresource/bar",
+		},
+	}
+	actual, err := endpoint.URI(inputs, outputs)
+	assert.NoError(t, err)
+	assert.Equal(t, "/v1/myparent/foo/myresource/bar", actual)
+}
 
 func TestEvalPropertyValue(t *testing.T) {
 	values := map[string]interface{}{

--- a/provider/pkg/resources/resources_test.go
+++ b/provider/pkg/resources/resources_test.go
@@ -1,0 +1,49 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEvalPropertyValue(t *testing.T) {
+	values := map[string]interface{}{
+		"a": "123",
+		"b": map[string]interface{}{
+			"c": map[string]interface{}{
+				"d": "456",
+			},
+		},
+		"notastring": 789,
+	}
+
+	a, has := EvalPropertyValue(values, "a")
+	assert.True(t, has)
+	assert.Equal(t, "123", a)
+
+	_, has = EvalPropertyValue(values, "unknown")
+	assert.False(t, has)
+
+	d, has := EvalPropertyValue(values, "b.c.d")
+	assert.True(t, has)
+	assert.Equal(t, "456", d)
+
+	_, has = EvalPropertyValue(values, "b.unknown.d")
+	assert.False(t, has)
+
+	_, has = EvalPropertyValue(values, "notastring")
+	assert.False(t, has)
+}


### PR DESCRIPTION
Previously, the provider computed a resource ID during the Create operation, and then used this ID with hardcoded HTTP verbs for Read, Update, and Delete operations. While this works for many resources, some don’t follow this pattern. This change refactors the provider logic to use the endpoints and HTTP verbs specified for each operation by the schema.

---

I computed a [metadata diff](https://gist.github.com/lblackstone/52f66a0e9e9c4e819d999e9f3a0c1f8e) compared to the `v0.15.0` release. There are a bunch of changes to resources with a `IamPolicy` suffix that change `get` to `set` on update methods. The old metadata was not accurate for these cases, and the provider [previously handled them with an override](https://github.com/pulumi/pulumi-google-native/blob/v0.15.0/provider/pkg/provider/provider.go#L645-L647). 

Beyond that, the main changes are to HTTP verbs. The default update method changed from PUT to PATCH, and the `IamPolicy` resources were incorrectly using GET instead of POST for Read operations.

I looked through the proposed changes, and they all seem reasonable.