### PR TITLE
Fix autonaming bug and replace-on-changes for path and query params

### DIFF
--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -501,6 +501,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		if isRequired(param) {
 			requiredInputProperties.Add(sdkName)
 			requiredProperties.Add(sdkName)
+			p.Required = true
 		}
 		properties[sdkName] = inputProperties[sdkName]
 	}
@@ -518,8 +519,9 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		}
 		properties[sdkName] = inputProperties[sdkName]
 		p := resources.CloudAPIResourceParam{
-			Name: name,
-			Kind: "path",
+			Name:     name,
+			Kind:     "path",
+			Required: true,
 		}
 		if sdkName != name {
 			p.SdkName = sdkName
@@ -671,9 +673,10 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 			//       is always based on the GET method, so this may not be universally correct.
 			for _, k := range codegen.SortedKeys(vals) {
 				v := resources.CloudAPIResourceParam{
-					Name:    k,
-					SdkName: vals[k],
-					Kind:    "path",
+					Name:     k,
+					SdkName:  vals[k],
+					Kind:     "path",
+					Required: true,
 				}
 				if queryValNames.Has(k) {
 					v.Kind = "query"
@@ -702,9 +705,10 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 			if value.Format == "google-fieldmask" && isRequired(value) {
 				resourceMeta.Update.Endpoint.Values = append(resourceMeta.Update.Endpoint.Values,
 					resources.CloudAPIResourceParam{
-						Name:    name,
-						SdkName: name,
-						Kind:    value.Location,
+						Name:     name,
+						SdkName:  name,
+						Kind:     value.Location,
+						Required: true,
 					})
 			}
 		}

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -58,8 +58,9 @@ func calculateDetailedDiff(resource *resources.CloudAPIResource, types map[strin
 	populateReplaceKeys := func(params []resources.CloudAPIResourceParam,
 		properties map[string]resources.CloudAPIProperty) {
 		for _, p := range params {
-			// All the parameters that are part of the resource path cause a replacement.
-			if p.Kind == "path" {
+			// All path parameters that are part of the resource create URI as well as required query params
+			// automatically cause a replacement.
+			if p.Kind == "path" || p.Required {
 				name := p.Name
 				if p.SdkName != "" {
 					name = p.SdkName

--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -115,16 +115,17 @@ func buildURL(
 var autonameFieldRegex = regexp.MustCompile(`^\w+$`) // Only word characters allowed
 
 // getDefaultName generates a random name for a resource based on its URN name, a given pattern,
-// and other properties.
+// and other properties if necessary. If an existing name is derived from previous state,
+// the existing name is returned. If getDefaultName generates a new random name,
+// then the second return value is true, false otherwise.
 func getDefaultName(
 	urn resource.URN,
+	nameKey resource.PropertyKey,
 	pattern string,
 	olds, news resource.PropertyMap,
 ) (resource.PropertyValue, bool) {
-	if v, ok := olds[resource.PropertyKey("name")]; ok {
-		return v, false
-	}
-	if v, ok := olds[resource.PropertyKey(pattern)]; ok {
+	previouslyAutonamed := olds.HasValue(autonamed)
+	if v, ok := olds[nameKey]; ok && previouslyAutonamed {
 		return v, false
 	}
 

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -71,25 +71,60 @@ func TestGetDefaultName_Generated(t *testing.T) {
 		"location": "west",
 		"ignoreMe": 1.2,
 	})
-	actual, autonamed := getDefaultName(urn, "projects/{project}/locations/{location}/things/{name}", olds, news)
+	actual, autonamed := getDefaultName(urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
+		news)
 	expectedPrefix := "projects/p01/locations/west/things/myName-"
 	assert.True(t, autonamed)
 	assert.True(t, strings.HasPrefix(actual.StringValue(), expectedPrefix))
 	assert.Equal(t, len(expectedPrefix)+7, len(actual.StringValue()))
 }
 
+func TestGetDefaultName_NamedToGenerated(t *testing.T) {
+	urn := resource.URN("urn:pulumi:dev::test::test-provider:testModule:TestResource::myName")
+	olds := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"project":  "p01",
+		"location": "west",
+		"name":     "my-special-name",
+	})
+	news := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"project":  "p01",
+		"location": "west",
+	})
+	actual, autonamed := getDefaultName(urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
+		news)
+	expectedPrefix := "projects/p01/locations/west/things/myName-"
+	assert.True(t, autonamed)
+	assert.True(t, strings.HasPrefix(actual.StringValue(), expectedPrefix))
+	assert.Equal(t, len(expectedPrefix)+7, len(actual.StringValue()))
+}
+
+func TestGetDefaultName_SimpleAutonamePatternField(t *testing.T) {
+	urn := resource.URN("urn:pulumi:dev::test::test-provider:testModule:TestResource::myName")
+	fixedName := "myName-abc123f"
+	olds := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"keyRingId":   "myName-abc123f",
+		"__autonamed": true,
+	})
+	news := resource.NewPropertyMapFromMap(map[string]interface{}{})
+	actual, autonamed := getDefaultName(urn, "keyRingId", "keyRingId", olds, news)
+	assert.False(t, autonamed)
+	assert.Equal(t, fixedName, actual.StringValue())
+}
+
 func TestGetDefaultName_OldApplied(t *testing.T) {
 	urn := resource.URN("urn:pulumi:dev::test::test-provider:testModule:TestResource::myName")
 	fixedName := "projects/p01/locations/west/things/anotherName"
 	olds := resource.NewPropertyMapFromMap(map[string]interface{}{
-		"name": fixedName,
+		"name":        fixedName,
+		"__autonamed": true,
 	})
 	news := resource.NewPropertyMapFromMap(map[string]interface{}{
 		"project":  "p01",
 		"location": "west",
 		"ignoreMe": 1.2,
 	})
-	actual, autonamed := getDefaultName(urn, "projects/{project}/locations/{location}/things/{name}", olds, news)
+	actual, autonamed := getDefaultName(urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
+		news)
 	assert.False(t, autonamed)
 	assert.Equal(t, fixedName, actual.StringValue())
 }

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -315,7 +315,7 @@ func (p *googleCloudProvider) Check(_ context.Context, req *rpc.CheckRequest) (*
 	}
 	if res.Create.Autoname.FieldName != "" && !news.HasValue(nameKey) {
 		var randomlyNamed bool
-		news[nameKey], randomlyNamed = getDefaultName(urn, res.Create.Autoname.FieldName, olds, news)
+		news[nameKey], randomlyNamed = getDefaultName(urn, nameKey, res.Create.Autoname.FieldName, olds, news)
 		if randomlyNamed {
 			news[autonamed] = resource.NewBoolProperty(true)
 		}

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -202,6 +202,8 @@ type CloudAPIResourceParam struct {
 	SdkName string `json:"sdkName,omitempty"`
 	// Kind is the kind of parameter, either "path" or "query"
 	Kind string `json:"kind"`
+	// Required is true if the parameter is required.
+	Required bool `json:"required,omitempty"`
 }
 
 // ResourceURL returns the resource API URL by joining the base URL with the resource path.


### PR DESCRIPTION
This fixes a bug with autonaming which manifests when a resource moves from named to autonamed. We should also replace fields when path/query params for resources are changed.