### PR TITLE
Drop obsolete substitution logic from provider Update

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -678,10 +678,6 @@ func (p *googleCloudProvider) Update(_ context.Context, req *rpc.UpdateRequest) 
 		return nil, err
 	}
 
-	if strings.HasSuffix(uri, ":getIamPolicy") {
-		uri = strings.ReplaceAll(uri, ":getIamPolicy", ":setIamPolicy")
-	}
-
 	op, err := p.client.RequestWithTimeout(res.Update.Verb, uri, body, 0)
 	if err != nil {
 		return nil, fmt.Errorf("error sending request: %s: %q %+v", err, uri, body)


### PR DESCRIPTION
Prior to 096d781, the provider metadata did not map setIamPolicy methods correctly for resource Updates, so they were updated during a resource Update. The metadata has been corrected, so the manual substitution is no longer required.