### PR TITLE
Check for override functions on resource delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-- Re-introduce deprecated fields [#368](https://github.com/pulumi/pulumi-google-native/pull/368)
 
 Improvements:
 
+- Re-introduce deprecated fields [#368](https://github.com/pulumi/pulumi-google-native/pull/368)
+- Check for override functions on resource delete [#381](https://github.com/pulumi/pulumi-google-native/pull/381)
 - Add missing descriptions for many resource properties [#384](https://github.com/pulumi/pulumi-google-native/pull/384)
 
 ## 0.16.0 (2022-03-11)

--- a/provider/pkg/googleclient/http.go
+++ b/provider/pkg/googleclient/http.go
@@ -82,6 +82,9 @@ func New(ctx context.Context, config Config) (*GoogleClient, error) {
 	return googleClient, nil
 }
 
+// HTTPClient returns an initialized HTTP client for Google Cloud.
+func (c *GoogleClient) HTTPClient() *http.Client { return c.http }
+
 // RequestWithTimeout performs the specified request using the specified HTTP method and with the specified timeout.
 // TODO: This is taken from the TF provider (cut down to a minimal viable thing). We need to make it "good".
 func (c *GoogleClient) RequestWithTimeout(

--- a/provider/pkg/provider/overrides.go
+++ b/provider/pkg/provider/overrides.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-google-native/provider/pkg/resources"
+	"google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/option"
+)
+
+var ResourceDeleteOverrides = map[string]func(
+	providerInstance *googleCloudProvider,
+	res resources.CloudAPIResource,
+	inputs, outputs map[string]interface{},
+) error{
+	"google-native:cloudkms/v1:CryptoKey": func(
+		providerInstance *googleCloudProvider,
+		res resources.CloudAPIResource,
+		inputs, outputs map[string]interface{},
+	) error {
+		// TODO: may need to pass ctx for cancellation
+		ctx := context.Background()
+		clientkms, err := cloudkms.NewService(ctx, option.WithHTTPClient(providerInstance.client.HTTPClient()))
+		if err != nil {
+			return err
+		}
+		name := outputs["name"].(string)
+
+		versionsClient := clientkms.Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions
+		versionsResponse, err := versionsClient.List(name).Do()
+		if err != nil {
+			return err
+		}
+
+		// Destroy all versions of this CryptoKey.
+		for _, version := range versionsResponse.CryptoKeyVersions {
+			request := &cloudkms.DestroyCryptoKeyVersionRequest{}
+			_, err = versionsClient.Destroy(version.Name, request).Do()
+			if err != nil {
+				return err
+			}
+		}
+
+		// If key rotation is set, disable to avoid creating new keys in the future.
+		if _, ok := outputs["rotationPeriod"]; ok {
+			keyClient := clientkms.Projects.Locations.KeyRings.CryptoKeys
+			_, err = keyClient.
+				Patch(
+					name,
+					&cloudkms.CryptoKey{
+						NullFields: []string{"rotationPeriod", "nextRotationTime"},
+					}).
+				UpdateMask("rotationPeriod,nextRotationTime").Do()
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}


### PR DESCRIPTION
Previously, the provider always mapped resource operations 1:1 with a REST API call. While this works for many cases, some operations are more complex, and require special handling. This change adds lookup tables of functions for each type of operation. If a function is present for a particular resource, this function will be executed by the provider instead of using the default REST logic.