### PR TITLE
Add resource method for retrieving kubeconfig from a GKE cluster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -325,6 +325,7 @@ jobs:
     - name: Configure GCP credentials
       uses: google-github-actions/setup-gcloud@v0
       with:
+        install_components: 'gke-gcloud-auth-plugin'
         project_id: ${{ env.GOOGLE_PROJECT }}
         service_account_email: ${{ secrets.GCP_SA_EMAIL }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -316,6 +316,7 @@ jobs:
     - name: Configure GCP credentials
       uses: google-github-actions/setup-gcloud@v0
       with:
+        install_components: 'gke-gcloud-auth-plugin'
         project_id: ${{ env.GOOGLE_PROJECT }}
         service_account_email: ${{ secrets.GCP_SA_EMAIL }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,7 @@ jobs:
     - name: Configure GCP credentials
       uses: google-github-actions/setup-gcloud@v0
       with:
+        install_components: 'gke-gcloud-auth-plugin'
         project_id: ${{ env.GOOGLE_PROJECT }}
         service_account_email: ${{ secrets.GCP_SA_EMAIL }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -347,6 +347,7 @@ jobs:
     - name: Configure GCP credentials
       uses: google-github-actions/setup-gcloud@v0
       with:
+        install_components: 'gke-gcloud-auth-plugin'
         project_id: ${{ env.GOOGLE_PROJECT }}
         service_account_email: ${{ secrets.GCP_SA_EMAIL }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 - Remove DNS v2 API which is not actively advertised by Google (https://github.com/pulumi/pulumi-google-native/pull/662)
+- Add resource method for retrieving kubeconfig from a GKE cluster [#655](https://github.com/pulumi/pulumi-google-native/pull/655)
 
 ## 0.24.0 (2022-08-25)
 ### BREAKING CHANGE

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2022, Pulumi Corporation.  All rights reserved.
+//go:build python || all
 // +build python all
 
 package examples
@@ -46,6 +47,23 @@ func TestBigTableInstance(t *testing.T) {
 				Additive: true,
 			},
 		},
+	})
+	integration.ProgramTest(t, &options)
+}
+
+func TestGetKubeConfigPy(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	options := getPythonBaseOptions(t).With(integration.ProgramTestOptions{
+		Dir:         filepath.Join(cwd, "kubeconfig-py"),
+		SkipRefresh: true,
+		Config: map[string]string{
+			"google-native:project":  os.Getenv("GOOGLE_PROJECT"),
+			"google-native:location": os.Getenv("GOOGLE_ZONE"),
+		},
+		RunUpdateTest: false,
 	})
 	integration.ProgramTest(t, &options)
 }

--- a/examples/kubeconfig-py/.gitignore
+++ b/examples/kubeconfig-py/.gitignore
@@ -1,0 +1,2 @@
+venv/
+__pycache__/

--- a/examples/kubeconfig-py/Pulumi.yaml
+++ b/examples/kubeconfig-py/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: kubeconfig-py
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+description: Test getKubeconfig method support

--- a/examples/kubeconfig-py/__main__.py
+++ b/examples/kubeconfig-py/__main__.py
@@ -1,0 +1,21 @@
+import pulumi
+from pulumi_google_native.container import v1 as container
+import pulumi_kubernetes as k8s
+
+config = pulumi.Config("google-native")
+PROJECT_ID = config.require("project")
+LOCATION = config.require("location")
+
+server_config = container.get_server_config_output(location=LOCATION)
+
+cluster = container.Cluster("cluster", container.ClusterArgs(
+    initial_cluster_version=server_config.valid_master_versions[0],
+    node_pools=[container.NodePoolArgs(initial_node_count=1, name="initial")],
+))
+
+k8sprov = k8s.Provider("k8sprov", k8s.ProviderArgs(
+    kubeconfig=cluster.get_kubeconfig()))
+namespace = k8s.core.v1.Namespace(
+    "ns", opts=pulumi.ResourceOptions(provider=k8sprov))
+
+pulumi.export("ns", namespace.metadata.name)

--- a/examples/kubeconfig-py/requirements.txt
+++ b/examples/kubeconfig-py/requirements.txt
@@ -1,0 +1,2 @@
+pulumi>=3.0.0,<4.0.0
+pulumi-kubernetes>=3.0.0

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -251,7 +251,7 @@ func PulumiSchema() (*schema.PackageSpec, *resources.CloudAPIMetadata, error) {
 			Description: "Generate a kubeconfig for cluster authentication." +
 				"\n\nThe kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes" +
 				" provider.\nThe kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as" +
-				" recommended by google.\n\n" +
+				" recommended by Google.\n\n" +
 				"See for more details:\n" +
 				`- https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke`,
 			Inputs: &schema.ObjectTypeSpec{

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -280,8 +280,9 @@ func PulumiSchema() (*schema.PackageSpec, *resources.CloudAPIMetadata, error) {
 	}
 
 	pkg.Language["go"] = rawMessage(map[string]interface{}{
-		"importBasePath":       goBasePath,
-		"packageImportAliases": golangImportAliases,
+		"importBasePath":               goBasePath,
+		"packageImportAliases":         golangImportAliases,
+		"liftSingleValueMethodReturns": true,
 	})
 	pkg.Language["nodejs"] = rawMessage(map[string]interface{}{
 		"dependencies": map[string]string{
@@ -291,6 +292,7 @@ func PulumiSchema() (*schema.PackageSpec, *resources.CloudAPIMetadata, error) {
 programs. This provider uses the Google Cloud REST API directly and therefore provides full access to Google Cloud.
 The provider is currently in public preview and is not recommended for production deployments yet. Breaking changes
 will be introduced in minor version releases.`,
+		"liftSingleValueMethodReturns": true,
 	})
 
 	pkg.Language["python"] = rawMessage(map[string]interface{}{
@@ -303,17 +305,20 @@ will be introduced in minor version releases.`,
 programs. This provider uses the Google Cloud REST API directly and therefore provides full access to Google Cloud.
 The provider is currently in public preview and is not recommended for production deployments yet. Breaking changes
 will be introduced in minor version releases.`,
+		"liftSingleValueMethodReturns": true,
 	})
 
 	pkg.Language["csharp"] = rawMessage(map[string]interface{}{
 		"packageReferences": map[string]string{
 			"Pulumi": "3.*",
 		},
-		"namespaces": csharpNamespaces,
+		"namespaces":                   csharpNamespaces,
+		"liftSingleValueMethodReturns": true,
 	})
 
 	pkg.Language["java"] = rawMessage(map[string]interface{}{
-		"packages": javaPackages,
+		"packages":                     javaPackages,
+		"liftSingleValueMethodReturns": true,
 	})
 
 	return &pkg, &metadata, nil

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -857,6 +857,7 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 			Properties:  properties,
 			Required:    requiredProperties.SortedValues(),
 		},
+		Methods:         map[string]string{},
 		InputProperties: inputProperties,
 		RequiredInputs:  requiredInputProperties.SortedValues(),
 	}
@@ -867,9 +868,6 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 		}
 	}
 
-	if resourceSpec.Methods == nil {
-		resourceSpec.Methods = map[string]string{}
-	}
 	switch resourceTok {
 	case "google-native:container/v1:Cluster":
 		resourceSpec.Methods["getKubeconfig"] = "google-native:container/v1:Cluster/getKubeconfig"

--- a/provider/pkg/provider/container.go
+++ b/provider/pkg/provider/container.go
@@ -807,8 +807,8 @@ func getKubeConfigCallHandler(label, tok string, callArgs resource.PropertyMap) 
 			kubeconfigFmt,
 			state.GetOutput("name"),
 			state.GetOutput("endpoint"),
-			state.GetOutput("masterAuth").ApplyT(func(ma interface{}) interface{} {
-				return ma.(map[string]interface{})["clusterCaCertificate"]
+			state.GetOutput("masterAuth").ApplyT(func(ma interface{}) string {
+				return ma.(map[string]interface{})["clusterCaCertificate"].(string)
 			}))
 		result := clusterGetKubeconfigResult{
 			Kubeconfig: kubeconfig,

--- a/provider/pkg/provider/container.go
+++ b/provider/pkg/provider/container.go
@@ -729,7 +729,7 @@ func (st *customResourceState) GetOutput(k string) pulumi.Output {
 	return st.Outputs.ApplyT(func(outputs map[string]interface{}) (interface{}, error) {
 		out, ok := outputs[k]
 		if !ok {
-			return nil, fmt.Errorf("no output '%s' on resource '%s'", k, st.name)
+			return nil, fmt.Errorf("no output %q on resource %q", k, st.name)
 		}
 		return out, nil
 	})

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
+	pulumiprov "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
@@ -1285,11 +1286,28 @@ func retryRequest(client *googleclient.GoogleClient, method string, rawurl strin
 
 // Construct creates a new component resource.
 func (p *googleCloudProvider) Construct(_ context.Context, _ *rpc.ConstructRequest) (*rpc.ConstructResponse, error) {
+
 	return nil, status.Error(codes.Unimplemented, "Construct is not yet implemented")
 }
 
 // Call dynamically executes a method in the provider associated with a component resource.
-func (p *googleCloudProvider) Call(_ context.Context, _ *rpc.CallRequest) (*rpc.CallResponse, error) {
+func (p *googleCloudProvider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallResponse, error) {
+	label := fmt.Sprintf("%s.Call(%s)", p.name, req.Tok)
+	callArgs, err := plugin.UnmarshalProperties(req.GetArgs(), plugin.MarshalOptions{
+		Label:            fmt.Sprintf("%s.args", label),
+		KeepUnknowns:     req.DryRun,
+		KeepSecrets:      true,
+		KeepResources:    true,
+		KeepOutputValues: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	switch req.Tok {
+	case "google-native:container/v1:Cluster/getKubeconfig", "google-native:container/v1beta1:Cluster/getKubeconfig":
+		return pulumiprov.Call(ctx, req, p.host.EngineConn(), handleGetKubeConfigCall(label, req.Tok, callArgs))
+	}
 	return nil, status.Error(codes.Unimplemented, "Call is not yet implemented")
 }
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1306,7 +1306,7 @@ func (p *googleCloudProvider) Call(ctx context.Context, req *rpc.CallRequest) (*
 
 	switch req.Tok {
 	case "google-native:container/v1:Cluster/getKubeconfig", "google-native:container/v1beta1:Cluster/getKubeconfig":
-		return pulumiprov.Call(ctx, req, p.host.EngineConn(), handleGetKubeConfigCall(label, req.Tok, callArgs))
+		return pulumiprov.Call(ctx, req, p.host.EngineConn(), getKubeConfigCallHandler(label, req.Tok, callArgs))
 	}
 	return nil, status.Error(codes.Unimplemented, "Call is not yet implemented")
 }

--- a/sdk/dotnet/Container/V1/Cluster.cs
+++ b/sdk/dotnet/Container/V1/Cluster.cs
@@ -421,6 +421,18 @@ namespace Pulumi.GoogleNative.Container.V1
         {
             return new Cluster(name, id, options);
         }
+
+        /// <summary>
+        /// Generate a kubeconfig for cluster authentication.
+        /// 
+        /// The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+        /// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+        /// 
+        /// See for more details:
+        /// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+        /// </summary>
+        public Pulumi.Output<ClusterGetKubeconfigResult> GetKubeconfig()
+            => Pulumi.Deployment.Instance.Call<ClusterGetKubeconfigResult>("google-native:container/v1:Cluster/getKubeconfig", CallArgs.Empty, this);
     }
 
     public sealed class ClusterArgs : global::Pulumi.ResourceArgs
@@ -751,5 +763,20 @@ namespace Pulumi.GoogleNative.Container.V1
         {
         }
         public static new ClusterArgs Empty => new ClusterArgs();
+    }
+
+    /// <summary>
+    /// The results of the <see cref="Cluster.GetKubeconfig"/> method.
+    /// </summary>
+    [OutputType]
+    public sealed class ClusterGetKubeconfigResult
+    {
+        public readonly string Kubeconfig;
+
+        [OutputConstructor]
+        private ClusterGetKubeconfigResult(string kubeconfig)
+        {
+            Kubeconfig = kubeconfig;
+        }
     }
 }

--- a/sdk/dotnet/Container/V1/Cluster.cs
+++ b/sdk/dotnet/Container/V1/Cluster.cs
@@ -426,7 +426,7 @@ namespace Pulumi.GoogleNative.Container.V1
         /// Generate a kubeconfig for cluster authentication.
         /// 
         /// The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-        /// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+        /// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
         /// 
         /// See for more details:
         /// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

--- a/sdk/dotnet/Container/V1/Cluster.cs
+++ b/sdk/dotnet/Container/V1/Cluster.cs
@@ -431,8 +431,8 @@ namespace Pulumi.GoogleNative.Container.V1
         /// See for more details:
         /// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
         /// </summary>
-        public Pulumi.Output<ClusterGetKubeconfigResult> GetKubeconfig()
-            => Pulumi.Deployment.Instance.Call<ClusterGetKubeconfigResult>("google-native:container/v1:Cluster/getKubeconfig", CallArgs.Empty, this);
+        public Pulumi.Output<string> GetKubeconfig()
+            => Pulumi.Deployment.Instance.Call<ClusterGetKubeconfigResult>("google-native:container/v1:Cluster/getKubeconfig", CallArgs.Empty, this).Apply(v => v.Kubeconfig);
     }
 
     public sealed class ClusterArgs : global::Pulumi.ResourceArgs
@@ -769,7 +769,7 @@ namespace Pulumi.GoogleNative.Container.V1
     /// The results of the <see cref="Cluster.GetKubeconfig"/> method.
     /// </summary>
     [OutputType]
-    public sealed class ClusterGetKubeconfigResult
+    internal sealed class ClusterGetKubeconfigResult
     {
         public readonly string Kubeconfig;
 

--- a/sdk/dotnet/Container/V1Beta1/Cluster.cs
+++ b/sdk/dotnet/Container/V1Beta1/Cluster.cs
@@ -481,6 +481,18 @@ namespace Pulumi.GoogleNative.Container.V1Beta1
         {
             return new Cluster(name, id, options);
         }
+
+        /// <summary>
+        /// Generate a kubeconfig for cluster authentication.
+        /// 
+        /// The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+        /// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+        /// 
+        /// See for more details:
+        /// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+        /// </summary>
+        public Pulumi.Output<ClusterGetKubeconfigResult> GetKubeconfig()
+            => Pulumi.Deployment.Instance.Call<ClusterGetKubeconfigResult>("google-native:container/v1beta1:Cluster/getKubeconfig", CallArgs.Empty, this);
     }
 
     public sealed class ClusterArgs : global::Pulumi.ResourceArgs
@@ -871,5 +883,20 @@ namespace Pulumi.GoogleNative.Container.V1Beta1
         {
         }
         public static new ClusterArgs Empty => new ClusterArgs();
+    }
+
+    /// <summary>
+    /// The results of the <see cref="Cluster.GetKubeconfig"/> method.
+    /// </summary>
+    [OutputType]
+    public sealed class ClusterGetKubeconfigResult
+    {
+        public readonly string Kubeconfig;
+
+        [OutputConstructor]
+        private ClusterGetKubeconfigResult(string kubeconfig)
+        {
+            Kubeconfig = kubeconfig;
+        }
     }
 }

--- a/sdk/dotnet/Container/V1Beta1/Cluster.cs
+++ b/sdk/dotnet/Container/V1Beta1/Cluster.cs
@@ -491,8 +491,8 @@ namespace Pulumi.GoogleNative.Container.V1Beta1
         /// See for more details:
         /// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
         /// </summary>
-        public Pulumi.Output<ClusterGetKubeconfigResult> GetKubeconfig()
-            => Pulumi.Deployment.Instance.Call<ClusterGetKubeconfigResult>("google-native:container/v1beta1:Cluster/getKubeconfig", CallArgs.Empty, this);
+        public Pulumi.Output<string> GetKubeconfig()
+            => Pulumi.Deployment.Instance.Call<ClusterGetKubeconfigResult>("google-native:container/v1beta1:Cluster/getKubeconfig", CallArgs.Empty, this).Apply(v => v.Kubeconfig);
     }
 
     public sealed class ClusterArgs : global::Pulumi.ResourceArgs
@@ -889,7 +889,7 @@ namespace Pulumi.GoogleNative.Container.V1Beta1
     /// The results of the <see cref="Cluster.GetKubeconfig"/> method.
     /// </summary>
     [OutputType]
-    public sealed class ClusterGetKubeconfigResult
+    internal sealed class ClusterGetKubeconfigResult
     {
         public readonly string Kubeconfig;
 

--- a/sdk/dotnet/Container/V1Beta1/Cluster.cs
+++ b/sdk/dotnet/Container/V1Beta1/Cluster.cs
@@ -486,7 +486,7 @@ namespace Pulumi.GoogleNative.Container.V1Beta1
         /// Generate a kubeconfig for cluster authentication.
         /// 
         /// The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-        /// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+        /// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
         /// 
         /// See for more details:
         /// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

--- a/sdk/go/google/container/v1/cluster.go
+++ b/sdk/go/google/container/v1/cluster.go
@@ -423,26 +423,26 @@ func (ClusterArgs) ElementType() reflect.Type {
 //
 // See for more details:
 // - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
-func (r *Cluster) GetKubeconfig(ctx *pulumi.Context) (ClusterGetKubeconfigResultOutput, error) {
-	out, err := ctx.Call("google-native:container/v1:Cluster/getKubeconfig", nil, ClusterGetKubeconfigResultOutput{}, r)
+func (r *Cluster) GetKubeconfig(ctx *pulumi.Context) (pulumi.StringOutput, error) {
+	out, err := ctx.Call("google-native:container/v1:Cluster/getKubeconfig", nil, clusterGetKubeconfigResultOutput{}, r)
 	if err != nil {
-		return ClusterGetKubeconfigResultOutput{}, err
+		return pulumi.StringOutput{}, err
 	}
-	return out.(ClusterGetKubeconfigResultOutput), nil
+	return out.(clusterGetKubeconfigResultOutput).Kubeconfig(), nil
 }
 
-type ClusterGetKubeconfigResult struct {
+type clusterGetKubeconfigResult struct {
 	Kubeconfig string `pulumi:"kubeconfig"`
 }
 
-type ClusterGetKubeconfigResultOutput struct{ *pulumi.OutputState }
+type clusterGetKubeconfigResultOutput struct{ *pulumi.OutputState }
 
-func (ClusterGetKubeconfigResultOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*ClusterGetKubeconfigResult)(nil)).Elem()
+func (clusterGetKubeconfigResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*clusterGetKubeconfigResult)(nil)).Elem()
 }
 
-func (o ClusterGetKubeconfigResultOutput) Kubeconfig() pulumi.StringOutput {
-	return o.ApplyT(func(v ClusterGetKubeconfigResult) string { return v.Kubeconfig }).(pulumi.StringOutput)
+func (o clusterGetKubeconfigResultOutput) Kubeconfig() pulumi.StringOutput {
+	return o.ApplyT(func(v clusterGetKubeconfigResult) string { return v.Kubeconfig }).(pulumi.StringOutput)
 }
 
 type ClusterInput interface {
@@ -796,5 +796,5 @@ func (o ClusterOutput) Zone() pulumi.StringOutput {
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterInput)(nil)).Elem(), &Cluster{})
 	pulumi.RegisterOutputType(ClusterOutput{})
-	pulumi.RegisterOutputType(ClusterGetKubeconfigResultOutput{})
+	pulumi.RegisterOutputType(clusterGetKubeconfigResultOutput{})
 }

--- a/sdk/go/google/container/v1/cluster.go
+++ b/sdk/go/google/container/v1/cluster.go
@@ -419,7 +419,7 @@ func (ClusterArgs) ElementType() reflect.Type {
 // Generate a kubeconfig for cluster authentication.
 //
 // The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
 //
 // See for more details:
 // - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

--- a/sdk/go/google/container/v1/cluster.go
+++ b/sdk/go/google/container/v1/cluster.go
@@ -416,6 +416,35 @@ func (ClusterArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*clusterArgs)(nil)).Elem()
 }
 
+// Generate a kubeconfig for cluster authentication.
+//
+// The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+//
+// See for more details:
+// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+func (r *Cluster) GetKubeconfig(ctx *pulumi.Context) (ClusterGetKubeconfigResultOutput, error) {
+	out, err := ctx.Call("google-native:container/v1:Cluster/getKubeconfig", nil, ClusterGetKubeconfigResultOutput{}, r)
+	if err != nil {
+		return ClusterGetKubeconfigResultOutput{}, err
+	}
+	return out.(ClusterGetKubeconfigResultOutput), nil
+}
+
+type ClusterGetKubeconfigResult struct {
+	Kubeconfig string `pulumi:"kubeconfig"`
+}
+
+type ClusterGetKubeconfigResultOutput struct{ *pulumi.OutputState }
+
+func (ClusterGetKubeconfigResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ClusterGetKubeconfigResult)(nil)).Elem()
+}
+
+func (o ClusterGetKubeconfigResultOutput) Kubeconfig() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterGetKubeconfigResult) string { return v.Kubeconfig }).(pulumi.StringOutput)
+}
+
 type ClusterInput interface {
 	pulumi.Input
 
@@ -767,4 +796,5 @@ func (o ClusterOutput) Zone() pulumi.StringOutput {
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterInput)(nil)).Elem(), &Cluster{})
 	pulumi.RegisterOutputType(ClusterOutput{})
+	pulumi.RegisterOutputType(ClusterGetKubeconfigResultOutput{})
 }

--- a/sdk/go/google/container/v1beta1/cluster.go
+++ b/sdk/go/google/container/v1beta1/cluster.go
@@ -497,7 +497,7 @@ func (ClusterArgs) ElementType() reflect.Type {
 // Generate a kubeconfig for cluster authentication.
 //
 // The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
 //
 // See for more details:
 // - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

--- a/sdk/go/google/container/v1beta1/cluster.go
+++ b/sdk/go/google/container/v1beta1/cluster.go
@@ -501,26 +501,26 @@ func (ClusterArgs) ElementType() reflect.Type {
 //
 // See for more details:
 // - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
-func (r *Cluster) GetKubeconfig(ctx *pulumi.Context) (ClusterGetKubeconfigResultOutput, error) {
-	out, err := ctx.Call("google-native:container/v1beta1:Cluster/getKubeconfig", nil, ClusterGetKubeconfigResultOutput{}, r)
+func (r *Cluster) GetKubeconfig(ctx *pulumi.Context) (pulumi.StringOutput, error) {
+	out, err := ctx.Call("google-native:container/v1beta1:Cluster/getKubeconfig", nil, clusterGetKubeconfigResultOutput{}, r)
 	if err != nil {
-		return ClusterGetKubeconfigResultOutput{}, err
+		return pulumi.StringOutput{}, err
 	}
-	return out.(ClusterGetKubeconfigResultOutput), nil
+	return out.(clusterGetKubeconfigResultOutput).Kubeconfig(), nil
 }
 
-type ClusterGetKubeconfigResult struct {
+type clusterGetKubeconfigResult struct {
 	Kubeconfig string `pulumi:"kubeconfig"`
 }
 
-type ClusterGetKubeconfigResultOutput struct{ *pulumi.OutputState }
+type clusterGetKubeconfigResultOutput struct{ *pulumi.OutputState }
 
-func (ClusterGetKubeconfigResultOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*ClusterGetKubeconfigResult)(nil)).Elem()
+func (clusterGetKubeconfigResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*clusterGetKubeconfigResult)(nil)).Elem()
 }
 
-func (o ClusterGetKubeconfigResultOutput) Kubeconfig() pulumi.StringOutput {
-	return o.ApplyT(func(v ClusterGetKubeconfigResult) string { return v.Kubeconfig }).(pulumi.StringOutput)
+func (o clusterGetKubeconfigResultOutput) Kubeconfig() pulumi.StringOutput {
+	return o.ApplyT(func(v clusterGetKubeconfigResult) string { return v.Kubeconfig }).(pulumi.StringOutput)
 }
 
 type ClusterInput interface {
@@ -930,5 +930,5 @@ func (o ClusterOutput) Zone() pulumi.StringOutput {
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterInput)(nil)).Elem(), &Cluster{})
 	pulumi.RegisterOutputType(ClusterOutput{})
-	pulumi.RegisterOutputType(ClusterGetKubeconfigResultOutput{})
+	pulumi.RegisterOutputType(clusterGetKubeconfigResultOutput{})
 }

--- a/sdk/go/google/container/v1beta1/cluster.go
+++ b/sdk/go/google/container/v1beta1/cluster.go
@@ -494,6 +494,35 @@ func (ClusterArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*clusterArgs)(nil)).Elem()
 }
 
+// Generate a kubeconfig for cluster authentication.
+//
+// The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+// The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+//
+// See for more details:
+// - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+func (r *Cluster) GetKubeconfig(ctx *pulumi.Context) (ClusterGetKubeconfigResultOutput, error) {
+	out, err := ctx.Call("google-native:container/v1beta1:Cluster/getKubeconfig", nil, ClusterGetKubeconfigResultOutput{}, r)
+	if err != nil {
+		return ClusterGetKubeconfigResultOutput{}, err
+	}
+	return out.(ClusterGetKubeconfigResultOutput), nil
+}
+
+type ClusterGetKubeconfigResult struct {
+	Kubeconfig string `pulumi:"kubeconfig"`
+}
+
+type ClusterGetKubeconfigResultOutput struct{ *pulumi.OutputState }
+
+func (ClusterGetKubeconfigResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ClusterGetKubeconfigResult)(nil)).Elem()
+}
+
+func (o ClusterGetKubeconfigResultOutput) Kubeconfig() pulumi.StringOutput {
+	return o.ApplyT(func(v ClusterGetKubeconfigResult) string { return v.Kubeconfig }).(pulumi.StringOutput)
+}
+
 type ClusterInput interface {
 	pulumi.Input
 
@@ -901,4 +930,5 @@ func (o ClusterOutput) Zone() pulumi.StringOutput {
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ClusterInput)(nil)).Elem(), &Cluster{})
 	pulumi.RegisterOutputType(ClusterOutput{})
+	pulumi.RegisterOutputType(ClusterGetKubeconfigResultOutput{})
 }

--- a/sdk/nodejs/container/v1/cluster.ts
+++ b/sdk/nodejs/container/v1/cluster.ts
@@ -427,6 +427,21 @@ export class Cluster extends pulumi.CustomResource {
         opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(Cluster.__pulumiType, name, resourceInputs, opts);
     }
+
+    /**
+     * Generate a kubeconfig for cluster authentication.
+     *
+     * The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+     * The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+     *
+     * See for more details:
+     * - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+     */
+    getKubeconfig(): pulumi.Output<Cluster.GetKubeconfigResult> {
+        return pulumi.runtime.call("google-native:container/v1:Cluster/getKubeconfig", {
+            "__self__": this,
+        }, this);
+    }
 }
 
 /**
@@ -636,4 +651,14 @@ export interface ClusterArgs {
      * @deprecated Deprecated. The name of the Google Compute Engine [zone](https://cloud.google.com/compute/docs/zones#available) in which the cluster resides. This field has been deprecated and replaced by the parent field.
      */
     zone?: pulumi.Input<string>;
+}
+
+export namespace Cluster {
+    /**
+     * The results of the Cluster.getKubeconfig method.
+     */
+    export interface GetKubeconfigResult {
+        readonly kubeconfig: string;
+    }
+
 }

--- a/sdk/nodejs/container/v1/cluster.ts
+++ b/sdk/nodejs/container/v1/cluster.ts
@@ -432,7 +432,7 @@ export class Cluster extends pulumi.CustomResource {
      * Generate a kubeconfig for cluster authentication.
      *
      * The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-     * The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+     * The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
      *
      * See for more details:
      * - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

--- a/sdk/nodejs/container/v1/cluster.ts
+++ b/sdk/nodejs/container/v1/cluster.ts
@@ -437,10 +437,11 @@ export class Cluster extends pulumi.CustomResource {
      * See for more details:
      * - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
      */
-    getKubeconfig(): pulumi.Output<Cluster.GetKubeconfigResult> {
-        return pulumi.runtime.call("google-native:container/v1:Cluster/getKubeconfig", {
+    getKubeconfig(): pulumi.Output<string> {
+        const result: pulumi.Output<Cluster.GetKubeconfigResult> = pulumi.runtime.call("google-native:container/v1:Cluster/getKubeconfig", {
             "__self__": this,
         }, this);
+        return result.kubeconfig;
     }
 }
 

--- a/sdk/nodejs/container/v1beta1/cluster.ts
+++ b/sdk/nodejs/container/v1beta1/cluster.ts
@@ -503,10 +503,11 @@ export class Cluster extends pulumi.CustomResource {
      * See for more details:
      * - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
      */
-    getKubeconfig(): pulumi.Output<Cluster.GetKubeconfigResult> {
-        return pulumi.runtime.call("google-native:container/v1beta1:Cluster/getKubeconfig", {
+    getKubeconfig(): pulumi.Output<string> {
+        const result: pulumi.Output<Cluster.GetKubeconfigResult> = pulumi.runtime.call("google-native:container/v1beta1:Cluster/getKubeconfig", {
             "__self__": this,
         }, this);
+        return result.kubeconfig;
     }
 }
 

--- a/sdk/nodejs/container/v1beta1/cluster.ts
+++ b/sdk/nodejs/container/v1beta1/cluster.ts
@@ -498,7 +498,7 @@ export class Cluster extends pulumi.CustomResource {
      * Generate a kubeconfig for cluster authentication.
      *
      * The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-     * The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+     * The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
      *
      * See for more details:
      * - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

--- a/sdk/nodejs/container/v1beta1/cluster.ts
+++ b/sdk/nodejs/container/v1beta1/cluster.ts
@@ -493,6 +493,21 @@ export class Cluster extends pulumi.CustomResource {
         opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(Cluster.__pulumiType, name, resourceInputs, opts);
     }
+
+    /**
+     * Generate a kubeconfig for cluster authentication.
+     *
+     * The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+     * The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+     *
+     * See for more details:
+     * - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+     */
+    getKubeconfig(): pulumi.Output<Cluster.GetKubeconfigResult> {
+        return pulumi.runtime.call("google-native:container/v1beta1:Cluster/getKubeconfig", {
+            "__self__": this,
+        }, this);
+    }
 }
 
 /**
@@ -748,4 +763,14 @@ export interface ClusterArgs {
      * @deprecated Required. Deprecated. The name of the Google Compute Engine [zone](https://cloud.google.com/compute/docs/zones#available) in which the cluster resides. This field has been deprecated and replaced by the parent field.
      */
     zone?: pulumi.Input<string>;
+}
+
+export namespace Cluster {
+    /**
+     * The results of the Cluster.getKubeconfig method.
+     */
+    export interface GetKubeconfigResult {
+        readonly kubeconfig: string;
+    }
+
 }

--- a/sdk/python/pulumi_google_native/container/v1/cluster.py
+++ b/sdk/python/pulumi_google_native/container/v1/cluster.py
@@ -1671,7 +1671,7 @@ class Cluster(pulumi.CustomResource):
         Generate a kubeconfig for cluster authentication.
 
         The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-        The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+        The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
 
         See for more details:
         - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

--- a/sdk/python/pulumi_google_native/container/v1/cluster.py
+++ b/sdk/python/pulumi_google_native/container/v1/cluster.py
@@ -1654,3 +1654,29 @@ class Cluster(pulumi.CustomResource):
         """
         return pulumi.get(self, "zone")
 
+    @pulumi.output_type
+    class GetKubeconfigResult:
+        def __init__(__self__, kubeconfig=None):
+            if kubeconfig and not isinstance(kubeconfig, str):
+                raise TypeError("Expected argument 'kubeconfig' to be a str")
+            pulumi.set(__self__, "kubeconfig", kubeconfig)
+
+        @property
+        @pulumi.getter
+        def kubeconfig(self) -> str:
+            return pulumi.get(self, "kubeconfig")
+
+    def get_kubeconfig(__self__) -> pulumi.Output['Cluster.GetKubeconfigResult']:
+        """
+        Generate a kubeconfig for cluster authentication.
+
+        The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+        The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+
+        See for more details:
+        - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+        """
+        __args__ = dict()
+        __args__['__self__'] = __self__
+        return pulumi.runtime.call('google-native:container/v1:Cluster/getKubeconfig', __args__, res=__self__, typ=Cluster.GetKubeconfigResult)
+

--- a/sdk/python/pulumi_google_native/container/v1/cluster.py
+++ b/sdk/python/pulumi_google_native/container/v1/cluster.py
@@ -1666,7 +1666,7 @@ class Cluster(pulumi.CustomResource):
         def kubeconfig(self) -> str:
             return pulumi.get(self, "kubeconfig")
 
-    def get_kubeconfig(__self__) -> pulumi.Output['Cluster.GetKubeconfigResult']:
+    def get_kubeconfig(__self__) -> pulumi.Output['str']:
         """
         Generate a kubeconfig for cluster authentication.
 
@@ -1678,5 +1678,6 @@ class Cluster(pulumi.CustomResource):
         """
         __args__ = dict()
         __args__['__self__'] = __self__
-        return pulumi.runtime.call('google-native:container/v1:Cluster/getKubeconfig', __args__, res=__self__, typ=Cluster.GetKubeconfigResult)
+        __result__ = pulumi.runtime.call('google-native:container/v1:Cluster/getKubeconfig', __args__, res=__self__, typ=Cluster.GetKubeconfigResult)
+        return __result__.kubeconfig
 

--- a/sdk/python/pulumi_google_native/container/v1beta1/cluster.py
+++ b/sdk/python/pulumi_google_native/container/v1beta1/cluster.py
@@ -1962,3 +1962,29 @@ class Cluster(pulumi.CustomResource):
         """
         return pulumi.get(self, "zone")
 
+    @pulumi.output_type
+    class GetKubeconfigResult:
+        def __init__(__self__, kubeconfig=None):
+            if kubeconfig and not isinstance(kubeconfig, str):
+                raise TypeError("Expected argument 'kubeconfig' to be a str")
+            pulumi.set(__self__, "kubeconfig", kubeconfig)
+
+        @property
+        @pulumi.getter
+        def kubeconfig(self) -> str:
+            return pulumi.get(self, "kubeconfig")
+
+    def get_kubeconfig(__self__) -> pulumi.Output['Cluster.GetKubeconfigResult']:
+        """
+        Generate a kubeconfig for cluster authentication.
+
+        The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
+        The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+
+        See for more details:
+        - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+        """
+        __args__ = dict()
+        __args__['__self__'] = __self__
+        return pulumi.runtime.call('google-native:container/v1beta1:Cluster/getKubeconfig', __args__, res=__self__, typ=Cluster.GetKubeconfigResult)
+

--- a/sdk/python/pulumi_google_native/container/v1beta1/cluster.py
+++ b/sdk/python/pulumi_google_native/container/v1beta1/cluster.py
@@ -1974,7 +1974,7 @@ class Cluster(pulumi.CustomResource):
         def kubeconfig(self) -> str:
             return pulumi.get(self, "kubeconfig")
 
-    def get_kubeconfig(__self__) -> pulumi.Output['Cluster.GetKubeconfigResult']:
+    def get_kubeconfig(__self__) -> pulumi.Output['str']:
         """
         Generate a kubeconfig for cluster authentication.
 
@@ -1986,5 +1986,6 @@ class Cluster(pulumi.CustomResource):
         """
         __args__ = dict()
         __args__['__self__'] = __self__
-        return pulumi.runtime.call('google-native:container/v1beta1:Cluster/getKubeconfig', __args__, res=__self__, typ=Cluster.GetKubeconfigResult)
+        __result__ = pulumi.runtime.call('google-native:container/v1beta1:Cluster/getKubeconfig', __args__, res=__self__, typ=Cluster.GetKubeconfigResult)
+        return __result__.kubeconfig
 

--- a/sdk/python/pulumi_google_native/container/v1beta1/cluster.py
+++ b/sdk/python/pulumi_google_native/container/v1beta1/cluster.py
@@ -1979,7 +1979,7 @@ class Cluster(pulumi.CustomResource):
         Generate a kubeconfig for cluster authentication.
 
         The kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.
-        The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by google.
+        The kubeconfig uses the new `gke-gcloud-auth-plugin` authentication plugin as recommended by Google.
 
         See for more details:
         - https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke


### PR DESCRIPTION
Fixes #635 

This change also addresses switching to `gke-gcloud-auth-plugin` for authentication as required by [Google](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke).
