### PR TITLE
Add field-mask support for iam:v1/ServiceAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ CHANGELOG
   - Add support for replace-on-changes based on annotations and manual override for replace-on-change behavior
   - Make method discovery deterministic
   - Improvements to discovering operation endpoints
-- Relax heuristics on setting update mask in metadata [#515](https://github.com/pulumi/pulumi-google-native/pull/515)
 - Set force-new for storage bucket resource [#516](https://github.com/pulumi/pulumi-google-native/pull/516)
+- Override field-mask for iam:v1/ServiceAccount [#518](https://github.com/pulumi/pulumi-google-native/pull/518)
 
 ## 0.19.1 (2022-05-24)
 

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -210,6 +210,13 @@ var metadataOverrides = map[string]resources.CloudAPIResource{
 			},
 		},
 	},
+	"google-native:iam/v1:ServiceAccount": {
+		Update: resources.UpdateAPIOperation{
+			UpdateMask: resources.UpdateMask{
+				BodyPropertyName: "updateMask",
+			},
+		},
+	},
 }
 
 // csharpNamespaceOverrides is a map of canonical C# namespaces per lowercase module name. It only lists the ones

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -587,7 +587,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 			}
 
 			for name, param := range dd.updateMethod.Parameters {
-				if param.Format == "google-fieldmask" {
+				if param.Format == "google-fieldmask" && isRequired(param) {
 					contract.Assert(param.Location == "query")
 					resourceMeta.Update.UpdateMask.QueryParamName = name
 				}
@@ -597,7 +597,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 				if _, has := bodyBag.properties[name]; has {
 					resourceMeta.Update.SDKProperties[name] = value
 				} else {
-					if value.Format == "google-fieldmask" {
+					if value.Format == "google-fieldmask" && value.Required {
 						resourceMeta.Update.UpdateMask.BodyPropertyName = name
 					} else {
 						fmt.Printf("unknown update property %s: %s.%s\n", resourceTok, dd.updateMethod.Request.Ref, name)


### PR DESCRIPTION
Reverts #515 since that may cause issues with optional fieldmasks. Instead just add an override for `iam:v1/ServiceAccount` instead which actually is a required fieldmask.

Fixes #514 