### PR TITLE
Disable autonaming for vpcaccess/v1:Connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 - Ensure inputs in partial error checkpoints for nodepools are correctly resumable [#602](https://github.com/pulumi/pulumi-google-native/pull/602)
+- Disable autonaming for vpcaccess/v1:Connector [#618](https://github.com/pulumi/pulumi-google-native/pull/618)
 
 ## 0.22.0 (2022-07-29)
 - Add support for apigee resources that use multipart/form-data content-type [#590](https://github.com/pulumi/pulumi-google-native/pull/590)

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -156,7 +156,8 @@ var autonameExcludes = codegen.NewStringSet(
 	"google-native:dialogflow/v3beta1:Agent",
 	"google-native:monitoring/v3:NotificationChannel",
 	"google-native:monitoring/v3:AlertPolicy",
-	"google-native:monitoring/v3:UptimeCheckConfig")
+	"google-native:monitoring/v3:UptimeCheckConfig",
+	"google-native:vpcaccess/v1:Connector")
 
 // metadataOverrides is a map of values static overlays to merge into the metadata for
 // individual resource tokens. In case of conflict, the values in this mapping are preferred.

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -157,7 +157,8 @@ var autonameExcludes = codegen.NewStringSet(
 	"google-native:monitoring/v3:NotificationChannel",
 	"google-native:monitoring/v3:AlertPolicy",
 	"google-native:monitoring/v3:UptimeCheckConfig",
-	"google-native:vpcaccess/v1:Connector")
+	"google-native:vpcaccess/v1:Connector",
+	"google-native:run/v2:Service")
 
 // metadataOverrides is a map of values static overlays to merge into the metadata for
 // individual resource tokens. In case of conflict, the values in this mapping are preferred.

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -563,11 +563,10 @@ func (p *googleCloudProvider) Create(ctx context.Context, req *rpc.CreateRequest
 		if getErr != nil {
 			return nil, errors.Wrapf(err, "waiting for completion / read state %s", getErr)
 		}
-		defaults, err := extractDefaultsFromResponse(res, inputs, readResp)
-		if err != nil {
-			return nil, err
+		defaults, defErr := extractDefaultsFromResponse(res, inputs, readResp)
+		if defErr != nil {
+			return nil, errors.Wrapf(err, "failed to extract defaults from response: %s", defErr)
 		}
-
 		checkpoint, cpErr := plugin.MarshalProperties(
 			checkpointObject(inputs, defaults, readResp),
 			plugin.MarshalOptions{Label: fmt.Sprintf("%s.partialCheckpoint", label), KeepSecrets: true, SkipNulls: true},


### PR DESCRIPTION
Exclude vpcaccess/v1:Connector from autonaming. Also fixes a panic during partial success checkpointing.

Fixes #358 