### PR TITLE
Mark immutable fields for nodepools as replacements in diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 - Add support for apigee resources that use multipart/form-data content-type [#590](https://github.com/pulumi/pulumi-google-native/pull/590)
 - Add support for nodepool mutations [#588](https://github.com/pulumi/pulumi-google-native/pull/588)
+- Mark immutable fields for nodepools as replacements in diff [#598](https://github.com/pulumi/pulumi-google-native/pull/598)
 
 ## 0.21.0 (2022-07-14)
 - Handle network timeouts as retryable [#524](https://github.com/pulumi/pulumi-google-native/pull/524)


### PR DESCRIPTION
Follow up from #588. 

This change marks all fields which are not covered by the explicit mutations in the custom nodepool implementation to cause replacements. We may push this down to the schema in the future.