### PR TITLE
Convert token expiry to string on assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+Improvements:
+
 - Support attach
   [#460](https://github.com/pulumi/pulumi-google-native/pull/460)
+
+Bug fixes:
+
+- Convert token expiry to string on assignment [#470](https://github.com/pulumi/pulumi-google-native/pull/470)
 
 ## 0.18.1 (2022-04-20)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -175,7 +175,7 @@ func (p *googleCloudProvider) Invoke(_ context.Context, req *rpc.InvokeRequest) 
 		t := p.client.OAuth2Token()
 		resp = map[string]interface{}{
 			"accessToken":  t.AccessToken,
-			"expiry":       t.Expiry,
+			"expiry":       t.Expiry.String(),
 			"refreshToken": t.RefreshToken,
 			"tokenType":    t.TokenType,
 		}


### PR DESCRIPTION
The provider incorrectly assigned a time.Time struct to a string field. This worked for TypeScript, but resulted in an error in the other SDKs.