### PR TITLE
Custom mutations for v1/v1beta1 cluster and nodepool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Custom mutations for v1/v1beta1 cluster and nodepool [#632](https://github.com/pulumi/pulumi-google-native/pull/632)
 
 ## 0.23.0 (2022-07-29)
 - Ensure inputs in partial error checkpoints for nodepools are correctly resumable [#602](https://github.com/pulumi/pulumi-google-native/pull/602)

--- a/examples/gke-ts/step2/index.ts
+++ b/examples/gke-ts/step2/index.ts
@@ -40,6 +40,8 @@ const cluster = new google.container.v1.Cluster("cluster", {
         },
         name: "initial",
     }],
+    // Change
+    resourceLabels: {"test": "true"},
 });
 
 const nodepool = new google.container.v1.NodePool("nodepool", {

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -265,6 +265,34 @@ var metadataOverrides = map[string]resources.CloudAPIResource{
 			CloudAPIOperation: resources.CloudAPIOperation{
 				Polling: &resources.Polling{Strategy: resources.ClusterAwaitRestingStatePoll},
 			},
+			RecordDefaults: map[string]resources.CloudAPIProperty{
+				"loggingService":                        {},
+				"monitoringService":                     {},
+				"initialClusterVersion":                 {},
+				"locations":                             {},
+				"networkConfig.privateIpv6GoogleAccess": {},
+				"nodeConfig.imageType":                  {},
+			},
+		},
+		Update: resources.UpdateAPIOperation{
+			CloudAPIOperation: resources.CloudAPIOperation{
+				Polling: &resources.Polling{Strategy: resources.ClusterAwaitRestingStatePoll},
+			},
+		},
+	},
+	"google-native:container/v1beta1:Cluster": {
+		Create: resources.CreateAPIOperation{
+			CloudAPIOperation: resources.CloudAPIOperation{
+				Polling: &resources.Polling{Strategy: resources.ClusterAwaitRestingStatePoll},
+			},
+			RecordDefaults: map[string]resources.CloudAPIProperty{
+				"loggingService":                        {},
+				"monitoringService":                     {},
+				"initialClusterVersion":                 {},
+				"locations":                             {},
+				"networkConfig.privateIpv6GoogleAccess": {},
+				"nodeConfig.imageType":                  {},
+			},
 		},
 		Update: resources.UpdateAPIOperation{
 			CloudAPIOperation: resources.CloudAPIOperation{
@@ -280,6 +308,24 @@ var metadataOverrides = map[string]resources.CloudAPIResource{
 			RecordDefaults: map[string]resources.CloudAPIProperty{
 				"version":          {},
 				"config.imageType": {},
+				"locations":        {},
+			},
+		},
+		Update: resources.UpdateAPIOperation{
+			CloudAPIOperation: resources.CloudAPIOperation{
+				Polling: &resources.Polling{Strategy: resources.NodepoolAwaitRestingStatePoll},
+			},
+		},
+	},
+	"google-native:container/v1beta1:NodePool": {
+		Create: resources.CreateAPIOperation{
+			CloudAPIOperation: resources.CloudAPIOperation{
+				Polling: &resources.Polling{Strategy: resources.NodepoolAwaitRestingStatePoll},
+			},
+			RecordDefaults: map[string]resources.CloudAPIProperty{
+				"version":          {},
+				"config.imageType": {},
+				"locations":        {},
 			},
 		},
 		Update: resources.UpdateAPIOperation{

--- a/provider/pkg/provider/container.go
+++ b/provider/pkg/provider/container.go
@@ -255,6 +255,9 @@ func updateClusterNestedField(diffPropPath, targetPropPath resource.PropertyPath
 	}
 }
 
+// The ordering here loosely follows what is in the terraform provider which is itself somewhat arbitrary.
+// There is some underlying value since there are a lot overlapping dependencies on mutations (e.g. setting
+// network policies require the network policy add on etc.). This may need to change over time.
 var clusterUpdateOrder = []string{
 	"masterAuthorizedNetworksConfig",          //
 	"addonsConfig",                            //
@@ -273,17 +276,21 @@ var clusterUpdateOrder = []string{
 	"loggingService",                          //
 	"networkPolicy",                           //
 	//"nodePools",                               // TODO: Don't believe we can allow this to be changed?
-	"initialClusterVersion", // maybe initialClusterVersion //
+	"initialClusterVersion", //
 	// nodeVersion, // nodePools[*].version
-	"nodeConfig.imageType",      //
-	"notificationConfig",        //
-	"verticalPodAutoscaling",    //
-	"meshCertificates",          //
-	"databaseEncryption",        //
-	"workloadIdentifyConfig",    //
-	"identityServiceConfig",     //
-	"loggingConfig",             //
-	"monitoringConfig",          //
+	"nodeConfig.imageType",   //
+	"notificationConfig",     //
+	"verticalPodAutoscaling", //
+	"meshCertificates",       //
+	"databaseEncryption",     //
+	"workloadIdentifyConfig", //
+	"identityServiceConfig",  //
+	// masterAuth has a pretty imperative API for mutations.
+	// Its mostly deprecated anyway so lets mark it replace-on-change.
+	// "masterAuth",
+	// TODO: Enable these later. See note in overrides.go.
+	//"loggingConfig",             //
+	//"monitoringConfig",          //
 	"resourceLabels",            //
 	"resourceUsageExportConfig", //
 	// Only beta

--- a/provider/pkg/provider/overrides.go
+++ b/provider/pkg/provider/overrides.go
@@ -47,7 +47,8 @@ var clusterMutationHandlers = clusterMutations{
 			"addonsConfig",
 			defaultValue(emptyObjVal),
 			":setAddons",
-			"POST"),
+			"POST",
+			nil),
 		"legacyAbac.enabled": updateClusterNestedField(
 			mustParsePropertyPath("legacyAbac.enabled"),
 			mustParsePropertyPath("enabled"),
@@ -59,19 +60,15 @@ var clusterMutationHandlers = clusterMutations{
 			"locations",
 			defaultValue(resource.NewArrayProperty([]resource.PropertyValue{})),
 			":setLocations",
-			"POST"),
-		"loggingService": updateClusterMapping(
-			mustParsePropertyPath("loggingService"),
-			"loggingService",
-			extractFromDefaults(resource.NewStringProperty("")),
-			":setLogging",
-			"POST"),
+			"POST",
+			nil),
 		"maintenancePolicy": updateClusterMapping(
 			mustParsePropertyPath("maintenancePolicy"),
 			"maintenancePolicy",
 			defaultValue(emptyObjVal),
 			":setMaintenancePolicy",
-			"POST"),
+			"POST",
+			nil),
 		// How to set `action` field?
 		//"masterAuth.password": updateClusterNestedField(
 		//	mustParsePropertyPath("masterAuth.password"),
@@ -79,30 +76,43 @@ var clusterMutationHandlers = clusterMutations{
 		//	defaultValue(emptyObjVal),
 		//	":setMasterAuth",
 		//	"POST"),
-		"monitoringService": updateClusterMapping(
-			mustParsePropertyPath("monitoringService"),
-			"monitoringService",
-			extractFromDefaults(resource.NewStringProperty("")),
-			":setMonitoring",
-			"POST"),
+		// The following endpoints don't actually work. The API requires both monitoring and logging service
+		// to be modified simultaneously which is possible only through the main update API.
+		//"monitoringService": updateClusterMapping(
+		//	mustParsePropertyPath("monitoringService"),
+		//	"monitoringService",
+		//	extractFromDefaults(resource.NewStringProperty("")),
+		//	":setMonitoring",
+		//	"POST",
+		//	nil),
+		//"loggingService": updateClusterMapping(
+		//	mustParsePropertyPath("loggingService"),
+		//	"loggingService",
+		//	extractFromDefaults(resource.NewStringProperty("")),
+		//	":setLogging",
+		//	"POST",
+		//	nil),
 		"networkPolicy": updateClusterMapping(
 			mustParsePropertyPath("networkPolicy"),
 			"networkPolicy",
 			defaultValue(emptyObjVal),
 			":setNetworkPolicy",
-			"POST"),
+			"POST",
+			nil),
 		"resourceLabels": updateClusterMapping(
 			mustParsePropertyPath("resourceLabels"),
 			"resourceLabels",
 			defaultValue(emptyObjVal),
 			":setResourceLabels",
-			"POST"),
+			"POST",
+			map[string]resources.CloudAPIProperty{"labelFingerprint": {CopyFromOutputs: true}}),
 		"initialClusterVersion": updateClusterMapping(
 			mustParsePropertyPath("initialClusterVersion"),
-			"initialClusterVersion",
+			"masterVersion",
 			extractFromDefaults(resource.NewStringProperty("")),
 			":updateMaster",
-			"POST"),
+			"POST",
+			nil),
 		"authenticatorGroupsConfig": updateClusterNestedField(
 			mustParsePropertyPath("authenticatorGroupsConfig"),
 			mustParsePropertyPath("update.desiredAuthenticatorGroupsConfig"),
@@ -147,8 +157,8 @@ var clusterMutationHandlers = clusterMutations{
 			"PUT"),
 		"networkConfig.enableIntraNodeVisibility": updateClusterNestedField(
 			mustParsePropertyPath("networkConfig.enableIntraNodeVisibility"),
-			mustParsePropertyPath("update.desiredIntraNodeVisibilityConfig"),
-			defaultValue(emptyObjVal),
+			mustParsePropertyPath("update.desiredIntraNodeVisibilityConfig.enabled"),
+			defaultValue(resource.NewBoolProperty(false)),
 			"",
 			"PUT"),
 		"networkConfig.privateIpv6GoogleAccess": updateClusterNestedField(

--- a/provider/pkg/provider/overrides.go
+++ b/provider/pkg/provider/overrides.go
@@ -34,79 +34,306 @@ type customMutationsHandler interface {
 	) (appliedInputs resource.PropertyMap, resp map[string]interface{}, err error)
 }
 
-var customMutations = map[string]customMutationsHandler{
-	"google-native:container/v1:NodePool": nodepoolMutations{
-		updateHandlers: map[string]nodepoolUpdateHandlerFunc{
-			"autoscaling": updateNodePoolMapping(
-				mustParsePropertyPath("autoscaling"),
-				"autoscaling",
-				defaultValue(resource.NewObjectProperty(
-					resource.PropertyMap{
-						"enabled": resource.NewBoolProperty(false),
-					})),
-				":setAutoscaling",
-				"POST"),
-			"management": updateNodePoolMapping(
-				mustParsePropertyPath("management"),
-				"management",
-				defaultValue(emptyObjVal),
-				":setManagement",
-				"POST"),
-			"upgradeSettings": updateNodePoolMapping(
-				mustParsePropertyPath("upgradeSettings"),
-				"upgradeSettings",
-				defaultValue(emptyObjVal),
-				"",
-				"PUT"),
-			"locations": updateNodePoolMapping(
-				mustParsePropertyPath("locations"),
-				"locations",
-				defaultValue(resource.NewArrayProperty([]resource.PropertyValue{})),
-				"",
-				"PUT"),
-			"version": updateNodePoolMapping(
-				mustParsePropertyPath("version"),
-				"nodeVersion",
-				extractFromDefaults(resource.NewStringProperty("")),
-				"",
-				"PUT"),
-			"networkConfig": updateNodePoolMapping(
-				mustParsePropertyPath("networkConfig"),
-				"nodeNetworkConfig",
-				defaultValue(emptyObjVal),
-				"",
-				"PUT"),
-			"initialNodeCount": updateNodePoolMapping(
-				mustParsePropertyPath("initialNodeCount"),
-				"nodeCount",
-				defaultValue(resource.NewNumberProperty(0)),
-				":setSize",
-				"POST"),
-			"config.confidentialNodes": updateNodePoolConfig(mustParsePropertyPath("config.confidentialNodes"), nil,
-				defaultValue(emptyObjVal)),
-			"config.gcfsConfig": updateNodePoolConfig(mustParsePropertyPath("config.gcfsConfig"), nil,
-				defaultValue(emptyObjVal)),
-			"config.gvnic": updateNodePoolConfig(mustParsePropertyPath("config.gvnic"), nil,
-				defaultValue(emptyObjVal)),
-			"config.imageType": updateNodePoolConfig(mustParsePropertyPath("config.imageType"), nil,
-				extractFromDefaults(resource.NewStringProperty(""))),
-			"config.kubeletConfig": updateNodePoolConfig(mustParsePropertyPath("config.kubeletConfig"), nil,
-				defaultValue(emptyObjVal)),
-			"config.labels": updateNodePoolConfig(mustParsePropertyPath("config.labels"),
-				mustParsePropertyPath("config.labels.labels"),
-				defaultValue(emptyObjVal)),
-			"config.linuxNodeConfig": updateNodePoolConfig(mustParsePropertyPath("config.linuxNodeConfig"), nil,
-				defaultValue(emptyObjVal)),
-			"config.tags": updateNodePoolConfig(mustParsePropertyPath("config.tags"),
-				mustParsePropertyPath("config.tags.tags"),
-				defaultValue(emptyArrayVal)),
-			"config.taints": updateNodePoolConfig(mustParsePropertyPath("config.taints"),
-				mustParsePropertyPath("config.taints.taints"),
-				defaultValue(emptyArrayVal)),
-			"config.workloadMetadataConfig": updateNodePoolConfig(mustParsePropertyPath("config.workloadMetadataConfig"), nil,
-				defaultValue(emptyObjVal)),
-		},
+var clusterMutationHandlers = clusterMutations{
+	updateHandlers: map[string]containerCustomUpdateHandlerFunc{
+		"masterAuthorizedNetworksConfig": updateClusterNestedField(
+			mustParsePropertyPath("masterAuthorizedNetworksConfig"),
+			mustParsePropertyPath("update.desiredMasterAuthorizedNetworksConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"addonsConfig": updateClusterMapping(
+			mustParsePropertyPath("addonsConfig"),
+			"addonsConfig",
+			defaultValue(emptyObjVal),
+			":setAddons",
+			"POST"),
+		"legacyAbac.enabled": updateClusterNestedField(
+			mustParsePropertyPath("legacyAbac.enabled"),
+			mustParsePropertyPath("enabled"),
+			extractFromDefaults(resource.NewBoolProperty(false)),
+			":setLegacyAbac",
+			"POST"),
+		"locations": updateClusterMapping(
+			mustParsePropertyPath("locations"),
+			"locations",
+			defaultValue(resource.NewArrayProperty([]resource.PropertyValue{})),
+			":setLocations",
+			"POST"),
+		"loggingService": updateClusterMapping(
+			mustParsePropertyPath("loggingService"),
+			"loggingService",
+			extractFromDefaults(resource.NewStringProperty("")),
+			":setLogging",
+			"POST"),
+		"maintenancePolicy": updateClusterMapping(
+			mustParsePropertyPath("maintenancePolicy"),
+			"maintenancePolicy",
+			defaultValue(emptyObjVal),
+			":setMaintenancePolicy",
+			"POST"),
+		// How to set `action` field?
+		//"masterAuth.password": updateClusterNestedField(
+		//	mustParsePropertyPath("masterAuth.password"),
+		//	nil,
+		//	defaultValue(emptyObjVal),
+		//	":setMasterAuth",
+		//	"POST"),
+		"monitoringService": updateClusterMapping(
+			mustParsePropertyPath("monitoringService"),
+			"monitoringService",
+			extractFromDefaults(resource.NewStringProperty("")),
+			":setMonitoring",
+			"POST"),
+		"networkPolicy": updateClusterMapping(
+			mustParsePropertyPath("networkPolicy"),
+			"networkPolicy",
+			defaultValue(emptyObjVal),
+			":setNetworkPolicy",
+			"POST"),
+		"resourceLabels": updateClusterMapping(
+			mustParsePropertyPath("resourceLabels"),
+			"resourceLabels",
+			defaultValue(emptyObjVal),
+			":setResourceLabels",
+			"POST"),
+		"initialClusterVersion": updateClusterMapping(
+			mustParsePropertyPath("initialClusterVersion"),
+			"initialClusterVersion",
+			extractFromDefaults(resource.NewStringProperty("")),
+			":updateMaster",
+			"POST"),
+		"authenticatorGroupsConfig": updateClusterNestedField(
+			mustParsePropertyPath("authenticatorGroupsConfig"),
+			mustParsePropertyPath("update.desiredAuthenticatorGroupsConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"binaryAuthorization": updateClusterNestedField(
+			mustParsePropertyPath("binaryAuthorization"),
+			mustParsePropertyPath("update.desiredBinaryAuthorization"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"autoscaling": updateClusterNestedField(
+			mustParsePropertyPath("autoscaling"),
+			mustParsePropertyPath("update.desiredClusterAutoscaling"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"shieldedNodes": updateClusterNestedField(
+			mustParsePropertyPath("shieldedNodes"),
+			mustParsePropertyPath("update.desiredShieldedNodes"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"releaseChannel": updateClusterNestedField(
+			mustParsePropertyPath("releaseChannel"),
+			mustParsePropertyPath("update.desiredReleaseChannel"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"resourceUsageExportConfig": updateClusterNestedField(
+			mustParsePropertyPath("resourceUsageExportConfig"),
+			mustParsePropertyPath("update.desiredResourceUsageExportConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"networkConfig.serviceExternalIpsConfig": updateClusterNestedField(
+			mustParsePropertyPath("networkConfig.serviceExternalIpsConfig"),
+			mustParsePropertyPath("update.desiredServiceExternalIpsConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"networkConfig.enableIntraNodeVisibility": updateClusterNestedField(
+			mustParsePropertyPath("networkConfig.enableIntraNodeVisibility"),
+			mustParsePropertyPath("update.desiredIntraNodeVisibilityConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"networkConfig.privateIpv6GoogleAccess": updateClusterNestedField(
+			mustParsePropertyPath("networkConfig.privateIpv6GoogleAccess"),
+			mustParsePropertyPath("update.desiredPrivateIpv6GoogleAccess"),
+			extractFromDefaults(resource.NewStringProperty("")),
+			"",
+			"PUT"),
+		"networkConfig.enableL4ilbSubsetting": updateClusterNestedField(
+			mustParsePropertyPath("networkConfig.enableL4ilbSubsetting"),
+			mustParsePropertyPath("update.desiredL4ilbSubsettingConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"nodeConfig.imageType": updateClusterNestedField(
+			mustParsePropertyPath("nodeConfig.imageType"),
+			mustParsePropertyPath("update.desiredImageType"),
+			extractFromDefaults(resource.NewStringProperty("")),
+			"",
+			"PUT"),
+		"notificationConfig": updateClusterNestedField(
+			mustParsePropertyPath("notificationConfig"),
+			mustParsePropertyPath("update.desiredNotificationConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"verticalPodAutoscaling": updateClusterNestedField(
+			mustParsePropertyPath("verticalPodAutoscaling"),
+			mustParsePropertyPath("update.desiredVerticalPodAutoscaling"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"meshCertificates": updateClusterNestedField(
+			mustParsePropertyPath("meshCertificates"),
+			mustParsePropertyPath("update.desiredMeshCertificates"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"databaseEncryption": updateClusterNestedField(
+			mustParsePropertyPath("databaseEncryption"),
+			mustParsePropertyPath("update.desiredDatabaseEncryption"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"identityServiceConfig": updateClusterNestedField(
+			mustParsePropertyPath("identityServiceConfig"),
+			mustParsePropertyPath("update.desiredIdentityServiceConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"workloadIdentityConfig": updateClusterNestedField(
+			mustParsePropertyPath("workloadIdentityConfig"),
+			mustParsePropertyPath("update.desiredWorkloadIdentityConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"loggingConfig": updateClusterNestedField(
+			mustParsePropertyPath("loggingConfig"),
+			mustParsePropertyPath("update.desiredLoggingConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"monitoringConfig": updateClusterNestedField(
+			mustParsePropertyPath("monitoringConfig"),
+			mustParsePropertyPath("update.desiredMonitoringConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"networkConfig.datapathProvider": updateClusterNestedField(
+			mustParsePropertyPath("networkConfig.datapathProvider"),
+			mustParsePropertyPath("update.desiredDatapathProvider"),
+			defaultValue(resource.NewStringProperty("DATAPATH_PROVIDER_UNSPECIFIED")),
+			"",
+			"PUT"),
+		"networkConfig.dnsConfig": updateClusterNestedField(
+			mustParsePropertyPath("networkConfig.dnsConfig"),
+			mustParsePropertyPath("update.desiredDnsConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"networkConfig.gcfsConfig": updateClusterNestedField(
+			mustParsePropertyPath("networkConfig.gcfsConfig"),
+			mustParsePropertyPath("update.desiredGcfsConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"privateClusterConfig": updateClusterNestedField(
+			mustParsePropertyPath("privateClusterConfig"),
+			mustParsePropertyPath("update.desiredPrivateClusterConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		// V1 Beta1 only
+		"podSecurityPolicyConfig": updateClusterNestedField(
+			mustParsePropertyPath("podSecurityPolicyConfig"),
+			mustParsePropertyPath("update.desiredPodSecurityPolicyConfig"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"clusterTelemetry": updateClusterNestedField(
+			mustParsePropertyPath("clusterTelemetry"),
+			mustParsePropertyPath("update.desiredClusterTelemetry"),
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+	}}
+
+var nodepoolMutationHanders = nodepoolMutations{
+	updateHandlers: map[string]containerCustomUpdateHandlerFunc{
+		"autoscaling": updateNodePoolMapping(
+			mustParsePropertyPath("autoscaling"),
+			"autoscaling",
+			defaultValue(resource.NewObjectProperty(
+				resource.PropertyMap{
+					"enabled": resource.NewBoolProperty(false),
+				})),
+			":setAutoscaling",
+			"POST"),
+		"management": updateNodePoolMapping(
+			mustParsePropertyPath("management"),
+			"management",
+			defaultValue(emptyObjVal),
+			":setManagement",
+			"POST"),
+		"upgradeSettings": updateNodePoolMapping(
+			mustParsePropertyPath("upgradeSettings"),
+			"upgradeSettings",
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"locations": updateNodePoolMapping(
+			mustParsePropertyPath("locations"),
+			"locations",
+			defaultValue(resource.NewArrayProperty([]resource.PropertyValue{})),
+			"",
+			"PUT"),
+		"version": updateNodePoolMapping(
+			mustParsePropertyPath("version"),
+			"nodeVersion",
+			extractFromDefaults(resource.NewStringProperty("")),
+			"",
+			"PUT"),
+		"networkConfig": updateNodePoolMapping(
+			mustParsePropertyPath("networkConfig"),
+			"nodeNetworkConfig",
+			defaultValue(emptyObjVal),
+			"",
+			"PUT"),
+		"initialNodeCount": updateNodePoolMapping(
+			mustParsePropertyPath("initialNodeCount"),
+			"nodeCount",
+			defaultValue(resource.NewNumberProperty(0)),
+			":setSize",
+			"POST"),
+		"config.confidentialNodes": updateNodePoolConfig(mustParsePropertyPath("config.confidentialNodes"), nil,
+			defaultValue(emptyObjVal)),
+		"config.gcfsConfig": updateNodePoolConfig(mustParsePropertyPath("config.gcfsConfig"), nil,
+			defaultValue(emptyObjVal)),
+		"config.gvnic": updateNodePoolConfig(mustParsePropertyPath("config.gvnic"), nil,
+			defaultValue(emptyObjVal)),
+		"config.imageType": updateNodePoolConfig(mustParsePropertyPath("config.imageType"), nil,
+			extractFromDefaults(resource.NewStringProperty(""))),
+		"config.kubeletConfig": updateNodePoolConfig(mustParsePropertyPath("config.kubeletConfig"), nil,
+			defaultValue(emptyObjVal)),
+		"config.labels": updateNodePoolConfig(mustParsePropertyPath("config.labels"),
+			mustParsePropertyPath("config.labels.labels"),
+			defaultValue(emptyObjVal)),
+		"config.linuxNodeConfig": updateNodePoolConfig(mustParsePropertyPath("config.linuxNodeConfig"), nil,
+			defaultValue(emptyObjVal)),
+		"config.tags": updateNodePoolConfig(mustParsePropertyPath("config.tags"),
+			mustParsePropertyPath("config.tags.tags"),
+			defaultValue(emptyArrayVal)),
+		"config.taints": updateNodePoolConfig(mustParsePropertyPath("config.taints"),
+			mustParsePropertyPath("config.taints.taints"),
+			defaultValue(emptyArrayVal)),
+		"config.workloadMetadataConfig": updateNodePoolConfig(mustParsePropertyPath("config.workloadMetadataConfig"), nil,
+			defaultValue(emptyObjVal)),
 	},
+}
+
+var customMutations = map[string]customMutationsHandler{
+	"google-native:container/v1:Cluster":       clusterMutationHandlers,
+	"google-native:container/v1beta1:Cluster":  clusterMutationHandlers,
+	"google-native:container/v1:NodePool":      nodepoolMutationHanders,
+	"google-native:container/v1beta1:NodePool": nodepoolMutationHanders,
 }
 
 var ResourceDeleteOverrides = map[string]func(

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -174,7 +174,10 @@ type Operations struct {
 // CreateAPIOperation is a Create resource operation in the Google Cloud REST API.
 type CreateAPIOperation struct {
 	CloudAPIOperation
-	Autoname       ResourceAutoname            `json:"autoname,omitempty"`
+	Autoname ResourceAutoname `json:"autoname,omitempty"`
+	// RecordDefaults should be set for properties which have implicit default values which can only
+	// be determined by examining the response of the resource creation. The corresponding default values
+	// are recorded in the __defaults custom input field as part of the resource checkpoint.
 	RecordDefaults map[string]CloudAPIProperty `json:"recordDefaults,omitempty"`
 }
 


### PR DESCRIPTION
Extension of #588 to cluster.

Also extends the custom mutation support originally targeting v1 nodepools to include v1beta1 as well.

Fixes #124 