### PR TITLE
Enable env vars for project, region, zone

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -131,7 +131,7 @@ func (p *googleCloudProvider) Configure(ctx context.Context,
 	if projectValue != "" {
 		p.config["project"] = projectValue
 	}
-	
+
 	regionValue := p.getConfig("region", []string{
 		"GOOGLE_REGION",
 	})
@@ -147,7 +147,6 @@ func (p *googleCloudProvider) Configure(ctx context.Context,
 	if zoneValue != "" {
 		p.config["zone"] = zoneValue
 	}
-	
 
 	p.setLoggingContext(ctx)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -121,17 +121,33 @@ func (p *googleCloudProvider) Configure(ctx context.Context,
 	// * GCLOUD_PROJECT Env Var
 	// * CLOUDSDK_CORE_PROJECT Env Var
 	// This aligns with our provider documentation
-	project := p.getConfig("project", []string{
+	projectValue := p.getConfig("project", []string{
 		"GOOGLE_PROJECT",
 		"GOOGLE_CLOUD_PROJECT",
 		"GCLOUD_PROJECT",
 		"CLOUDSDK_CORE_PROJECT",
 	})
-	if project == "" {
-		return nil, fmt.Errorf("unable to find a valid Project. Set the Project by using: \n\n" +
-			" \t • `pulumi config set google-native:project my-project` or \n" +
-			" \t • Environment variables: `GOOGLE_PROJECT`, `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT` or `CLOUDSDK_CORE_PROJECT` \n\n")
+
+	if projectValue != "" {
+		p.config["project"] = projectValue
 	}
+	
+	regionValue := p.getConfig("region", []string{
+		"GOOGLE_REGION",
+	})
+
+	if regionValue != "" {
+		p.config["region"] = regionValue
+	}
+
+	zoneValue := p.getConfig("zone", []string{
+		"GOOGLE_ZONE",
+	})
+
+	if zoneValue != "" {
+		p.config["zone"] = zoneValue
+	}
+	
 
 	p.setLoggingContext(ctx)
 


### PR DESCRIPTION
fixes #664
fixes #666

I welcome feedback on this approach, assigning env vars for config values if none have been configured via provider.  I removed the error if no project is designated, as that is not a requirement and it can be specified at the resource level.

related #565
I will address the docs issue in a registry PR.