### PR TITLE
Use NewUniqueName

### DIFF
--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -119,6 +119,7 @@ var autonameFieldRegex = regexp.MustCompile(`^\w+$`) // Only word characters all
 // the existing name is returned. If getDefaultName generates a new random name,
 // then the second return value is true, false otherwise.
 func getDefaultName(
+	randomSeed []byte,
 	urn resource.URN,
 	nameKey resource.PropertyKey,
 	pattern string,
@@ -132,7 +133,7 @@ func getDefaultName(
 	name := urn.Name().String()
 
 	// Resource name is URN name + "-" + random suffix.
-	random, err := resource.NewUniqueHex(name+"-", 7, 0)
+	random, err := resource.NewUniqueName(randomSeed, name+"-", 7, 0, nil)
 	contract.AssertNoError(err)
 
 	// Simple field replacement, so just return the autoname.

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -71,7 +71,7 @@ func TestGetDefaultName_Generated(t *testing.T) {
 		"location": "west",
 		"ignoreMe": 1.2,
 	})
-	actual, autonamed := getDefaultName(urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
+	actual, autonamed := getDefaultName(nil, urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
 		news)
 	expectedPrefix := "projects/p01/locations/west/things/myName-"
 	assert.True(t, autonamed)
@@ -90,7 +90,7 @@ func TestGetDefaultName_NamedToGenerated(t *testing.T) {
 		"project":  "p01",
 		"location": "west",
 	})
-	actual, autonamed := getDefaultName(urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
+	actual, autonamed := getDefaultName(nil, urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
 		news)
 	expectedPrefix := "projects/p01/locations/west/things/myName-"
 	assert.True(t, autonamed)
@@ -106,7 +106,7 @@ func TestGetDefaultName_SimpleAutonamePatternField(t *testing.T) {
 		"__autonamed": true,
 	})
 	news := resource.NewPropertyMapFromMap(map[string]interface{}{})
-	actual, autonamed := getDefaultName(urn, "keyRingId", "keyRingId", olds, news)
+	actual, autonamed := getDefaultName(nil, urn, "keyRingId", "keyRingId", olds, news)
 	assert.True(t, autonamed)
 	assert.Equal(t, fixedName, actual.StringValue())
 }
@@ -123,7 +123,7 @@ func TestGetDefaultName_OldApplied(t *testing.T) {
 		"location": "west",
 		"ignoreMe": 1.2,
 	})
-	actual, autonamed := getDefaultName(urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
+	actual, autonamed := getDefaultName(nil, urn, "name", "projects/{project}/locations/{location}/things/{name}", olds,
 		news)
 	assert.True(t, autonamed)
 	assert.Equal(t, fixedName, actual.StringValue())

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -319,7 +319,7 @@ func (p *googleCloudProvider) Check(_ context.Context, req *rpc.CheckRequest) (*
 	}
 	if res.Create.Autoname.FieldName != "" && !news.HasValue(nameKey) {
 		var randomlyNamed bool
-		news[nameKey], randomlyNamed = getDefaultName(urn, nameKey, res.Create.Autoname.FieldName, olds, news)
+		news[nameKey], randomlyNamed = getDefaultName(req.RandomSeed, urn, nameKey, res.Create.Autoname.FieldName, olds, news)
 		if randomlyNamed {
 			news[autonamed] = resource.NewBoolProperty(true)
 		}


### PR DESCRIPTION
This is the new system for deterministic names with update plans. The engine will fill in the random seed with a non-deterministic slice of bytes for normal updates, but when using plans it will save and restore the bytes used thus allowing names to be deterministic between preview and update. NewUniqueName handles the case of old engines that didn't send anything for seed by just falling back to non-deterministic randomness. 