### PR TITLE
Ensure inputs in partial error checkpoints for nodepools are correctly resumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Ensure inputs in partial error checkpoints for nodepools are correctly resumable [#602](https://github.com/pulumi/pulumi-google-native/pull/602)
 
 ## 0.22.0 (2022-07-29)
 - Add support for apigee resources that use multipart/form-data content-type [#590](https://github.com/pulumi/pulumi-google-native/pull/590)

--- a/provider/pkg/provider/overrides.go
+++ b/provider/pkg/provider/overrides.go
@@ -31,7 +31,7 @@ type customMutationsHandler interface {
 		res *resources.CloudAPIResource,
 		inputs resource.PropertyMap,
 		oldState resource.PropertyMap,
-	) (map[string]interface{}, error)
+	) (appliedInputs resource.PropertyMap, resp map[string]interface{}, err error)
 }
 
 var customMutations = map[string]customMutationsHandler{

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -989,15 +989,16 @@ func (p *googleCloudProvider) Update(ctx context.Context, req *rpc.UpdateRequest
 	defaults := parseDefaultsObject(oldState)
 
 	var resp, op map[string]interface{}
+	var appliedInputs resource.PropertyMap
 	if mutations, ok := customMutations[resourceKey]; ok {
 		var err error
 		logging.V(9).Infof("[%s] calling custom update function for resource: %+v", label, resourceKey)
-		resp, err = mutations.update(p, urn, label, &res, inputs, oldState)
+		appliedInputs, resp, err = mutations.update(p, urn, label, &res, inputs, oldState)
 		if err != nil {
 			logging.V(9).Infof("[%s] custom update override failed: %+v, resp: %+v", label, err, resp)
 			if resp != nil {
 				checkpoint, cpErr := plugin.MarshalProperties(
-					checkpointObject(inputs, defaults, resp),
+					checkpointObject(appliedInputs, defaults, resp),
 					plugin.MarshalOptions{
 						Label:        fmt.Sprintf("%s.partialCheckpoint", label),
 						KeepUnknowns: true,


### PR DESCRIPTION
Follow up from #588 

Since we need to split up multiple updates to satisfy the container/v1 api, in the event of partial success/failure (e.g. 2/3 updates succeed, last one fails), we want to record the inputs in the partial error checkpoint to reflect the successful portions but exclude the unsuccessful bits so they can be retried. Without this, pulumi assumes the entire batch of changes was successful.