### PR TITLE
Pin Gradle version to v7.6 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,11 @@ jobs:
         java-version: ${{matrix.javaversion}}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until ported to Gradle 8
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -195,6 +195,11 @@ jobs:
         java-version: ${{matrix.javaversion}}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until ported to Gradle 8
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,11 @@ jobs:
         java-version: ${{matrix.javaversion}}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until ported to Gradle 8
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -222,6 +222,11 @@ jobs:
         java-version: ${{matrix.javaversion}}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until ported to Gradle 8
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
As in https://github.com/pulumi/ci-mgmt/pull/352, this pins the version of Gradle to one that is known to work.