### PR TITLE
Disable autonaming for tagkey/tagval

### DIFF
--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -152,6 +152,8 @@ var autonameExcludes = codegen.NewStringSet(
 	"google-native:bigtableadmin/v1:Cluster",
 	"google-native:bigtableadmin/v2:Cluster",
 	"google-native:bigtableadmin/v2:Instance",
+	"google-native:cloudresourcemanager/v3:TagKey",
+	"google-native:cloudresourcemanager/v3:TagValue",
 	"google-native:dialogflow/v3:Agent",
 	"google-native:dialogflow/v3beta1:Agent",
 	"google-native:monitoring/v3:NotificationChannel",

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -864,9 +864,7 @@ func (p *googleCloudProvider) waitForResourceOpCompletion(
 				}
 				// Extract the resource response, if any.
 				// A partial error could happen, so both response and error could be available.
-				// We choose to not trust the response here unless we hit an error during the invocation,
-				// in which case we use the partial response to checkpoint state.
-				if response, has := op["response"].(map[string]interface{}); has && err != nil {
+				if response, has := op["response"].(map[string]interface{}); has {
 					return response, err
 				}
 


### PR DESCRIPTION
Fixes #689 
In addition, we no longer need to be skeptical about the response embedded in operation response since we do a fresh `GET` during creation and updates anyway.