### PR TITLE
Fix regression in schema decompressor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+## 0.17.1 (2022-03-17)
+Bug fixes:
+
+- Fix regression in schema decompressor [#397](https://github.com/pulumi/pulumi-google-native/pull/397)
+
 ## 0.17.0 (2022-03-16)
 Improvements:
 

--- a/provider/pkg/gen/compression.go
+++ b/provider/pkg/gen/compression.go
@@ -43,7 +43,9 @@ func DecompressSchema(compressedSchema []byte) ([]byte, error) {
 		return nil, errors.Wrap(err, "expand compressed schema")
 	}
 	uncompressedBuf := bytes.Buffer{}
-	if _, err = io.CopyN(&uncompressedBuf, uncompressed, 1024); err != nil {
+	//nolint: gosec
+	// Ignore warning about decompression bomb since we control the input.
+	if _, err = io.Copy(&uncompressedBuf, uncompressed); err != nil {
 		return nil, err
 	}
 	if err = uncompressed.Close(); err != nil {


### PR DESCRIPTION
The io.CopyN function only copies up to N bytes, so this was failing for long schema elements. Reverted the change and disabled the lint check for this line.