### PR TITLE
Embed endpoints in operations instead of bespoke URL template processing

### DIFF
--- a/provider/pkg/gen/discovery.go
+++ b/provider/pkg/gen/discovery.go
@@ -65,8 +65,9 @@ func findResources(
 		if strings.HasSuffix(docName, "appengine_v1.json") ||
 			strings.HasSuffix(docName, "appengine_v1alpha.json") ||
 			strings.HasSuffix(docName, "appengine_v1beta.json") {
-			dd.getMethod.Path = strings.ReplaceAll(dd.getMethod.Path, `{appsId}/operations/{operationsId}`, `{+name}`)
-			dd.getMethod.FlatPath = strings.ReplaceAll(dd.getMethod.FlatPath, `{appsId}/operations/{operationsId}`,
+			dd.getMethod.Path = strings.ReplaceAll(dd.getMethod.Path, `apps/{appsId}/operations/{operationsId}`,
+				`{+name}`)
+			dd.getMethod.FlatPath = strings.ReplaceAll(dd.getMethod.FlatPath, `apps/{appsId}/operations/{operationsId}`,
 				`{+name}`)
 			dd.getMethod.Parameters = map[string]discovery.JsonSchema{
 				"name": {Description: "`name` encapsulates both `appsId` and `operationsId`", Location: "path",
@@ -162,6 +163,7 @@ func findResourcesImpl(docName, parentName string, rest map[string]discovery.Res
 				}
 				if override, has := resourceNameByPathOverrides[fmt.Sprintf("%s:%s", filepath.Base(docName),
 					operationGetPath)]; has {
+					// If the override is set to an empty string, the intent is to skip the operation.
 					if override == "" {
 						continue
 					}
@@ -214,6 +216,7 @@ func findResourcesImpl(docName, parentName string, rest map[string]discovery.Res
 				path = methods.createMethod.Path
 			}
 			if override, has := resourceNameByPathOverrides[fmt.Sprintf("%s:%s", filepath.Base(docName), path)]; has {
+				// If the override is set to an empty string, the intent is to skip the resource.
 				if override == "" {
 					continue
 				}

--- a/provider/pkg/gen/discovery.go
+++ b/provider/pkg/gen/discovery.go
@@ -17,6 +17,7 @@ package gen
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -159,7 +160,8 @@ func findResourcesImpl(docName, parentName string, rest map[string]discovery.Res
 				if operationGetPath == "" {
 					operationGetPath = getMethod.Path
 				}
-				if override, has := resourceNameByPathOverrides[fmt.Sprintf("%s:%s", docName, operationGetPath)]; has {
+				if override, has := resourceNameByPathOverrides[fmt.Sprintf("%s:%s", filepath.Base(docName),
+					operationGetPath)]; has {
 					if override == "" {
 						continue
 					}
@@ -211,7 +213,7 @@ func findResourcesImpl(docName, parentName string, rest map[string]discovery.Res
 			if path == "" {
 				path = methods.createMethod.Path
 			}
-			if override, has := resourceNameByPathOverrides[fmt.Sprintf("%s:%s", docName, path)]; has {
+			if override, has := resourceNameByPathOverrides[fmt.Sprintf("%s:%s", filepath.Base(docName), path)]; has {
 				if override == "" {
 					continue
 				}

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -183,6 +183,16 @@ var metadataOverrides = map[string]resources.CloudAPIResource{
 			},
 		},
 	},
+	"google-native:dns/v1:ManagedZone": {
+		Update: resources.UpdateAPIOperation{
+			CloudAPIOperation: resources.CloudAPIOperation{
+				Operations: &resources.Operations{
+					OperationsBaseURL: "https://dns.googleapis." +
+						"com/dns/v1/projects/{project}/managedZones/{managedZone}/operations/{id}",
+				},
+			},
+		},
+	},
 	"google-native:bigtableadmin/v2:Instance": {
 		Create: resources.CreateAPIOperation{
 			CloudAPIOperation: resources.CloudAPIOperation{

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -183,16 +183,6 @@ var metadataOverrides = map[string]resources.CloudAPIResource{
 			},
 		},
 	},
-	"google-native:dns/v1:ManagedZone": {
-		Update: resources.UpdateAPIOperation{
-			CloudAPIOperation: resources.CloudAPIOperation{
-				Operations: &resources.Operations{
-					OperationsBaseURL: "https://dns.googleapis." +
-						"com/dns/v1/projects/{project}/managedZones/{managedZone}/operations/{id}",
-				},
-			},
-		},
-	},
 	"google-native:bigtableadmin/v2:Instance": {
 		Create: resources.CreateAPIOperation{
 			CloudAPIOperation: resources.CloudAPIOperation{

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -51,71 +51,75 @@ var resourceNameByTypeOverrides = map[string]string{
 // that is present in the discovery document.
 var resourceNameByPathOverrides = map[string]string{
 	// Cloud Run: remove domain mapping on the KNative path.
-	"apis/domains.cloudrun.com/v1/namespaces/{namespacesId}/domainmappings": "",
-	"apis/serving.knative.dev/v1/namespaces/{namespacesId}/services":        "",
+	"discovery/run_v1.json:apis/domains.cloudrun.com/v1/namespaces/{namespacesId}/domainmappings": "",
+	"discovery/run_v1.json:apis/serving.knative.dev/v1/namespaces/{namespacesId}/services":        "",
 
 	// Apigee.
-	"v1/organizations/{organizationsId}/envgroups/{envgroupsId}/attachments":                                 "EnvgroupAttachment",
-	"v1/organizations/{organizationsId}/instances/{instancesId}/attachments":                                 "InstanceAttachment",
-	"v1/organizations/{organizationsId}/environments/{environmentsId}/keyvaluemaps/{keyvaluemapsId}/entries": "EnvironmentEntry",
+	"discovery/apigee_v1.json:v1/organizations/{organizationsId}/envgroups/{envgroupsId}/attachments":                                 "EnvgroupAttachment",
+	"discovery/apigee_v1.json:v1/organizations/{organizationsId}/instances/{instancesId}/attachments":                                 "InstanceAttachment",
+	"discovery/apigee_v1.json:v1/organizations/{organizationsId}/environments/{environmentsId}/keyvaluemaps/{keyvaluemapsId}/entries": "EnvironmentEntry",
+
+	// App Engine Alpha v1. Get rid of locations and operations nested under locations.
+	"discovery/appengine_v1alpha.json:v1alpha/projects/{projectsId}/locations/{locationsId}":                           "",
+	"discovery/appengine_v1alpha.json:v1alpha/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}": "",
 
 	// ApigeeRegistry
-	"v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts": "DeploymentArtifact",
-	"v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts":       "VersionArtifact",
+	"discovery/apigeeregistry_v1.json:v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts": "DeploymentArtifact",
+	"discovery/apigeeregistry_v1.json:v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts":       "VersionArtifact",
 
 	// DLP.
-	"v2/organizations/{organizationsId}/deidentifyTemplates":                         "",
-	"v2/organizations/{organizationsId}/locations/{locationsId}/deidentifyTemplates": "OrganizationsDeidentifyTemplate",
-	"v2/organizations/{organizationsId}/inspectTemplates":                            "",
-	"v2/organizations/{organizationsId}/locations/{locationsId}/inspectTemplates":    "OrganizationInspectTemplate",
-	"v2/organizations/{organizationsId}/locations/{locationsId}/jobTriggers":         "OrganizationJobTrigger",
-	"v2/organizations/{organizationsId}/locations/{locationsId}/storedInfoTypes":     "",
-	"v2/organizations/{organizationsId}/storedInfoTypes":                             "",
+	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/deidentifyTemplates":                         "",
+	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/deidentifyTemplates": "OrganizationsDeidentifyTemplate",
+	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/inspectTemplates":                            "",
+	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/inspectTemplates":    "OrganizationInspectTemplate",
+	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/jobTriggers":         "OrganizationJobTrigger",
+	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/storedInfoTypes":     "",
+	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/storedInfoTypes":                             "",
 
-	// Essential Contracts.
-	"v1/folders/{foldersId}/contacts":             "FolderContact",
-	"v1/organizations/{organizationsId}/contacts": "OrganizationContact",
+	// Essential Contacts.
+	"discovery/essentialcontacts_v1.json:v1/folders/{foldersId}/contacts":             "FolderContact",
+	"discovery/essentialcontacts_v1.json:v1/organizations/{organizationsId}/contacts": "OrganizationContact",
 
 	// IAM.
-	"v1/organizations/{organizationsId}/roles": "OrganizationRole",
+	"discovery/iam_v1.json:v1/organizations/{organizationsId}/roles": "OrganizationRole",
 
 	// Logging.
-	"v2/billingAccounts/{billingAccountsId}/exclusions":                                        "BillingAccountExclusion",
-	"v2/folders/{foldersId}/exclusions":                                                        "FolderExclusion",
-	"v2/organizations/{organizationsId}/exclusions":                                            "OrganizationExclusion",
-	"v2/{v2Id}/{v2Id1}/exclusions":                                                             "",
-	"v2/billingAccounts/{billingAccountsId}/sinks":                                             "BillingAccountSink",
-	"v2/folders/{foldersId}/sinks":                                                             "FolderSink",
-	"v2/organizations/{organizationsId}/sinks":                                                 "OrganizationSink",
-	"v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets":                   "BillingAccountBucket",
-	"v2/folders/{foldersId}/locations/{locationsId}/buckets":                                   "FolderBucket",
-	"v2/organizations/{organizationsId}/locations/{locationsId}/buckets":                       "OrganizationBucket",
-	"v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets/{bucketsId}/views": "BillingAccountBucketView",
-	"v2/folders/{foldersId}/locations/{locationsId}/buckets/{bucketsId}/views":                 "FolderBucketView",
-	"v2/organizations/{organizationsId}/locations/{locationsId}/buckets/{bucketsId}/views":     "OrganizationBucketView",
-	"v2/projects/{projectsId}/locations/{locationsId}/buckets/{bucketsId}/views":               "BucketView",
-	"v2/{v2Id}/{v2Id1}/locations/{locationsId}/buckets":                                        "",
-	"v2/{v2Id}/{v2Id1}/sinks":                                                                  "",
+	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/exclusions":                                        "BillingAccountExclusion",
+	"discovery/logging_v2.json:v2/folders/{foldersId}/exclusions":                                                        "FolderExclusion",
+	"discovery/logging_v2.json:v2/organizations/{organizationsId}/exclusions":                                            "OrganizationExclusion",
+	"discovery/logging_v2.json:v2/{v2Id}/{v2Id1}/exclusions":                                                             "",
+	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/sinks":                                             "BillingAccountSink",
+	"discovery/logging_v2.json:v2/folders/{foldersId}/sinks":                                                             "FolderSink",
+	"discovery/logging_v2.json:v2/organizations/{organizationsId}/sinks":                                                 "OrganizationSink",
+	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets":                   "BillingAccountBucket",
+	"discovery/logging_v2.json:v2/folders/{foldersId}/locations/{locationsId}/buckets":                                   "FolderBucket",
+	"discovery/logging_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/buckets":                       "OrganizationBucket",
+	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets/{bucketsId}/views": "BillingAccountBucketView",
+	"discovery/logging_v2.json:v2/folders/{foldersId}/locations/{locationsId}/buckets/{bucketsId}/views":                 "FolderBucketView",
+	"discovery/logging_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/buckets/{bucketsId}/views":     "OrganizationBucketView",
+	"discovery/logging_v2.json:v2/projects/{projectsId}/locations/{locationsId}/buckets/{bucketsId}/views":               "BucketView",
+	"discovery/logging_v2.json:v2/{v2Id}/{v2Id1}/locations/{locationsId}/buckets":                                        "",
+	"discovery/logging_v2.json:v2/{v2Id}/{v2Id1}/sinks":                                                                  "",
 
 	// Org Policy.
-	"v2/folders/{foldersId}/policies":             "FolderPolicy",
-	"v2/organizations/{organizationsId}/policies": "OrganizationPolicy",
+	"discovery/orgpolicy_v2.json:v2/folders/{foldersId}/policies":             "FolderPolicy",
+	"discovery/orgpolicy_v2.json:v2/organizations/{organizationsId}/policies": "OrganizationPolicy",
 
 	// Policy Simulator.
-	"v1/folders/{foldersId}/locations/{locationsId}/replays":                  "FolderReplay",
-	"v1/organizations/{organizationsId}/locations/{locationsId}/replays":      "OrganizationReplay",
-	"v1beta1/folders/{foldersId}/locations/{locationsId}/replays":             "FolderReplay",
-	"v1beta1/organizations/{organizationsId}/locations/{locationsId}/replays": "OrganizationReplay",
+	"discovery/policysimulator_v1.json:v1/folders/{foldersId}/locations/{locationsId}/replays":                       "FolderReplay",
+	"discovery/policysimulator_v1.json:v1/organizations/{organizationsId}/locations/{locationsId}/replays":           "OrganizationReplay",
+	"discovery/policysimulator_v1beta1.json:v1beta1/folders/{foldersId}/locations/{locationsId}/replays":             "FolderReplay",
+	"discovery/policysimulator_v1beta1.json:v1beta1/organizations/{organizationsId}/locations/{locationsId}/replays": "OrganizationReplay",
 
 	// Security Center.
-	"v1/folders/{foldersId}/muteConfigs":                 "",
-	"v1/folders/{foldersId}/bigQueryExports":             "FolderBigQueryExport",
-	"v1/organizations/{organizationsId}/bigQueryExports": "OrganizationBigQueryExport",
-	"v1/organizations/{organizationsId}/muteConfigs":     "OrganizationMuteConfig",
-	"v1/projects/{projectsId}/bigQueryExports":           "ProjectBigQueryExport",
+	"discovery/securitycenter_v1.json:v1/folders/{foldersId}/muteConfigs":                 "",
+	"discovery/securitycenter_v1.json:v1/folders/{foldersId}/bigQueryExports":             "FolderBigQueryExport",
+	"discovery/securitycenter_v1.json:v1/organizations/{organizationsId}/bigQueryExports": "OrganizationBigQueryExport",
+	"discovery/securitycenter_v1.json:v1/organizations/{organizationsId}/muteConfigs":     "OrganizationMuteConfig",
+	"discovery/securitycenter_v1.json:v1/projects/{projectsId}/bigQueryExports":           "ProjectBigQueryExport",
 
 	// Storage.
-	"b/{bucket}/o": "BucketObject",
+	"discovery/storage_v1.json:b/{bucket}/o": "BucketObject",
 }
 
 // resourceNamePropertyOverrides is a list of exceptions populated for the buildIdParams method above.

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -51,75 +51,75 @@ var resourceNameByTypeOverrides = map[string]string{
 // that is present in the discovery document.
 var resourceNameByPathOverrides = map[string]string{
 	// Cloud Run: remove domain mapping on the KNative path.
-	"discovery/run_v1.json:apis/domains.cloudrun.com/v1/namespaces/{namespacesId}/domainmappings": "",
-	"discovery/run_v1.json:apis/serving.knative.dev/v1/namespaces/{namespacesId}/services":        "",
+	"run_v1.json:apis/domains.cloudrun.com/v1/namespaces/{namespacesId}/domainmappings": "",
+	"run_v1.json:apis/serving.knative.dev/v1/namespaces/{namespacesId}/services":        "",
 
 	// Apigee.
-	"discovery/apigee_v1.json:v1/organizations/{organizationsId}/envgroups/{envgroupsId}/attachments":                                 "EnvgroupAttachment",
-	"discovery/apigee_v1.json:v1/organizations/{organizationsId}/instances/{instancesId}/attachments":                                 "InstanceAttachment",
-	"discovery/apigee_v1.json:v1/organizations/{organizationsId}/environments/{environmentsId}/keyvaluemaps/{keyvaluemapsId}/entries": "EnvironmentEntry",
+	"apigee_v1.json:v1/organizations/{organizationsId}/envgroups/{envgroupsId}/attachments":                                 "EnvgroupAttachment",
+	"apigee_v1.json:v1/organizations/{organizationsId}/instances/{instancesId}/attachments":                                 "InstanceAttachment",
+	"apigee_v1.json:v1/organizations/{organizationsId}/environments/{environmentsId}/keyvaluemaps/{keyvaluemapsId}/entries": "EnvironmentEntry",
 
 	// App Engine Alpha v1. Get rid of locations and operations nested under locations.
-	"discovery/appengine_v1alpha.json:v1alpha/projects/{projectsId}/locations/{locationsId}":                           "",
-	"discovery/appengine_v1alpha.json:v1alpha/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}": "",
+	"appengine_v1alpha.json:v1alpha/projects/{projectsId}/locations/{locationsId}":                           "",
+	"appengine_v1alpha.json:v1alpha/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}": "",
 
 	// ApigeeRegistry
-	"discovery/apigeeregistry_v1.json:v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts": "DeploymentArtifact",
-	"discovery/apigeeregistry_v1.json:v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts":       "VersionArtifact",
+	"apigeeregistry_v1.json:v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts": "DeploymentArtifact",
+	"apigeeregistry_v1.json:v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts":       "VersionArtifact",
 
 	// DLP.
-	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/deidentifyTemplates":                         "",
-	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/deidentifyTemplates": "OrganizationsDeidentifyTemplate",
-	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/inspectTemplates":                            "",
-	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/inspectTemplates":    "OrganizationInspectTemplate",
-	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/jobTriggers":         "OrganizationJobTrigger",
-	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/storedInfoTypes":     "",
-	"discovery/dlp_v2.json:v2/organizations/{organizationsId}/storedInfoTypes":                             "",
+	"dlp_v2.json:v2/organizations/{organizationsId}/deidentifyTemplates":                         "",
+	"dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/deidentifyTemplates": "OrganizationsDeidentifyTemplate",
+	"dlp_v2.json:v2/organizations/{organizationsId}/inspectTemplates":                            "",
+	"dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/inspectTemplates":    "OrganizationInspectTemplate",
+	"dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/jobTriggers":         "OrganizationJobTrigger",
+	"dlp_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/storedInfoTypes":     "",
+	"dlp_v2.json:v2/organizations/{organizationsId}/storedInfoTypes":                             "",
 
 	// Essential Contacts.
-	"discovery/essentialcontacts_v1.json:v1/folders/{foldersId}/contacts":             "FolderContact",
-	"discovery/essentialcontacts_v1.json:v1/organizations/{organizationsId}/contacts": "OrganizationContact",
+	"essentialcontacts_v1.json:v1/folders/{foldersId}/contacts":             "FolderContact",
+	"essentialcontacts_v1.json:v1/organizations/{organizationsId}/contacts": "OrganizationContact",
 
 	// IAM.
-	"discovery/iam_v1.json:v1/organizations/{organizationsId}/roles": "OrganizationRole",
+	"iam_v1.json:v1/organizations/{organizationsId}/roles": "OrganizationRole",
 
 	// Logging.
-	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/exclusions":                                        "BillingAccountExclusion",
-	"discovery/logging_v2.json:v2/folders/{foldersId}/exclusions":                                                        "FolderExclusion",
-	"discovery/logging_v2.json:v2/organizations/{organizationsId}/exclusions":                                            "OrganizationExclusion",
-	"discovery/logging_v2.json:v2/{v2Id}/{v2Id1}/exclusions":                                                             "",
-	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/sinks":                                             "BillingAccountSink",
-	"discovery/logging_v2.json:v2/folders/{foldersId}/sinks":                                                             "FolderSink",
-	"discovery/logging_v2.json:v2/organizations/{organizationsId}/sinks":                                                 "OrganizationSink",
-	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets":                   "BillingAccountBucket",
-	"discovery/logging_v2.json:v2/folders/{foldersId}/locations/{locationsId}/buckets":                                   "FolderBucket",
-	"discovery/logging_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/buckets":                       "OrganizationBucket",
-	"discovery/logging_v2.json:v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets/{bucketsId}/views": "BillingAccountBucketView",
-	"discovery/logging_v2.json:v2/folders/{foldersId}/locations/{locationsId}/buckets/{bucketsId}/views":                 "FolderBucketView",
-	"discovery/logging_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/buckets/{bucketsId}/views":     "OrganizationBucketView",
-	"discovery/logging_v2.json:v2/projects/{projectsId}/locations/{locationsId}/buckets/{bucketsId}/views":               "BucketView",
-	"discovery/logging_v2.json:v2/{v2Id}/{v2Id1}/locations/{locationsId}/buckets":                                        "",
-	"discovery/logging_v2.json:v2/{v2Id}/{v2Id1}/sinks":                                                                  "",
+	"logging_v2.json:v2/billingAccounts/{billingAccountsId}/exclusions":                                        "BillingAccountExclusion",
+	"logging_v2.json:v2/folders/{foldersId}/exclusions":                                                        "FolderExclusion",
+	"logging_v2.json:v2/organizations/{organizationsId}/exclusions":                                            "OrganizationExclusion",
+	"logging_v2.json:v2/{v2Id}/{v2Id1}/exclusions":                                                             "",
+	"logging_v2.json:v2/billingAccounts/{billingAccountsId}/sinks":                                             "BillingAccountSink",
+	"logging_v2.json:v2/folders/{foldersId}/sinks":                                                             "FolderSink",
+	"logging_v2.json:v2/organizations/{organizationsId}/sinks":                                                 "OrganizationSink",
+	"logging_v2.json:v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets":                   "BillingAccountBucket",
+	"logging_v2.json:v2/folders/{foldersId}/locations/{locationsId}/buckets":                                   "FolderBucket",
+	"logging_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/buckets":                       "OrganizationBucket",
+	"logging_v2.json:v2/billingAccounts/{billingAccountsId}/locations/{locationsId}/buckets/{bucketsId}/views": "BillingAccountBucketView",
+	"logging_v2.json:v2/folders/{foldersId}/locations/{locationsId}/buckets/{bucketsId}/views":                 "FolderBucketView",
+	"logging_v2.json:v2/organizations/{organizationsId}/locations/{locationsId}/buckets/{bucketsId}/views":     "OrganizationBucketView",
+	"logging_v2.json:v2/projects/{projectsId}/locations/{locationsId}/buckets/{bucketsId}/views":               "BucketView",
+	"logging_v2.json:v2/{v2Id}/{v2Id1}/locations/{locationsId}/buckets":                                        "",
+	"logging_v2.json:v2/{v2Id}/{v2Id1}/sinks":                                                                  "",
 
 	// Org Policy.
-	"discovery/orgpolicy_v2.json:v2/folders/{foldersId}/policies":             "FolderPolicy",
-	"discovery/orgpolicy_v2.json:v2/organizations/{organizationsId}/policies": "OrganizationPolicy",
+	"orgpolicy_v2.json:v2/folders/{foldersId}/policies":             "FolderPolicy",
+	"orgpolicy_v2.json:v2/organizations/{organizationsId}/policies": "OrganizationPolicy",
 
 	// Policy Simulator.
-	"discovery/policysimulator_v1.json:v1/folders/{foldersId}/locations/{locationsId}/replays":                       "FolderReplay",
-	"discovery/policysimulator_v1.json:v1/organizations/{organizationsId}/locations/{locationsId}/replays":           "OrganizationReplay",
-	"discovery/policysimulator_v1beta1.json:v1beta1/folders/{foldersId}/locations/{locationsId}/replays":             "FolderReplay",
-	"discovery/policysimulator_v1beta1.json:v1beta1/organizations/{organizationsId}/locations/{locationsId}/replays": "OrganizationReplay",
+	"policysimulator_v1.json:v1/folders/{foldersId}/locations/{locationsId}/replays":                       "FolderReplay",
+	"policysimulator_v1.json:v1/organizations/{organizationsId}/locations/{locationsId}/replays":           "OrganizationReplay",
+	"policysimulator_v1beta1.json:v1beta1/folders/{foldersId}/locations/{locationsId}/replays":             "FolderReplay",
+	"policysimulator_v1beta1.json:v1beta1/organizations/{organizationsId}/locations/{locationsId}/replays": "OrganizationReplay",
 
 	// Security Center.
-	"discovery/securitycenter_v1.json:v1/folders/{foldersId}/muteConfigs":                 "",
-	"discovery/securitycenter_v1.json:v1/folders/{foldersId}/bigQueryExports":             "FolderBigQueryExport",
-	"discovery/securitycenter_v1.json:v1/organizations/{organizationsId}/bigQueryExports": "OrganizationBigQueryExport",
-	"discovery/securitycenter_v1.json:v1/organizations/{organizationsId}/muteConfigs":     "OrganizationMuteConfig",
-	"discovery/securitycenter_v1.json:v1/projects/{projectsId}/bigQueryExports":           "ProjectBigQueryExport",
+	"securitycenter_v1.json:v1/folders/{foldersId}/muteConfigs":                 "",
+	"securitycenter_v1.json:v1/folders/{foldersId}/bigQueryExports":             "FolderBigQueryExport",
+	"securitycenter_v1.json:v1/organizations/{organizationsId}/bigQueryExports": "OrganizationBigQueryExport",
+	"securitycenter_v1.json:v1/organizations/{organizationsId}/muteConfigs":     "OrganizationMuteConfig",
+	"securitycenter_v1.json:v1/projects/{projectsId}/bigQueryExports":           "ProjectBigQueryExport",
 
 	// Storage.
-	"discovery/storage_v1.json:b/{bucket}/o": "BucketObject",
+	"storage_v1.json:b/{bucket}/o": "BucketObject",
 }
 
 // resourceNamePropertyOverrides is a list of exceptions populated for the buildIdParams method above.

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -978,12 +978,8 @@ func (g *packageGenerator) setOperationsBaseURL(cloudOp *resources.CloudAPIOpera
 				if strings.Contains(param.Description, "(ID of the operation)") {
 					return "id"
 				}
-			case "projectId", "locationId":
-				return name[:len(name)-2]
 			case "managedZone":
 				return "name"
-			case "datum":
-				return "dataId"
 			default:
 				if strings.HasSuffix(name, "Id") {
 					name = name[:len(name)-2]

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -25,6 +25,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/gedex/inflector"
+
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-google-native/provider/pkg/resources"
@@ -982,6 +984,11 @@ func (g *packageGenerator) setOperationsBaseURL(cloudOp *resources.CloudAPIOpera
 				return "name"
 			case "datum":
 				return "dataId"
+			default:
+				if strings.HasSuffix(name, "Id") {
+					name = name[:len(name)-2]
+					return inflector.Singularize(name)
+				}
 			}
 			return name
 		}

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -988,7 +988,12 @@ func (g *packageGenerator) setOperationsBaseURL(cloudOp *resources.CloudAPIOpera
 		// Bunch of operations' rest methods have parameters that are not correctly
 		// referenced in flatPaths but are in paths.
 		cloudOp.Operations.Template = g.fullPath(op.restMethod, true)
-		for name, value := range op.restMethod.Parameters {
+		paramNames := codegen.NewStringSet()
+		for name := range op.restMethod.Parameters {
+			paramNames.Add(name)
+		}
+		for _, name := range paramNames.SortedValues() {
+			value := op.restMethod.Parameters[name]
 			cloudOp.Operations.Values = append(cloudOp.Operations.Values,
 				resources.CloudAPIResourceParam{
 					Name:    name,

--- a/provider/pkg/gen/schema_test.go
+++ b/provider/pkg/gen/schema_test.go
@@ -21,14 +21,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var root = path.Join("..", "..", "..")
+
 // This is a validation test to make sure that the metadata generated at schema generation stands-up
 // to the assumptions made for operation URL resolution at runtime in the provider.
 // NOTE this will need to be kept up-to-date with the provider.go implementation but this framework gives
 // valuable confidence in correctness around metadata generation without destabalizing the provider at runtime.
 func TestMetadata_Operations(t *testing.T) {
-	root := path.Join(".", "discovery")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Logf("Current directory: %s", cwd)
 	var fileNames []string
-	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	require.NoError(t, filepath.Walk(filepath.Join(root, "discovery"), func(path string, info os.FileInfo,
+		err error) error {
 		if err != nil {
 			return err
 		}
@@ -158,7 +163,7 @@ func TestMetadata_Operations(t *testing.T) {
 func loadMetadata() (*resources.CloudAPIMetadata, error) {
 	var resourceMap resources.CloudAPIMetadata
 
-	bytes, err := os.Open(path.Join(".", "provider", "cmd", "pulumi-resource-google-native",
+	bytes, err := os.Open(path.Join(root, "provider", "cmd", "pulumi-resource-google-native",
 		"metadata.json"))
 	if err != nil {
 		return nil, err
@@ -172,7 +177,7 @@ func loadMetadata() (*resources.CloudAPIMetadata, error) {
 func loadSchema() (*schema.PackageSpec, error) {
 	var pkg schema.PackageSpec
 
-	bytes, err := os.Open(path.Join(".", "provider", "cmd", "pulumi-resource-google-native",
+	bytes, err := os.Open(path.Join(root, "provider", "cmd", "pulumi-resource-google-native",
 		"schema.json"))
 	if err != nil {
 		return nil, err

--- a/provider/pkg/gen/utilities.go
+++ b/provider/pkg/gen/utilities.go
@@ -31,7 +31,9 @@ func apiParamNameToSdkName(name string) string {
 	if strings.HasSuffix(name, "Id") {
 		name = inflector.Singularize(name[:len(name)-2])
 		switch name {
-		case "project", "location", "managedZone", "zone":
+		case "project", "location":
+			return name
+		case "managedZone" /* DNS */, "zone":
 			return name
 		case "datum":
 			return "dataId"

--- a/provider/pkg/provider/container.go
+++ b/provider/pkg/provider/container.go
@@ -190,7 +190,7 @@ func updateClusterMapping(
 			return fmt.Errorf("error sending request: %s: %q %+v", err, uri, body)
 		}
 
-		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op)
+		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op, nil)
 		if err != nil {
 			return errors.Wrapf(err, "waiting for completion")
 		}
@@ -251,7 +251,7 @@ func updateClusterNestedField(diffPropPath, targetPropPath resource.PropertyPath
 			return fmt.Errorf("error sending request: %s: %q %+v", err, uri, body)
 		}
 
-		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op)
+		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op, nil)
 		if err != nil {
 			return errors.Wrapf(err, "waiting for completion")
 		}
@@ -635,7 +635,7 @@ func updateNodePoolMapping(
 			return fmt.Errorf("error sending request: %s: %q %+v", err, uri, body)
 		}
 
-		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op)
+		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op, nil)
 		if err != nil {
 			return errors.Wrapf(err, "waiting for completion")
 		}
@@ -695,7 +695,7 @@ func updateNodePoolConfig(diffPropPath, targetPropPath resource.PropertyPath,
 			return fmt.Errorf("error sending request: %s: %q %+v", err, uri, body)
 		}
 
-		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op)
+		_, err = p.waitForResourceOpCompletion(urn, res.Update.CloudAPIOperation, op, nil)
 		if err != nil {
 			return errors.Wrapf(err, "waiting for completion")
 		}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -916,7 +916,6 @@ func (p *googleCloudProvider) waitForResourceOpCompletion(
 				}
 				// At this point, we assume either a complete failure or a clean response.
 				if !continuePollingForRestingState {
-					// Try and fetch state from
 					return resp, nil
 				}
 			}

--- a/provider/pkg/resources/resources.go
+++ b/provider/pkg/resources/resources.go
@@ -17,7 +17,10 @@ package resources
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
+
+	"github.com/jtacoma/uritemplates"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -41,6 +44,8 @@ type CloudAPIEndpoint struct {
 	Values []CloudAPIResourceParam `json:"values,omitempty"`
 }
 
+var reservedExpansion = regexp.MustCompile(`{\+.*}`)
+
 // URI constructs a concrete URI value based on the properties of a created resource.
 func (e CloudAPIEndpoint) URI(
 	states ...map[string]interface{},
@@ -62,7 +67,14 @@ func (e CloudAPIEndpoint) URI(
 		return v, nil
 	}
 
-	id := e.Template
+	// This lets us process RFC 6570 URL templates.
+	tmpl, err := uritemplates.Parse(e.Template)
+	if err != nil {
+		return "", err
+	}
+	hasReservedExpansion := reservedExpansion.MatchString(e.Template)
+
+	pathParams := map[string]interface{}{}
 	queryMap := map[string]string{}
 	idParams := e.Values
 	for _, param := range idParams {
@@ -89,12 +101,18 @@ func (e CloudAPIEndpoint) URI(
 			return "", fmt.Errorf("property %q/%q not found", param.Name, param.SdkName)
 		}
 
-		// The name property can sometimes contain multiple segments. We only care about the last one
-		// because we flattened the path while building metadata.
-		parts := strings.Split(propValue, "/")
-		propValue = parts[len(parts)-1]
+		if !hasReservedExpansion {
+			// The name property can sometimes contain multiple segments. We only care about the last one
+			// because we flattened the path while building metadata.
+			parts := strings.Split(propValue, "/")
+			propValue = parts[len(parts)-1]
+		}
+		pathParams[param.Name] = propValue
+	}
 
-		id = strings.Replace(id, fmt.Sprintf("{%s}", param.Name), propValue, 1)
+	id, err := tmpl.Expand(pathParams)
+	if err != nil {
+		return "", err
 	}
 	uri, err := url.Parse(id)
 	if err != nil {

--- a/provider/pkg/resources/resources_test.go
+++ b/provider/pkg/resources/resources_test.go
@@ -37,7 +37,7 @@ func TestCalculateResourceId_IdProperty(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestCalculateResourceId_IdPath(t *testing.T) {
+func TestEndpoint_URI(t *testing.T) {
 	endpoint := CloudAPIEndpoint{
 		Template: "/v1/myparent/{parentsId}/myresource/{myresourcesId}",
 		Values: []CloudAPIResourceParam{
@@ -58,6 +58,27 @@ func TestCalculateResourceId_IdPath(t *testing.T) {
 		"reference": map[string]interface{}{
 			"name": "myparent/foo/myresource/bar",
 		},
+	}
+	actual, err := endpoint.URI(inputs, outputs)
+	assert.NoError(t, err)
+	assert.Equal(t, "/v1/myparent/foo/myresource/bar", actual)
+}
+
+func TestEndpoint_URI_RFC_6570(t *testing.T) {
+	endpoint := CloudAPIEndpoint{
+		Template: "/v1/myparent/{+name}",
+		Values: []CloudAPIResourceParam{
+			{
+				Name:    "name",
+				SdkName: "name",
+			},
+		},
+	}
+	inputs := map[string]interface{}{
+		"parentId": "foo",
+	}
+	outputs := map[string]interface{}{
+		"name": "foo/myresource/bar",
 	}
 	actual, err := endpoint.URI(inputs, outputs)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes #659

DNS managed zones and a few other resources need additional information for resolving the operations URL for updates etc than is readily available from the PATCH/Update response. Switching to an embedded endpoint gives us more control over resolving parameters where we can inject parameter values from the resource state or inputs.
The order of resolving URL params is:
1. Response payload from the relevant resource CRUD operation
2. Resource inputs
3. Resource outputs
