### PR TITLE
Move change check to prerequisites

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -67,6 +67,13 @@ jobs:
 
             ${{ env.SCHEMA_CHANGES }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add label if no breaking changes
+        if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.')
+        uses: actions-ecosystem/action-add-labels@v1.1.0
+        with:
+          labels: impact/no-changelog-required
+          number: ${{ github.event.issue.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build provider binary
         run: make provider
       - name: Check worktree clean
@@ -233,10 +240,3 @@ jobs:
           set -euo pipefail
           cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
           }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - name: Adjust label for breaking changes
-        if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.')
-        uses: actions-ecosystem/action-add-labels@v1.1.0
-        with:
-          labels: impact/no-changelog-required
-          number: ${{ github.event.issue.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The environment variable needed for this step is not available across jobs, and while we could change that I think it also makes sense to keep these steps together since they are related.

Part of #https://github.com/pulumi/platform-providers-team/issues/44

<img width="867" alt="image" src="https://user-images.githubusercontent.com/41454626/164739929-85176a55-dd36-432c-9d9b-39d29c52e269.png">