### PR TITLE
Remove validateOnly from SDKs and resource URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+Bug fixes:
+
+- Remove `validateOnly` query parameter from SDK properties
+  [#865](https://github.com/pulumi/pulumi-google-native/issues/865)
+
 ## v0.30.0 (2023-04-14)
 Upstream breaking changes:
 - Resource "google-native:sqladmin/v1beta4:Instance" missing input "availableMaintenanceVersions"

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -461,6 +461,9 @@ func (g *packageGenerator) fullPath(method *discovery.RestMethod, preferPath boo
 
 	queryParams := url.Values{}
 	for param, details := range method.Parameters {
+		if isIgnoredQueryParam(param) {
+			continue
+		}
 		if details.Location != "query" || !isRequired(details) {
 			continue
 		}
@@ -545,6 +548,9 @@ func (g *packageGenerator) genResource(typeName string, dd discoveryDocumentReso
 
 	for _, name := range codegen.SortedKeys(dd.createMethod.Parameters) {
 		param := dd.createMethod.Parameters[name]
+		if isIgnoredQueryParam(name) {
+			continue
+		}
 		if param.Location != "query" {
 			continue
 		}
@@ -1541,6 +1547,15 @@ func clearDescription(description string) string {
 	description = strings.TrimPrefix(description, "Output only. ")
 	description = strings.TrimSuffix(description, "@OutputOnly")
 	return description
+}
+
+// isIgnoredQueryParam returns true if a query parameter with a given name
+// should be ignored.
+func isIgnoredQueryParam(name string) bool {
+	// "validateOnly" is a special query parameter that allows a dry-run
+	// without actually executing an operation. It's always options and
+	// should not be projected to SDKs. See https://google.aip.dev/163#guidance.
+	return name == "validateOnly"
 }
 
 func rawMessage(v interface{}) schema.RawMessage {

--- a/sdk/dotnet/BeyondCorp/V1/AppConnection.cs
+++ b/sdk/dotnet/BeyondCorp/V1/AppConnection.cs
@@ -99,12 +99,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a AppConnection resource with the given unique name, arguments, and options.
@@ -226,12 +220,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         /// </summary>
         [Input("type", required: true)]
         public Input<Pulumi.GoogleNative.BeyondCorp.V1.AppConnectionType> Type { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public AppConnectionArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1/AppConnector.cs
+++ b/sdk/dotnet/BeyondCorp/V1/AppConnector.cs
@@ -87,12 +87,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a AppConnector resource with the given unique name, arguments, and options.
@@ -196,12 +190,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         /// </summary>
         [Input("resourceInfo")]
         public Input<Inputs.GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs>? ResourceInfo { get; set; }
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public AppConnectorArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1/AppGateway.cs
+++ b/sdk/dotnet/BeyondCorp/V1/AppGateway.cs
@@ -99,12 +99,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         [Output("uri")]
         public Output<string> Uri { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a AppGateway resource with the given unique name, arguments, and options.
@@ -208,12 +202,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         /// </summary>
         [Input("type", required: true)]
         public Input<Pulumi.GoogleNative.BeyondCorp.V1.AppGatewayType> Type { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public AppGatewayArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1/ClientConnectorService.cs
+++ b/sdk/dotnet/BeyondCorp/V1/ClientConnectorService.cs
@@ -75,12 +75,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a ClientConnectorService resource with the given unique name, arguments, and options.
@@ -172,12 +166,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         /// </summary>
         [Input("requestId")]
         public Input<string>? RequestId { get; set; }
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ClientConnectorServiceArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1/ClientGateway.cs
+++ b/sdk/dotnet/BeyondCorp/V1/ClientGateway.cs
@@ -63,12 +63,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a ClientGateway resource with the given unique name, arguments, and options.
@@ -142,12 +136,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1
         /// </summary>
         [Input("requestId")]
         public Input<string>? RequestId { get; set; }
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ClientGatewayArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1Alpha/AppConnection.cs
+++ b/sdk/dotnet/BeyondCorp/V1Alpha/AppConnection.cs
@@ -99,12 +99,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a AppConnection resource with the given unique name, arguments, and options.
@@ -226,12 +220,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         /// </summary>
         [Input("type", required: true)]
         public Input<Pulumi.GoogleNative.BeyondCorp.V1Alpha.AppConnectionType> Type { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public AppConnectionArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1Alpha/AppConnector.cs
+++ b/sdk/dotnet/BeyondCorp/V1Alpha/AppConnector.cs
@@ -87,12 +87,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a AppConnector resource with the given unique name, arguments, and options.
@@ -196,12 +190,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         /// </summary>
         [Input("resourceInfo")]
         public Input<Inputs.GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs>? ResourceInfo { get; set; }
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public AppConnectorArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1Alpha/AppGateway.cs
+++ b/sdk/dotnet/BeyondCorp/V1Alpha/AppGateway.cs
@@ -99,12 +99,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         [Output("uri")]
         public Output<string> Uri { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a AppGateway resource with the given unique name, arguments, and options.
@@ -208,12 +202,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         /// </summary>
         [Input("type", required: true)]
         public Input<Pulumi.GoogleNative.BeyondCorp.V1Alpha.AppGatewayType> Type { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public AppGatewayArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1Alpha/ClientConnectorService.cs
+++ b/sdk/dotnet/BeyondCorp/V1Alpha/ClientConnectorService.cs
@@ -75,12 +75,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a ClientConnectorService resource with the given unique name, arguments, and options.
@@ -172,12 +166,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         /// </summary>
         [Input("requestId")]
         public Input<string>? RequestId { get; set; }
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ClientConnectorServiceArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1Alpha/ClientGateway.cs
+++ b/sdk/dotnet/BeyondCorp/V1Alpha/ClientGateway.cs
@@ -63,12 +63,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a ClientGateway resource with the given unique name, arguments, and options.
@@ -142,12 +136,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         /// </summary>
         [Input("requestId")]
         public Input<string>? RequestId { get; set; }
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ClientGatewayArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1Alpha/Connection.cs
+++ b/sdk/dotnet/BeyondCorp/V1Alpha/Connection.cs
@@ -99,12 +99,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Connection resource with the given unique name, arguments, and options.
@@ -226,12 +220,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         /// </summary>
         [Input("type", required: true)]
         public Input<Pulumi.GoogleNative.BeyondCorp.V1Alpha.ConnectionType> Type { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ConnectionArgs()
         {

--- a/sdk/dotnet/BeyondCorp/V1Alpha/Connector.cs
+++ b/sdk/dotnet/BeyondCorp/V1Alpha/Connector.cs
@@ -87,12 +87,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Connector resource with the given unique name, arguments, and options.
@@ -196,12 +190,6 @@ namespace Pulumi.GoogleNative.BeyondCorp.V1Alpha
         /// </summary>
         [Input("resourceInfo")]
         public Input<Inputs.ResourceInfoArgs>? ResourceInfo { get; set; }
-
-        /// <summary>
-        /// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ConnectorArgs()
         {

--- a/sdk/dotnet/CloudBuild/V1/WorkerPool.cs
+++ b/sdk/dotnet/CloudBuild/V1/WorkerPool.cs
@@ -83,12 +83,6 @@ namespace Pulumi.GoogleNative.CloudBuild.V1
         public Output<string> UpdateTime { get; private set; } = null!;
 
         /// <summary>
-        /// If set, validate the request and preview the response, but do not actually post it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
-        /// <summary>
         /// Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
         /// </summary>
         [Output("workerPoolId")]
@@ -174,12 +168,6 @@ namespace Pulumi.GoogleNative.CloudBuild.V1
 
         [Input("project")]
         public Input<string>? Project { get; set; }
-
-        /// <summary>
-        /// If set, validate the request and preview the response, but do not actually post it.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         /// <summary>
         /// Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.

--- a/sdk/dotnet/CloudDeploy/V1/DeliveryPipeline.cs
+++ b/sdk/dotnet/CloudDeploy/V1/DeliveryPipeline.cs
@@ -100,12 +100,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a DeliveryPipeline resource with the given unique name, arguments, and options.
@@ -228,12 +222,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         /// </summary>
         [Input("suspended")]
         public Input<bool>? Suspended { get; set; }
-
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public DeliveryPipelineArgs()
         {

--- a/sdk/dotnet/CloudDeploy/V1/Release.cs
+++ b/sdk/dotnet/CloudDeploy/V1/Release.cs
@@ -159,12 +159,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         [Output("uid")]
         public Output<string> Uid { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Release resource with the given unique name, arguments, and options.
@@ -309,12 +303,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         /// </summary>
         [Input("skaffoldVersion")]
         public Input<string>? SkaffoldVersion { get; set; }
-
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ReleaseArgs()
         {

--- a/sdk/dotnet/CloudDeploy/V1/Rollout.cs
+++ b/sdk/dotnet/CloudDeploy/V1/Rollout.cs
@@ -168,12 +168,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         [Output("uid")]
         public Output<string> Uid { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Rollout resource with the given unique name, arguments, and options.
@@ -304,12 +298,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         /// </summary>
         [Input("targetId", required: true)]
         public Input<string> TargetId { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public RolloutArgs()
         {

--- a/sdk/dotnet/CloudDeploy/V1/Target.cs
+++ b/sdk/dotnet/CloudDeploy/V1/Target.cs
@@ -117,12 +117,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Target resource with the given unique name, arguments, and options.
@@ -275,12 +269,6 @@ namespace Pulumi.GoogleNative.CloudDeploy.V1
         /// </summary>
         [Input("targetId", required: true)]
         public Input<string> TargetId { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public TargetArgs()
         {

--- a/sdk/dotnet/CloudResourceManager/V3/TagKey.cs
+++ b/sdk/dotnet/CloudResourceManager/V3/TagKey.cs
@@ -75,12 +75,6 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a TagKey resource with the given unique name, arguments, and options.
@@ -173,12 +167,6 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
         /// </summary>
         [Input("shortName", required: true)]
         public Input<string> ShortName { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public TagKeyArgs()
         {

--- a/sdk/dotnet/CloudResourceManager/V3/TagValue.cs
+++ b/sdk/dotnet/CloudResourceManager/V3/TagValue.cs
@@ -63,12 +63,6 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a TagValue resource with the given unique name, arguments, and options.
@@ -143,12 +137,6 @@ namespace Pulumi.GoogleNative.CloudResourceManager.V3
         /// </summary>
         [Input("shortName", required: true)]
         public Input<string> ShortName { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public TagValueArgs()
         {

--- a/sdk/dotnet/Compute/Alpha/InterconnectAttachment.cs
+++ b/sdk/dotnet/Compute/Alpha/InterconnectAttachment.cs
@@ -256,12 +256,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         public Output<string> Type { get; private set; } = null!;
 
         /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
-        /// <summary>
         /// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         /// </summary>
         [Output("vlanTag8021q")]
@@ -478,12 +472,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Compute.Alpha.InterconnectAttachmentType>? Type { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         /// <summary>
         /// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.

--- a/sdk/dotnet/Compute/Alpha/NetworkEdgeSecurityService.cs
+++ b/sdk/dotnet/Compute/Alpha/NetworkEdgeSecurityService.cs
@@ -75,12 +75,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         [Output("selfLinkWithId")]
         public Output<string> SelfLinkWithId { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a NetworkEdgeSecurityService resource with the given unique name, arguments, and options.
@@ -160,12 +154,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         /// </summary>
         [Input("securityPolicy")]
         public Input<string>? SecurityPolicy { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public NetworkEdgeSecurityServiceArgs()
         {

--- a/sdk/dotnet/Compute/Alpha/RegionSecurityPolicy.cs
+++ b/sdk/dotnet/Compute/Alpha/RegionSecurityPolicy.cs
@@ -138,12 +138,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         [Output("userDefinedFields")]
         public Output<ImmutableArray<Outputs.SecurityPolicyUserDefinedFieldResponse>> UserDefinedFields { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a RegionSecurityPolicy resource with the given unique name, arguments, and options.
@@ -292,12 +286,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
             get => _userDefinedFields ?? (_userDefinedFields = new InputList<Inputs.SecurityPolicyUserDefinedFieldArgs>());
             set => _userDefinedFields = value;
         }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public RegionSecurityPolicyArgs()
         {

--- a/sdk/dotnet/Compute/Alpha/SecurityPolicy.cs
+++ b/sdk/dotnet/Compute/Alpha/SecurityPolicy.cs
@@ -141,12 +141,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
         [Output("userDefinedFields")]
         public Output<ImmutableArray<Outputs.SecurityPolicyUserDefinedFieldResponse>> UserDefinedFields { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a SecurityPolicy resource with the given unique name, arguments, and options.
@@ -291,12 +285,6 @@ namespace Pulumi.GoogleNative.Compute.Alpha
             get => _userDefinedFields ?? (_userDefinedFields = new InputList<Inputs.SecurityPolicyUserDefinedFieldArgs>());
             set => _userDefinedFields = value;
         }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public SecurityPolicyArgs()
         {

--- a/sdk/dotnet/Compute/Beta/InterconnectAttachment.cs
+++ b/sdk/dotnet/Compute/Beta/InterconnectAttachment.cs
@@ -232,12 +232,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         public Output<string> Type { get; private set; } = null!;
 
         /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
-        /// <summary>
         /// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         /// </summary>
         [Output("vlanTag8021q")]
@@ -448,12 +442,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Compute.Beta.InterconnectAttachmentType>? Type { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         /// <summary>
         /// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.

--- a/sdk/dotnet/Compute/Beta/NetworkEdgeSecurityService.cs
+++ b/sdk/dotnet/Compute/Beta/NetworkEdgeSecurityService.cs
@@ -75,12 +75,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         [Output("selfLinkWithId")]
         public Output<string> SelfLinkWithId { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a NetworkEdgeSecurityService resource with the given unique name, arguments, and options.
@@ -160,12 +154,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Input("securityPolicy")]
         public Input<string>? SecurityPolicy { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public NetworkEdgeSecurityServiceArgs()
         {

--- a/sdk/dotnet/Compute/Beta/RegionSecurityPolicy.cs
+++ b/sdk/dotnet/Compute/Beta/RegionSecurityPolicy.cs
@@ -129,12 +129,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         [Output("type")]
         public Output<string> Type { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a RegionSecurityPolicy resource with the given unique name, arguments, and options.
@@ -268,12 +262,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Compute.Beta.RegionSecurityPolicyType>? Type { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public RegionSecurityPolicyArgs()
         {

--- a/sdk/dotnet/Compute/Beta/SecurityPolicy.cs
+++ b/sdk/dotnet/Compute/Beta/SecurityPolicy.cs
@@ -132,12 +132,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         [Output("type")]
         public Output<string> Type { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a SecurityPolicy resource with the given unique name, arguments, and options.
@@ -267,12 +261,6 @@ namespace Pulumi.GoogleNative.Compute.Beta
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Compute.Beta.SecurityPolicyType>? Type { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public SecurityPolicyArgs()
         {

--- a/sdk/dotnet/Compute/V1/InterconnectAttachment.cs
+++ b/sdk/dotnet/Compute/V1/InterconnectAttachment.cs
@@ -220,12 +220,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         public Output<string> Type { get; private set; } = null!;
 
         /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
-        /// <summary>
         /// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         /// </summary>
         [Output("vlanTag8021q")]
@@ -424,12 +418,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Compute.V1.InterconnectAttachmentType>? Type { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         /// <summary>
         /// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.

--- a/sdk/dotnet/Compute/V1/NetworkEdgeSecurityService.cs
+++ b/sdk/dotnet/Compute/V1/NetworkEdgeSecurityService.cs
@@ -75,12 +75,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         [Output("selfLinkWithId")]
         public Output<string> SelfLinkWithId { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a NetworkEdgeSecurityService resource with the given unique name, arguments, and options.
@@ -160,12 +154,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Input("securityPolicy")]
         public Input<string>? SecurityPolicy { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public NetworkEdgeSecurityServiceArgs()
         {

--- a/sdk/dotnet/Compute/V1/RegionSecurityPolicy.cs
+++ b/sdk/dotnet/Compute/V1/RegionSecurityPolicy.cs
@@ -87,12 +87,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         [Output("type")]
         public Output<string> Type { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a RegionSecurityPolicy resource with the given unique name, arguments, and options.
@@ -196,12 +190,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Compute.V1.RegionSecurityPolicyType>? Type { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public RegionSecurityPolicyArgs()
         {

--- a/sdk/dotnet/Compute/V1/SecurityPolicy.cs
+++ b/sdk/dotnet/Compute/V1/SecurityPolicy.cs
@@ -90,12 +90,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         [Output("type")]
         public Output<string> Type { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a SecurityPolicy resource with the given unique name, arguments, and options.
@@ -195,12 +189,6 @@ namespace Pulumi.GoogleNative.Compute.V1
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Compute.V1.SecurityPolicyType>? Type { get; set; }
-
-        /// <summary>
-        /// If true, the request will not be committed.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public SecurityPolicyArgs()
         {

--- a/sdk/dotnet/Datamigration/V1/ConnectionProfile.cs
+++ b/sdk/dotnet/Datamigration/V1/ConnectionProfile.cs
@@ -117,12 +117,6 @@ namespace Pulumi.GoogleNative.Datamigration.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a ConnectionProfile resource with the given unique name, arguments, and options.
@@ -263,12 +257,6 @@ namespace Pulumi.GoogleNative.Datamigration.V1
         /// </summary>
         [Input("state")]
         public Input<Pulumi.GoogleNative.Datamigration.V1.ConnectionProfileState>? State { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ConnectionProfileArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/Asset.cs
+++ b/sdk/dotnet/Dataplex/V1/Asset.cs
@@ -109,12 +109,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
         [Output("zone")]
         public Output<string> Zone { get; private set; } = null!;
 
@@ -221,12 +215,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("resourceSpec", required: true)]
         public Input<Inputs.GoogleCloudDataplexV1AssetResourceSpecArgs> ResourceSpec { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         [Input("zone")]
         public Input<string>? Zone { get; set; }

--- a/sdk/dotnet/Dataplex/V1/Attribute.cs
+++ b/sdk/dotnet/Dataplex/V1/Attribute.cs
@@ -103,12 +103,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Attribute resource with the given unique name, arguments, and options.
@@ -223,12 +217,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("resourceAccessSpec")]
         public Input<Inputs.GoogleCloudDataplexV1ResourceAccessSpecArgs>? ResourceAccessSpec { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public AttributeArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/Content.cs
+++ b/sdk/dotnet/Dataplex/V1/Content.cs
@@ -85,12 +85,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Content resource with the given unique name, arguments, and options.
@@ -192,12 +186,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("sqlScript")]
         public Input<Inputs.GoogleCloudDataplexV1ContentSqlScriptArgs>? SqlScript { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ContentArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/Contentitem.cs
+++ b/sdk/dotnet/Dataplex/V1/Contentitem.cs
@@ -85,12 +85,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Contentitem resource with the given unique name, arguments, and options.
@@ -192,12 +186,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("sqlScript")]
         public Input<Inputs.GoogleCloudDataplexV1ContentSqlScriptArgs>? SqlScript { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ContentitemArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/DataAttributeBinding.cs
+++ b/sdk/dotnet/Dataplex/V1/DataAttributeBinding.cs
@@ -94,12 +94,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a DataAttributeBinding resource with the given unique name, arguments, and options.
@@ -222,12 +216,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("resource")]
         public Input<string>? Resource { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public DataAttributeBindingArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/DataScan.cs
+++ b/sdk/dotnet/Dataplex/V1/DataScan.cs
@@ -124,12 +124,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a DataScan resource with the given unique name, arguments, and options.
@@ -240,12 +234,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
 
         [Input("project")]
         public Input<string>? Project { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public DataScanArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/DataTaxonomy.cs
+++ b/sdk/dotnet/Dataplex/V1/DataTaxonomy.cs
@@ -82,12 +82,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a DataTaxonomy resource with the given unique name, arguments, and options.
@@ -180,12 +174,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
 
         [Input("project")]
         public Input<string>? Project { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public DataTaxonomyArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/Entity.cs
+++ b/sdk/dotnet/Dataplex/V1/Entity.cs
@@ -127,12 +127,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
         [Output("zone")]
         public Output<string> Zone { get; private set; } = null!;
 
@@ -262,12 +256,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("type", required: true)]
         public Input<Pulumi.GoogleNative.Dataplex.V1.EntityType> Type { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         [Input("zone")]
         public Input<string>? Zone { get; set; }

--- a/sdk/dotnet/Dataplex/V1/Environment.cs
+++ b/sdk/dotnet/Dataplex/V1/Environment.cs
@@ -103,12 +103,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Environment resource with the given unique name, arguments, and options.
@@ -211,12 +205,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("sessionSpec")]
         public Input<Inputs.GoogleCloudDataplexV1EnvironmentSessionSpecArgs>? SessionSpec { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public EnvironmentArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/Lake.cs
+++ b/sdk/dotnet/Dataplex/V1/Lake.cs
@@ -100,12 +100,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Lake resource with the given unique name, arguments, and options.
@@ -198,12 +192,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
 
         [Input("project")]
         public Input<string>? Project { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public LakeArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/Partition.cs
+++ b/sdk/dotnet/Dataplex/V1/Partition.cs
@@ -41,12 +41,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         public Output<string> Project { get; private set; } = null!;
 
         /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
-        /// <summary>
         /// Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
         /// </summary>
         [Output("values")]
@@ -128,12 +122,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
 
         [Input("project")]
         public Input<string>? Project { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         [Input("values", required: true)]
         private InputList<string>? _values;

--- a/sdk/dotnet/Dataplex/V1/Task.cs
+++ b/sdk/dotnet/Dataplex/V1/Task.cs
@@ -109,12 +109,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Task resource with the given unique name, arguments, and options.
@@ -229,12 +223,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("triggerSpec", required: true)]
         public Input<Inputs.GoogleCloudDataplexV1TaskTriggerSpecArgs> TriggerSpec { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public TaskArgs()
         {

--- a/sdk/dotnet/Dataplex/V1/Zone.cs
+++ b/sdk/dotnet/Dataplex/V1/Zone.cs
@@ -98,12 +98,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         public Output<string> UpdateTime { get; private set; } = null!;
 
         /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
-        /// <summary>
         /// Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")
         /// </summary>
         [Output("zoneId")]
@@ -211,12 +205,6 @@ namespace Pulumi.GoogleNative.Dataplex.V1
         /// </summary>
         [Input("type", required: true)]
         public Input<Pulumi.GoogleNative.Dataplex.V1.ZoneType> Type { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Only validate the request, but do not perform mutations. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         /// <summary>
         /// Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")

--- a/sdk/dotnet/Datastream/V1/ConnectionProfile.cs
+++ b/sdk/dotnet/Datastream/V1/ConnectionProfile.cs
@@ -118,12 +118,6 @@ namespace Pulumi.GoogleNative.Datastream.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the connection profile, but don't create any resources. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a ConnectionProfile resource with the given unique name, arguments, and options.
@@ -264,12 +258,6 @@ namespace Pulumi.GoogleNative.Datastream.V1
         /// </summary>
         [Input("staticServiceIpConnectivity")]
         public Input<Inputs.StaticServiceIpConnectivityArgs>? StaticServiceIpConnectivity { get; set; }
-
-        /// <summary>
-        /// Optional. Only validate the connection profile, but don't create any resources. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ConnectionProfileArgs()
         {

--- a/sdk/dotnet/Datastream/V1/Stream.cs
+++ b/sdk/dotnet/Datastream/V1/Stream.cs
@@ -112,12 +112,6 @@ namespace Pulumi.GoogleNative.Datastream.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the stream, but don't create any resources. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Stream resource with the given unique name, arguments, and options.
@@ -246,12 +240,6 @@ namespace Pulumi.GoogleNative.Datastream.V1
         /// </summary>
         [Input("streamId", required: true)]
         public Input<string> StreamId { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Only validate the stream, but don't create any resources. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public StreamArgs()
         {

--- a/sdk/dotnet/Datastream/V1Alpha1/Stream.cs
+++ b/sdk/dotnet/Datastream/V1Alpha1/Stream.cs
@@ -112,12 +112,6 @@ namespace Pulumi.GoogleNative.Datastream.V1Alpha1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. Only validate the stream, but do not create any resources. The default is false.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Stream resource with the given unique name, arguments, and options.
@@ -246,12 +240,6 @@ namespace Pulumi.GoogleNative.Datastream.V1Alpha1
         /// </summary>
         [Input("streamId", required: true)]
         public Input<string> StreamId { get; set; } = null!;
-
-        /// <summary>
-        /// Optional. Only validate the stream, but do not create any resources. The default is false.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public StreamArgs()
         {

--- a/sdk/dotnet/Eventarc/V1/Channel.cs
+++ b/sdk/dotnet/Eventarc/V1/Channel.cs
@@ -81,12 +81,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Required. If set, validate the request and preview the review, but do not post it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Channel resource with the given unique name, arguments, and options.
@@ -115,7 +109,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1
                     "channelId",
                     "location",
                     "project",
-                    "validateOnly",
                 },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
@@ -168,12 +161,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1
         /// </summary>
         [Input("provider")]
         public Input<string>? Provider { get; set; }
-
-        /// <summary>
-        /// Required. If set, validate the request and preview the review, but do not post it.
-        /// </summary>
-        [Input("validateOnly", required: true)]
-        public Input<bool> ValidateOnly { get; set; } = null!;
 
         public ChannelArgs()
         {

--- a/sdk/dotnet/Eventarc/V1/Trigger.cs
+++ b/sdk/dotnet/Eventarc/V1/Trigger.cs
@@ -105,12 +105,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Required. If set, validate the request and preview the review, but do not post it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Trigger resource with the given unique name, arguments, and options.
@@ -139,7 +133,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1
                     "location",
                     "project",
                     "triggerId",
-                    "validateOnly",
                 },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
@@ -234,12 +227,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1
         /// </summary>
         [Input("triggerId", required: true)]
         public Input<string> TriggerId { get; set; } = null!;
-
-        /// <summary>
-        /// Required. If set, validate the request and preview the review, but do not post it.
-        /// </summary>
-        [Input("validateOnly", required: true)]
-        public Input<bool> ValidateOnly { get; set; } = null!;
 
         public TriggerArgs()
         {

--- a/sdk/dotnet/Eventarc/V1Beta1/Trigger.cs
+++ b/sdk/dotnet/Eventarc/V1Beta1/Trigger.cs
@@ -81,12 +81,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1Beta1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Required. If set, validate the request and preview the review, but do not actually post it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Trigger resource with the given unique name, arguments, and options.
@@ -115,7 +109,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1Beta1
                     "location",
                     "project",
                     "triggerId",
-                    "validateOnly",
                 },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
@@ -192,12 +185,6 @@ namespace Pulumi.GoogleNative.Eventarc.V1Beta1
         /// </summary>
         [Input("triggerId", required: true)]
         public Input<string> TriggerId { get; set; } = null!;
-
-        /// <summary>
-        /// Required. If set, validate the request and preview the review, but do not actually post it.
-        /// </summary>
-        [Input("validateOnly", required: true)]
-        public Input<bool> ValidateOnly { get; set; } = null!;
 
         public TriggerArgs()
         {

--- a/sdk/dotnet/Firebasedatabase/V1Beta/Instance.cs
+++ b/sdk/dotnet/Firebasedatabase/V1Beta/Instance.cs
@@ -51,12 +51,6 @@ namespace Pulumi.GoogleNative.Firebasedatabase.V1Beta
         [Output("type")]
         public Output<string> Type { get; private set; } = null!;
 
-        /// <summary>
-        /// When set to true, the request will be validated but not submitted.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Instance resource with the given unique name, arguments, and options.
@@ -130,12 +124,6 @@ namespace Pulumi.GoogleNative.Firebasedatabase.V1Beta
         /// </summary>
         [Input("type")]
         public Input<Pulumi.GoogleNative.Firebasedatabase.V1Beta.InstanceType>? Type { get; set; }
-
-        /// <summary>
-        /// When set to true, the request will be validated but not submitted.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public InstanceArgs()
         {

--- a/sdk/dotnet/Monitoring/V1/Dashboard.cs
+++ b/sdk/dotnet/Monitoring/V1/Dashboard.cs
@@ -72,12 +72,6 @@ namespace Pulumi.GoogleNative.Monitoring.V1
         [Output("rowLayout")]
         public Output<Outputs.RowLayoutResponse> RowLayout { get; private set; } = null!;
 
-        /// <summary>
-        /// If set, validate the request and preview the review, but do not actually save it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Dashboard resource with the given unique name, arguments, and options.
@@ -195,12 +189,6 @@ namespace Pulumi.GoogleNative.Monitoring.V1
         /// </summary>
         [Input("rowLayout")]
         public Input<Inputs.RowLayoutArgs>? RowLayout { get; set; }
-
-        /// <summary>
-        /// If set, validate the request and preview the review, but do not actually save it.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public DashboardArgs()
         {

--- a/sdk/dotnet/Monitoring/V3/Group.cs
+++ b/sdk/dotnet/Monitoring/V3/Group.cs
@@ -49,12 +49,6 @@ namespace Pulumi.GoogleNative.Monitoring.V3
         [Output("project")]
         public Output<string> Project { get; private set; } = null!;
 
-        /// <summary>
-        /// If true, validate this request but do not create the group.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Group resource with the given unique name, arguments, and options.
@@ -130,12 +124,6 @@ namespace Pulumi.GoogleNative.Monitoring.V3
 
         [Input("project")]
         public Input<string>? Project { get; set; }
-
-        /// <summary>
-        /// If true, validate this request but do not create the group.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public GroupArgs()
         {

--- a/sdk/dotnet/Privateca/V1/Certificate.cs
+++ b/sdk/dotnet/Privateca/V1/Certificate.cs
@@ -129,12 +129,6 @@ namespace Pulumi.GoogleNative.Privateca.V1
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Certificate resource with the given unique name, arguments, and options.
@@ -254,12 +248,6 @@ namespace Pulumi.GoogleNative.Privateca.V1
         /// </summary>
         [Input("subjectMode")]
         public Input<Pulumi.GoogleNative.Privateca.V1.CertificateSubjectMode>? SubjectMode { get; set; }
-
-        /// <summary>
-        /// Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public CertificateArgs()
         {

--- a/sdk/dotnet/Run/V2/Job.cs
+++ b/sdk/dotnet/Run/V2/Job.cs
@@ -171,12 +171,6 @@ namespace Pulumi.GoogleNative.Run.V2
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Job resource with the given unique name, arguments, and options.
@@ -299,12 +293,6 @@ namespace Pulumi.GoogleNative.Run.V2
         /// </summary>
         [Input("template", required: true)]
         public Input<Inputs.GoogleCloudRunV2ExecutionTemplateArgs> Template { get; set; } = null!;
-
-        /// <summary>
-        /// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public JobArgs()
         {

--- a/sdk/dotnet/Run/V2/Service.cs
+++ b/sdk/dotnet/Run/V2/Service.cs
@@ -201,12 +201,6 @@ namespace Pulumi.GoogleNative.Run.V2
         [Output("uri")]
         public Output<string> Uri { get; private set; } = null!;
 
-        /// <summary>
-        /// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
 
         /// <summary>
         /// Create a Service resource with the given unique name, arguments, and options.
@@ -353,12 +347,6 @@ namespace Pulumi.GoogleNative.Run.V2
             get => _traffic ?? (_traffic = new InputList<Inputs.GoogleCloudRunV2TrafficTargetArgs>());
             set => _traffic = value;
         }
-
-        /// <summary>
-        /// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         public ServiceArgs()
         {

--- a/sdk/dotnet/Workstations/V1Beta/Workstation.cs
+++ b/sdk/dotnet/Workstations/V1Beta/Workstation.cs
@@ -93,12 +93,6 @@ namespace Pulumi.GoogleNative.Workstations.V1Beta
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// If set, validate the request and preview the review, but do not actually apply it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
         [Output("workstationClusterId")]
         public Output<string> WorkstationClusterId { get; private set; } = null!;
 
@@ -211,12 +205,6 @@ namespace Pulumi.GoogleNative.Workstations.V1Beta
 
         [Input("project")]
         public Input<string>? Project { get; set; }
-
-        /// <summary>
-        /// If set, validate the request and preview the review, but do not actually apply it.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         [Input("workstationClusterId", required: true)]
         public Input<string> WorkstationClusterId { get; set; } = null!;

--- a/sdk/dotnet/Workstations/V1Beta/WorkstationCluster.cs
+++ b/sdk/dotnet/Workstations/V1Beta/WorkstationCluster.cs
@@ -112,12 +112,6 @@ namespace Pulumi.GoogleNative.Workstations.V1Beta
         public Output<string> UpdateTime { get; private set; } = null!;
 
         /// <summary>
-        /// If set, validate the request and preview the review, but do not actually apply it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
-        /// <summary>
         /// Required. ID to use for the workstation cluster.
         /// </summary>
         [Output("workstationClusterId")]
@@ -239,12 +233,6 @@ namespace Pulumi.GoogleNative.Workstations.V1Beta
         /// </summary>
         [Input("subnetwork")]
         public Input<string>? Subnetwork { get; set; }
-
-        /// <summary>
-        /// If set, validate the request and preview the review, but do not actually apply it.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         /// <summary>
         /// Required. ID to use for the workstation cluster.

--- a/sdk/dotnet/Workstations/V1Beta/WorkstationConfig.cs
+++ b/sdk/dotnet/Workstations/V1Beta/WorkstationConfig.cs
@@ -129,12 +129,6 @@ namespace Pulumi.GoogleNative.Workstations.V1Beta
         [Output("updateTime")]
         public Output<string> UpdateTime { get; private set; } = null!;
 
-        /// <summary>
-        /// If set, validate the request and preview the review, but do not actually apply it.
-        /// </summary>
-        [Output("validateOnly")]
-        public Output<bool?> ValidateOnly { get; private set; } = null!;
-
         [Output("workstationClusterId")]
         public Output<string> WorkstationClusterId { get; private set; } = null!;
 
@@ -285,12 +279,6 @@ namespace Pulumi.GoogleNative.Workstations.V1Beta
         /// </summary>
         [Input("runningTimeout")]
         public Input<string>? RunningTimeout { get; set; }
-
-        /// <summary>
-        /// If set, validate the request and preview the review, but do not actually apply it.
-        /// </summary>
-        [Input("validateOnly")]
-        public Input<bool>? ValidateOnly { get; set; }
 
         [Input("workstationClusterId", required: true)]
         public Input<string> WorkstationClusterId { get; set; } = null!;

--- a/sdk/go/google/beyondcorp/v1/appConnection.go
+++ b/sdk/go/google/beyondcorp/v1/appConnection.go
@@ -43,8 +43,6 @@ type AppConnection struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Timestamp when the resource was last modified.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewAppConnection registers a new resource with the given unique name, arguments, and options.
@@ -117,8 +115,6 @@ type appConnectionArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The type of network connectivity used by the AppConnection.
 	Type AppConnectionType `pulumi:"type"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a AppConnection resource.
@@ -143,8 +139,6 @@ type AppConnectionArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The type of network connectivity used by the AppConnection.
 	Type AppConnectionTypeInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (AppConnectionArgs) ElementType() reflect.Type {
@@ -259,11 +253,6 @@ func (o AppConnectionOutput) Uid() pulumi.StringOutput {
 // Timestamp when the resource was last modified.
 func (o AppConnectionOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *AppConnection) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o AppConnectionOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *AppConnection) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1/appConnector.go
+++ b/sdk/go/google/beyondcorp/v1/appConnector.go
@@ -39,8 +39,6 @@ type AppConnector struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Timestamp when the resource was last modified.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewAppConnector registers a new resource with the given unique name, arguments, and options.
@@ -106,8 +104,6 @@ type appConnectorArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// Optional. Resource info of the connector.
 	ResourceInfo *GoogleCloudBeyondcorpAppconnectorsV1ResourceInfo `pulumi:"resourceInfo"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a AppConnector resource.
@@ -128,8 +124,6 @@ type AppConnectorArgs struct {
 	RequestId pulumi.StringPtrInput
 	// Optional. Resource info of the connector.
 	ResourceInfo GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoPtrInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (AppConnectorArgs) ElementType() reflect.Type {
@@ -234,11 +228,6 @@ func (o AppConnectorOutput) Uid() pulumi.StringOutput {
 // Timestamp when the resource was last modified.
 func (o AppConnectorOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *AppConnector) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o AppConnectorOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *AppConnector) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1/appGateway.go
+++ b/sdk/go/google/beyondcorp/v1/appGateway.go
@@ -43,8 +43,6 @@ type AppGateway struct {
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
 	// Server-defined URI for this resource.
 	Uri pulumi.StringOutput `pulumi:"uri"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewAppGateway registers a new resource with the given unique name, arguments, and options.
@@ -113,8 +111,6 @@ type appGatewayArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The type of network connectivity used by the AppGateway.
 	Type AppGatewayType `pulumi:"type"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a AppGateway resource.
@@ -135,8 +131,6 @@ type AppGatewayArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The type of network connectivity used by the AppGateway.
 	Type AppGatewayTypeInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (AppGatewayArgs) ElementType() reflect.Type {
@@ -247,11 +241,6 @@ func (o AppGatewayOutput) UpdateTime() pulumi.StringOutput {
 // Server-defined URI for this resource.
 func (o AppGatewayOutput) Uri() pulumi.StringOutput {
 	return o.ApplyT(func(v *AppGateway) pulumi.StringOutput { return v.Uri }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o AppGatewayOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *AppGateway) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1/clientConnectorService.go
+++ b/sdk/go/google/beyondcorp/v1/clientConnectorService.go
@@ -35,8 +35,6 @@ type ClientConnectorService struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// [Output only] Update time stamp.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewClientConnectorService registers a new resource with the given unique name, arguments, and options.
@@ -103,8 +101,6 @@ type clientConnectorServiceArgs struct {
 	Project *string `pulumi:"project"`
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId *string `pulumi:"requestId"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a ClientConnectorService resource.
@@ -123,8 +119,6 @@ type ClientConnectorServiceArgs struct {
 	Project pulumi.StringPtrInput
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId pulumi.StringPtrInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ClientConnectorServiceArgs) ElementType() reflect.Type {
@@ -215,11 +209,6 @@ func (o ClientConnectorServiceOutput) State() pulumi.StringOutput {
 // [Output only] Update time stamp.
 func (o ClientConnectorServiceOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *ClientConnectorService) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o ClientConnectorServiceOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *ClientConnectorService) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1/clientGateway.go
+++ b/sdk/go/google/beyondcorp/v1/clientGateway.go
@@ -30,8 +30,6 @@ type ClientGateway struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// [Output only] Update time stamp.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewClientGateway registers a new resource with the given unique name, arguments, and options.
@@ -86,8 +84,6 @@ type clientGatewayArgs struct {
 	Project *string `pulumi:"project"`
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId *string `pulumi:"requestId"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a ClientGateway resource.
@@ -100,8 +96,6 @@ type ClientGatewayArgs struct {
 	Project pulumi.StringPtrInput
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId pulumi.StringPtrInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ClientGatewayArgs) ElementType() reflect.Type {
@@ -182,11 +176,6 @@ func (o ClientGatewayOutput) State() pulumi.StringOutput {
 // [Output only] Update time stamp.
 func (o ClientGatewayOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *ClientGateway) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o ClientGatewayOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *ClientGateway) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1alpha/appConnection.go
+++ b/sdk/go/google/beyondcorp/v1alpha/appConnection.go
@@ -43,8 +43,6 @@ type AppConnection struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Timestamp when the resource was last modified.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewAppConnection registers a new resource with the given unique name, arguments, and options.
@@ -117,8 +115,6 @@ type appConnectionArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The type of network connectivity used by the AppConnection.
 	Type AppConnectionType `pulumi:"type"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a AppConnection resource.
@@ -143,8 +139,6 @@ type AppConnectionArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The type of network connectivity used by the AppConnection.
 	Type AppConnectionTypeInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (AppConnectionArgs) ElementType() reflect.Type {
@@ -259,11 +253,6 @@ func (o AppConnectionOutput) Uid() pulumi.StringOutput {
 // Timestamp when the resource was last modified.
 func (o AppConnectionOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *AppConnection) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o AppConnectionOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *AppConnection) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1alpha/appConnector.go
+++ b/sdk/go/google/beyondcorp/v1alpha/appConnector.go
@@ -39,8 +39,6 @@ type AppConnector struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Timestamp when the resource was last modified.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewAppConnector registers a new resource with the given unique name, arguments, and options.
@@ -106,8 +104,6 @@ type appConnectorArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// Optional. Resource info of the connector.
 	ResourceInfo *GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfo `pulumi:"resourceInfo"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a AppConnector resource.
@@ -128,8 +124,6 @@ type AppConnectorArgs struct {
 	RequestId pulumi.StringPtrInput
 	// Optional. Resource info of the connector.
 	ResourceInfo GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoPtrInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (AppConnectorArgs) ElementType() reflect.Type {
@@ -234,11 +228,6 @@ func (o AppConnectorOutput) Uid() pulumi.StringOutput {
 // Timestamp when the resource was last modified.
 func (o AppConnectorOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *AppConnector) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o AppConnectorOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *AppConnector) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1alpha/appGateway.go
+++ b/sdk/go/google/beyondcorp/v1alpha/appGateway.go
@@ -43,8 +43,6 @@ type AppGateway struct {
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
 	// Server-defined URI for this resource.
 	Uri pulumi.StringOutput `pulumi:"uri"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewAppGateway registers a new resource with the given unique name, arguments, and options.
@@ -113,8 +111,6 @@ type appGatewayArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The type of network connectivity used by the AppGateway.
 	Type AppGatewayType `pulumi:"type"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a AppGateway resource.
@@ -135,8 +131,6 @@ type AppGatewayArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The type of network connectivity used by the AppGateway.
 	Type AppGatewayTypeInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (AppGatewayArgs) ElementType() reflect.Type {
@@ -247,11 +241,6 @@ func (o AppGatewayOutput) UpdateTime() pulumi.StringOutput {
 // Server-defined URI for this resource.
 func (o AppGatewayOutput) Uri() pulumi.StringOutput {
 	return o.ApplyT(func(v *AppGateway) pulumi.StringOutput { return v.Uri }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o AppGatewayOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *AppGateway) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1alpha/clientConnectorService.go
+++ b/sdk/go/google/beyondcorp/v1alpha/clientConnectorService.go
@@ -35,8 +35,6 @@ type ClientConnectorService struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// [Output only] Update time stamp.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewClientConnectorService registers a new resource with the given unique name, arguments, and options.
@@ -103,8 +101,6 @@ type clientConnectorServiceArgs struct {
 	Project *string `pulumi:"project"`
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId *string `pulumi:"requestId"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a ClientConnectorService resource.
@@ -123,8 +119,6 @@ type ClientConnectorServiceArgs struct {
 	Project pulumi.StringPtrInput
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId pulumi.StringPtrInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ClientConnectorServiceArgs) ElementType() reflect.Type {
@@ -215,11 +209,6 @@ func (o ClientConnectorServiceOutput) State() pulumi.StringOutput {
 // [Output only] Update time stamp.
 func (o ClientConnectorServiceOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *ClientConnectorService) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o ClientConnectorServiceOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *ClientConnectorService) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1alpha/clientGateway.go
+++ b/sdk/go/google/beyondcorp/v1alpha/clientGateway.go
@@ -30,8 +30,6 @@ type ClientGateway struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// [Output only] Update time stamp.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewClientGateway registers a new resource with the given unique name, arguments, and options.
@@ -86,8 +84,6 @@ type clientGatewayArgs struct {
 	Project *string `pulumi:"project"`
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId *string `pulumi:"requestId"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a ClientGateway resource.
@@ -100,8 +96,6 @@ type ClientGatewayArgs struct {
 	Project pulumi.StringPtrInput
 	// Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
 	RequestId pulumi.StringPtrInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ClientGatewayArgs) ElementType() reflect.Type {
@@ -182,11 +176,6 @@ func (o ClientGatewayOutput) State() pulumi.StringOutput {
 // [Output only] Update time stamp.
 func (o ClientGatewayOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *ClientGateway) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o ClientGatewayOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *ClientGateway) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1alpha/connection.go
+++ b/sdk/go/google/beyondcorp/v1alpha/connection.go
@@ -43,8 +43,6 @@ type Connection struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Timestamp when the resource was last modified.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewConnection registers a new resource with the given unique name, arguments, and options.
@@ -117,8 +115,6 @@ type connectionArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The type of network connectivity used by the connection.
 	Type ConnectionType `pulumi:"type"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Connection resource.
@@ -143,8 +139,6 @@ type ConnectionArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The type of network connectivity used by the connection.
 	Type ConnectionTypeInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ConnectionArgs) ElementType() reflect.Type {
@@ -255,11 +249,6 @@ func (o ConnectionOutput) Uid() pulumi.StringOutput {
 // Timestamp when the resource was last modified.
 func (o ConnectionOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Connection) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o ConnectionOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Connection) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/beyondcorp/v1alpha/connector.go
+++ b/sdk/go/google/beyondcorp/v1alpha/connector.go
@@ -39,8 +39,6 @@ type Connector struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Timestamp when the resource was last modified.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewConnector registers a new resource with the given unique name, arguments, and options.
@@ -106,8 +104,6 @@ type connectorArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// Optional. Resource info of the connector.
 	ResourceInfo *ResourceInfo `pulumi:"resourceInfo"`
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Connector resource.
@@ -128,8 +124,6 @@ type ConnectorArgs struct {
 	RequestId pulumi.StringPtrInput
 	// Optional. Resource info of the connector.
 	ResourceInfo ResourceInfoPtrInput
-	// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ConnectorArgs) ElementType() reflect.Type {
@@ -230,11 +224,6 @@ func (o ConnectorOutput) Uid() pulumi.StringOutput {
 // Timestamp when the resource was last modified.
 func (o ConnectorOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Connector) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-func (o ConnectorOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Connector) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/cloudbuild/v1/workerPool.go
+++ b/sdk/go/google/cloudbuild/v1/workerPool.go
@@ -38,8 +38,6 @@ type WorkerPool struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Time at which the request to update the `WorkerPool` was received.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// If set, validate the request and preview the response, but do not actually post it.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 	// Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
 	WorkerPoolId pulumi.StringOutput `pulumi:"workerPoolId"`
 }
@@ -100,8 +98,6 @@ type workerPoolArgs struct {
 	// Legacy Private Pool configuration.
 	PrivatePoolV1Config *PrivatePoolV1Config `pulumi:"privatePoolV1Config"`
 	Project             *string              `pulumi:"project"`
-	// If set, validate the request and preview the response, but do not actually post it.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 	// Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
 	WorkerPoolId string `pulumi:"workerPoolId"`
 }
@@ -116,8 +112,6 @@ type WorkerPoolArgs struct {
 	// Legacy Private Pool configuration.
 	PrivatePoolV1Config PrivatePoolV1ConfigPtrInput
 	Project             pulumi.StringPtrInput
-	// If set, validate the request and preview the response, but do not actually post it.
-	ValidateOnly pulumi.BoolPtrInput
 	// Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
 	WorkerPoolId pulumi.StringInput
 }
@@ -215,11 +209,6 @@ func (o WorkerPoolOutput) Uid() pulumi.StringOutput {
 // Time at which the request to update the `WorkerPool` was received.
 func (o WorkerPoolOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *WorkerPool) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// If set, validate the request and preview the response, but do not actually post it.
-func (o WorkerPoolOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *WorkerPool) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 // Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.

--- a/sdk/go/google/clouddeploy/v1/deliveryPipeline.go
+++ b/sdk/go/google/clouddeploy/v1/deliveryPipeline.go
@@ -44,8 +44,6 @@ type DeliveryPipeline struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Most recent time at which the pipeline was updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewDeliveryPipeline registers a new resource with the given unique name, arguments, and options.
@@ -116,8 +114,6 @@ type deliveryPipelineArgs struct {
 	SerialPipeline *SerialPipeline `pulumi:"serialPipeline"`
 	// When suspended, no new releases or rollouts can be created, but in-progress ones will complete.
 	Suspended *bool `pulumi:"suspended"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a DeliveryPipeline resource.
@@ -142,8 +138,6 @@ type DeliveryPipelineArgs struct {
 	SerialPipeline SerialPipelinePtrInput
 	// When suspended, no new releases or rollouts can be created, but in-progress ones will complete.
 	Suspended pulumi.BoolPtrInput
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (DeliveryPipelineArgs) ElementType() reflect.Type {
@@ -254,11 +248,6 @@ func (o DeliveryPipelineOutput) Uid() pulumi.StringOutput {
 // Most recent time at which the pipeline was updated.
 func (o DeliveryPipelineOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *DeliveryPipeline) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-func (o DeliveryPipelineOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *DeliveryPipeline) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/clouddeploy/v1/release.go
+++ b/sdk/go/google/clouddeploy/v1/release.go
@@ -65,8 +65,6 @@ type Release struct {
 	TargetSnapshots TargetResponseArrayOutput `pulumi:"targetSnapshots"`
 	// Unique identifier of the `Release`.
 	Uid pulumi.StringOutput `pulumi:"uid"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewRelease registers a new resource with the given unique name, arguments, and options.
@@ -146,8 +144,6 @@ type releaseArgs struct {
 	SkaffoldConfigUri *string `pulumi:"skaffoldConfigUri"`
 	// The Skaffold version to use when operating on this release, such as "1.20.0". Not all versions are valid; Google Cloud Deploy supports a specific set of versions. If unset, the most recent supported Skaffold version will be used.
 	SkaffoldVersion *string `pulumi:"skaffoldVersion"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Release resource.
@@ -177,8 +173,6 @@ type ReleaseArgs struct {
 	SkaffoldConfigUri pulumi.StringPtrInput
 	// The Skaffold version to use when operating on this release, such as "1.20.0". Not all versions are valid; Google Cloud Deploy supports a specific set of versions. If unset, the most recent supported Skaffold version will be used.
 	SkaffoldVersion pulumi.StringPtrInput
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ReleaseArgs) ElementType() reflect.Type {
@@ -338,11 +332,6 @@ func (o ReleaseOutput) TargetSnapshots() TargetResponseArrayOutput {
 // Unique identifier of the `Release`.
 func (o ReleaseOutput) Uid() pulumi.StringOutput {
 	return o.ApplyT(func(v *Release) pulumi.StringOutput { return v.Uid }).(pulumi.StringOutput)
-}
-
-// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-func (o ReleaseOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Release) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/clouddeploy/v1/rollout.go
+++ b/sdk/go/google/clouddeploy/v1/rollout.go
@@ -68,8 +68,6 @@ type Rollout struct {
 	TargetId pulumi.StringOutput `pulumi:"targetId"`
 	// Unique identifier of the `Rollout`.
 	Uid pulumi.StringOutput `pulumi:"uid"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewRollout registers a new resource with the given unique name, arguments, and options.
@@ -153,8 +151,6 @@ type rolloutArgs struct {
 	StartingPhaseId *string `pulumi:"startingPhaseId"`
 	// The ID of Target to which this `Rollout` is deploying.
 	TargetId string `pulumi:"targetId"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Rollout resource.
@@ -181,8 +177,6 @@ type RolloutArgs struct {
 	StartingPhaseId pulumi.StringPtrInput
 	// The ID of Target to which this `Rollout` is deploying.
 	TargetId pulumi.StringInput
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (RolloutArgs) ElementType() reflect.Type {
@@ -351,11 +345,6 @@ func (o RolloutOutput) TargetId() pulumi.StringOutput {
 // Unique identifier of the `Rollout`.
 func (o RolloutOutput) Uid() pulumi.StringOutput {
 	return o.ApplyT(func(v *Rollout) pulumi.StringOutput { return v.Uid }).(pulumi.StringOutput)
-}
-
-// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-func (o RolloutOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Rollout) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/clouddeploy/v1/target.go
+++ b/sdk/go/google/clouddeploy/v1/target.go
@@ -49,8 +49,6 @@ type Target struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Most recent time at which the `Target` was updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewTarget registers a new resource with the given unique name, arguments, and options.
@@ -129,8 +127,6 @@ type targetArgs struct {
 	Run *CloudRunLocation `pulumi:"run"`
 	// Required. ID of the `Target`.
 	TargetId string `pulumi:"targetId"`
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Target resource.
@@ -163,8 +159,6 @@ type TargetArgs struct {
 	Run CloudRunLocationPtrInput
 	// Required. ID of the `Target`.
 	TargetId pulumi.StringInput
-	// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (TargetArgs) ElementType() reflect.Type {
@@ -290,11 +284,6 @@ func (o TargetOutput) Uid() pulumi.StringOutput {
 // Most recent time at which the `Target` was updated.
 func (o TargetOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Target) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-func (o TargetOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Target) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/cloudresourcemanager/v3/tagKey.go
+++ b/sdk/go/google/cloudresourcemanager/v3/tagKey.go
@@ -35,8 +35,6 @@ type TagKey struct {
 	ShortName pulumi.StringOutput `pulumi:"shortName"`
 	// Update time.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewTagKey registers a new resource with the given unique name, arguments, and options.
@@ -95,8 +93,6 @@ type tagKeyArgs struct {
 	PurposeData map[string]string `pulumi:"purposeData"`
 	// Immutable. The user friendly name for a TagKey. The short name should be unique for TagKeys within the same tag namespace. The short name must be 1-63 characters, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 	ShortName string `pulumi:"shortName"`
-	// Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a TagKey resource.
@@ -115,8 +111,6 @@ type TagKeyArgs struct {
 	PurposeData pulumi.StringMapInput
 	// Immutable. The user friendly name for a TagKey. The short name should be unique for TagKeys within the same tag namespace. The short name must be 1-63 characters, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 	ShortName pulumi.StringInput
-	// Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (TagKeyArgs) ElementType() reflect.Type {
@@ -204,11 +198,6 @@ func (o TagKeyOutput) ShortName() pulumi.StringOutput {
 // Update time.
 func (o TagKeyOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *TagKey) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-func (o TagKeyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *TagKey) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/cloudresourcemanager/v3/tagValue.go
+++ b/sdk/go/google/cloudresourcemanager/v3/tagValue.go
@@ -31,8 +31,6 @@ type TagValue struct {
 	ShortName pulumi.StringOutput `pulumi:"shortName"`
 	// Update time.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewTagValue registers a new resource with the given unique name, arguments, and options.
@@ -87,8 +85,6 @@ type tagValueArgs struct {
 	Parent *string `pulumi:"parent"`
 	// Immutable. User-assigned short name for TagValue. The short name should be unique for TagValues within the same parent TagKey. The short name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 	ShortName string `pulumi:"shortName"`
-	// Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a TagValue resource.
@@ -103,8 +99,6 @@ type TagValueArgs struct {
 	Parent pulumi.StringPtrInput
 	// Immutable. User-assigned short name for TagValue. The short name should be unique for TagValues within the same parent TagKey. The short name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
 	ShortName pulumi.StringInput
-	// Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (TagValueArgs) ElementType() reflect.Type {
@@ -182,11 +176,6 @@ func (o TagValueOutput) ShortName() pulumi.StringOutput {
 // Update time.
 func (o TagValueOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *TagValue) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-func (o TagValueOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *TagValue) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/alpha/interconnectAttachment.go
+++ b/sdk/go/google/compute/alpha/interconnectAttachment.go
@@ -97,8 +97,6 @@ type InterconnectAttachment struct {
 	SubnetLength pulumi.IntOutput `pulumi:"subnetLength"`
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q pulumi.IntOutput `pulumi:"vlanTag8021q"`
 }
@@ -196,8 +194,6 @@ type interconnectAttachmentArgs struct {
 	SubnetLength *int `pulumi:"subnetLength"`
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type *InterconnectAttachmentType `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q *int `pulumi:"vlanTag8021q"`
 }
@@ -250,8 +246,6 @@ type InterconnectAttachmentArgs struct {
 	SubnetLength pulumi.IntPtrInput
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type InterconnectAttachmentTypePtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q pulumi.IntPtrInput
 }
@@ -502,11 +496,6 @@ func (o InterconnectAttachmentOutput) SubnetLength() pulumi.IntOutput {
 // The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 func (o InterconnectAttachmentOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *InterconnectAttachment) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o InterconnectAttachmentOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *InterconnectAttachment) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 // The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.

--- a/sdk/go/google/compute/alpha/networkEdgeSecurityService.go
+++ b/sdk/go/google/compute/alpha/networkEdgeSecurityService.go
@@ -35,8 +35,6 @@ type NetworkEdgeSecurityService struct {
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// Server-defined URL for this resource with the resource id.
 	SelfLinkWithId pulumi.StringOutput `pulumi:"selfLinkWithId"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewNetworkEdgeSecurityService registers a new resource with the given unique name, arguments, and options.
@@ -96,8 +94,6 @@ type networkEdgeSecurityServiceArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The resource URL for the network edge security service associated with this network edge security service.
 	SecurityPolicy *string `pulumi:"securityPolicy"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a NetworkEdgeSecurityService resource.
@@ -112,8 +108,6 @@ type NetworkEdgeSecurityServiceArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The resource URL for the network edge security service associated with this network edge security service.
 	SecurityPolicy pulumi.StringPtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (NetworkEdgeSecurityServiceArgs) ElementType() reflect.Type {
@@ -204,11 +198,6 @@ func (o NetworkEdgeSecurityServiceOutput) SelfLink() pulumi.StringOutput {
 // Server-defined URL for this resource with the resource id.
 func (o NetworkEdgeSecurityServiceOutput) SelfLinkWithId() pulumi.StringOutput {
 	return o.ApplyT(func(v *NetworkEdgeSecurityService) pulumi.StringOutput { return v.SelfLinkWithId }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o NetworkEdgeSecurityServiceOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *NetworkEdgeSecurityService) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/alpha/regionSecurityPolicy.go
+++ b/sdk/go/google/compute/alpha/regionSecurityPolicy.go
@@ -56,8 +56,6 @@ type RegionSecurityPolicy struct {
 	Type pulumi.StringOutput `pulumi:"type"`
 	// Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
 	UserDefinedFields SecurityPolicyUserDefinedFieldResponseArrayOutput `pulumi:"userDefinedFields"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewRegionSecurityPolicy registers a new resource with the given unique name, arguments, and options.
@@ -132,8 +130,6 @@ type regionSecurityPolicyArgs struct {
 	Type *RegionSecurityPolicyType `pulumi:"type"`
 	// Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
 	UserDefinedFields []SecurityPolicyUserDefinedField `pulumi:"userDefinedFields"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a RegionSecurityPolicy resource.
@@ -163,8 +159,6 @@ type RegionSecurityPolicyArgs struct {
 	Type RegionSecurityPolicyTypePtrInput
 	// Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
 	UserDefinedFields SecurityPolicyUserDefinedFieldArrayInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (RegionSecurityPolicyArgs) ElementType() reflect.Type {
@@ -325,11 +319,6 @@ func (o RegionSecurityPolicyOutput) UserDefinedFields() SecurityPolicyUserDefine
 	return o.ApplyT(func(v *RegionSecurityPolicy) SecurityPolicyUserDefinedFieldResponseArrayOutput {
 		return v.UserDefinedFields
 	}).(SecurityPolicyUserDefinedFieldResponseArrayOutput)
-}
-
-// If true, the request will not be committed.
-func (o RegionSecurityPolicyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *RegionSecurityPolicy) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/alpha/securityPolicy.go
+++ b/sdk/go/google/compute/alpha/securityPolicy.go
@@ -56,8 +56,6 @@ type SecurityPolicy struct {
 	Type pulumi.StringOutput `pulumi:"type"`
 	// Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
 	UserDefinedFields SecurityPolicyUserDefinedFieldResponseArrayOutput `pulumi:"userDefinedFields"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewSecurityPolicy registers a new resource with the given unique name, arguments, and options.
@@ -127,8 +125,6 @@ type securityPolicyArgs struct {
 	Type *SecurityPolicyType `pulumi:"type"`
 	// Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
 	UserDefinedFields []SecurityPolicyUserDefinedField `pulumi:"userDefinedFields"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a SecurityPolicy resource.
@@ -157,8 +153,6 @@ type SecurityPolicyArgs struct {
 	Type SecurityPolicyTypePtrInput
 	// Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
 	UserDefinedFields SecurityPolicyUserDefinedFieldArrayInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (SecurityPolicyArgs) ElementType() reflect.Type {
@@ -318,11 +312,6 @@ func (o SecurityPolicyOutput) Type() pulumi.StringOutput {
 // Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
 func (o SecurityPolicyOutput) UserDefinedFields() SecurityPolicyUserDefinedFieldResponseArrayOutput {
 	return o.ApplyT(func(v *SecurityPolicy) SecurityPolicyUserDefinedFieldResponseArrayOutput { return v.UserDefinedFields }).(SecurityPolicyUserDefinedFieldResponseArrayOutput)
-}
-
-// If true, the request will not be committed.
-func (o SecurityPolicyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *SecurityPolicy) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/beta/interconnectAttachment.go
+++ b/sdk/go/google/compute/beta/interconnectAttachment.go
@@ -89,8 +89,6 @@ type InterconnectAttachment struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q pulumi.IntOutput `pulumi:"vlanTag8021q"`
 }
@@ -186,8 +184,6 @@ type interconnectAttachmentArgs struct {
 	StackType *InterconnectAttachmentStackType `pulumi:"stackType"`
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type *InterconnectAttachmentType `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q *int `pulumi:"vlanTag8021q"`
 }
@@ -238,8 +234,6 @@ type InterconnectAttachmentArgs struct {
 	StackType InterconnectAttachmentStackTypePtrInput
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type InterconnectAttachmentTypePtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q pulumi.IntPtrInput
 }
@@ -468,11 +462,6 @@ func (o InterconnectAttachmentOutput) State() pulumi.StringOutput {
 // The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 func (o InterconnectAttachmentOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *InterconnectAttachment) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o InterconnectAttachmentOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *InterconnectAttachment) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 // The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.

--- a/sdk/go/google/compute/beta/networkEdgeSecurityService.go
+++ b/sdk/go/google/compute/beta/networkEdgeSecurityService.go
@@ -35,8 +35,6 @@ type NetworkEdgeSecurityService struct {
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// Server-defined URL for this resource with the resource id.
 	SelfLinkWithId pulumi.StringOutput `pulumi:"selfLinkWithId"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewNetworkEdgeSecurityService registers a new resource with the given unique name, arguments, and options.
@@ -96,8 +94,6 @@ type networkEdgeSecurityServiceArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The resource URL for the network edge security service associated with this network edge security service.
 	SecurityPolicy *string `pulumi:"securityPolicy"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a NetworkEdgeSecurityService resource.
@@ -112,8 +108,6 @@ type NetworkEdgeSecurityServiceArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The resource URL for the network edge security service associated with this network edge security service.
 	SecurityPolicy pulumi.StringPtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (NetworkEdgeSecurityServiceArgs) ElementType() reflect.Type {
@@ -204,11 +198,6 @@ func (o NetworkEdgeSecurityServiceOutput) SelfLink() pulumi.StringOutput {
 // Server-defined URL for this resource with the resource id.
 func (o NetworkEdgeSecurityServiceOutput) SelfLinkWithId() pulumi.StringOutput {
 	return o.ApplyT(func(v *NetworkEdgeSecurityService) pulumi.StringOutput { return v.SelfLinkWithId }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o NetworkEdgeSecurityServiceOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *NetworkEdgeSecurityService) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/beta/regionSecurityPolicy.go
+++ b/sdk/go/google/compute/beta/regionSecurityPolicy.go
@@ -53,8 +53,6 @@ type RegionSecurityPolicy struct {
 	SelfLinkWithId pulumi.StringOutput `pulumi:"selfLinkWithId"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewRegionSecurityPolicy registers a new resource with the given unique name, arguments, and options.
@@ -126,8 +124,6 @@ type regionSecurityPolicyArgs struct {
 	Rules []SecurityPolicyRule `pulumi:"rules"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type *RegionSecurityPolicyType `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a RegionSecurityPolicy resource.
@@ -154,8 +150,6 @@ type RegionSecurityPolicyArgs struct {
 	Rules SecurityPolicyRuleArrayInput
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type RegionSecurityPolicyTypePtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (RegionSecurityPolicyArgs) ElementType() reflect.Type {
@@ -305,11 +299,6 @@ func (o RegionSecurityPolicyOutput) SelfLinkWithId() pulumi.StringOutput {
 // The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 func (o RegionSecurityPolicyOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *RegionSecurityPolicy) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o RegionSecurityPolicyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *RegionSecurityPolicy) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/beta/securityPolicy.go
+++ b/sdk/go/google/compute/beta/securityPolicy.go
@@ -53,8 +53,6 @@ type SecurityPolicy struct {
 	SelfLinkWithId pulumi.StringOutput `pulumi:"selfLinkWithId"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewSecurityPolicy registers a new resource with the given unique name, arguments, and options.
@@ -121,8 +119,6 @@ type securityPolicyArgs struct {
 	Rules []SecurityPolicyRule `pulumi:"rules"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type *SecurityPolicyType `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a SecurityPolicy resource.
@@ -148,8 +144,6 @@ type SecurityPolicyArgs struct {
 	Rules SecurityPolicyRuleArrayInput
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type SecurityPolicyTypePtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (SecurityPolicyArgs) ElementType() reflect.Type {
@@ -300,11 +294,6 @@ func (o SecurityPolicyOutput) SelfLinkWithId() pulumi.StringOutput {
 // The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 func (o SecurityPolicyOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *SecurityPolicy) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o SecurityPolicyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *SecurityPolicy) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/v1/interconnectAttachment.go
+++ b/sdk/go/google/compute/v1/interconnectAttachment.go
@@ -85,8 +85,6 @@ type InterconnectAttachment struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q pulumi.IntOutput `pulumi:"vlanTag8021q"`
 }
@@ -180,8 +178,6 @@ type interconnectAttachmentArgs struct {
 	StackType *InterconnectAttachmentStackType `pulumi:"stackType"`
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type *InterconnectAttachmentType `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q *int `pulumi:"vlanTag8021q"`
 }
@@ -230,8 +226,6 @@ type InterconnectAttachmentArgs struct {
 	StackType InterconnectAttachmentStackTypePtrInput
 	// The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 	Type InterconnectAttachmentTypePtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 	// The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
 	VlanTag8021q pulumi.IntPtrInput
 }
@@ -450,11 +444,6 @@ func (o InterconnectAttachmentOutput) State() pulumi.StringOutput {
 // The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner.
 func (o InterconnectAttachmentOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *InterconnectAttachment) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o InterconnectAttachmentOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *InterconnectAttachment) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 // The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.

--- a/sdk/go/google/compute/v1/networkEdgeSecurityService.go
+++ b/sdk/go/google/compute/v1/networkEdgeSecurityService.go
@@ -35,8 +35,6 @@ type NetworkEdgeSecurityService struct {
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// Server-defined URL for this resource with the resource id.
 	SelfLinkWithId pulumi.StringOutput `pulumi:"selfLinkWithId"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewNetworkEdgeSecurityService registers a new resource with the given unique name, arguments, and options.
@@ -96,8 +94,6 @@ type networkEdgeSecurityServiceArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// The resource URL for the network edge security service associated with this network edge security service.
 	SecurityPolicy *string `pulumi:"securityPolicy"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a NetworkEdgeSecurityService resource.
@@ -112,8 +108,6 @@ type NetworkEdgeSecurityServiceArgs struct {
 	RequestId pulumi.StringPtrInput
 	// The resource URL for the network edge security service associated with this network edge security service.
 	SecurityPolicy pulumi.StringPtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (NetworkEdgeSecurityServiceArgs) ElementType() reflect.Type {
@@ -204,11 +198,6 @@ func (o NetworkEdgeSecurityServiceOutput) SelfLink() pulumi.StringOutput {
 // Server-defined URL for this resource with the resource id.
 func (o NetworkEdgeSecurityServiceOutput) SelfLinkWithId() pulumi.StringOutput {
 	return o.ApplyT(func(v *NetworkEdgeSecurityService) pulumi.StringOutput { return v.SelfLinkWithId }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o NetworkEdgeSecurityServiceOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *NetworkEdgeSecurityService) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/v1/regionSecurityPolicy.go
+++ b/sdk/go/google/compute/v1/regionSecurityPolicy.go
@@ -39,8 +39,6 @@ type RegionSecurityPolicy struct {
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewRegionSecurityPolicy registers a new resource with the given unique name, arguments, and options.
@@ -106,8 +104,6 @@ type regionSecurityPolicyArgs struct {
 	Rules []SecurityPolicyRule `pulumi:"rules"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type *RegionSecurityPolicyType `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a RegionSecurityPolicy resource.
@@ -128,8 +124,6 @@ type RegionSecurityPolicyArgs struct {
 	Rules SecurityPolicyRuleArrayInput
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type RegionSecurityPolicyTypePtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (RegionSecurityPolicyArgs) ElementType() reflect.Type {
@@ -244,11 +238,6 @@ func (o RegionSecurityPolicyOutput) SelfLink() pulumi.StringOutput {
 // The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 func (o RegionSecurityPolicyOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *RegionSecurityPolicy) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o RegionSecurityPolicyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *RegionSecurityPolicy) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/compute/v1/securityPolicy.go
+++ b/sdk/go/google/compute/v1/securityPolicy.go
@@ -39,8 +39,6 @@ type SecurityPolicy struct {
 	SelfLink pulumi.StringOutput `pulumi:"selfLink"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewSecurityPolicy registers a new resource with the given unique name, arguments, and options.
@@ -101,8 +99,6 @@ type securityPolicyArgs struct {
 	Rules []SecurityPolicyRule `pulumi:"rules"`
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type *SecurityPolicyType `pulumi:"type"`
-	// If true, the request will not be committed.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a SecurityPolicy resource.
@@ -122,8 +118,6 @@ type SecurityPolicyArgs struct {
 	Rules SecurityPolicyRuleArrayInput
 	// The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 	Type SecurityPolicyTypePtrInput
-	// If true, the request will not be committed.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (SecurityPolicyArgs) ElementType() reflect.Type {
@@ -239,11 +233,6 @@ func (o SecurityPolicyOutput) SelfLink() pulumi.StringOutput {
 // The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
 func (o SecurityPolicyOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *SecurityPolicy) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// If true, the request will not be committed.
-func (o SecurityPolicyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *SecurityPolicy) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/datamigration/v1/connectionProfile.go
+++ b/sdk/go/google/datamigration/v1/connectionProfile.go
@@ -49,8 +49,6 @@ type ConnectionProfile struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// The timestamp when the resource was last updated. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewConnectionProfile registers a new resource with the given unique name, arguments, and options.
@@ -129,8 +127,6 @@ type connectionProfileArgs struct {
 	SkipValidation *bool `pulumi:"skipValidation"`
 	// The current connection profile state (e.g. DRAFT, READY, or FAILED).
 	State *ConnectionProfileStateEnum `pulumi:"state"`
-	// Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a ConnectionProfile resource.
@@ -163,8 +159,6 @@ type ConnectionProfileArgs struct {
 	SkipValidation pulumi.BoolPtrInput
 	// The current connection profile state (e.g. DRAFT, READY, or FAILED).
 	State ConnectionProfileStateEnumPtrInput
-	// Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ConnectionProfileArgs) ElementType() reflect.Type {
@@ -290,11 +284,6 @@ func (o ConnectionProfileOutput) State() pulumi.StringOutput {
 // The timestamp when the resource was last updated. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
 func (o ConnectionProfileOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *ConnectionProfile) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-func (o ConnectionProfileOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *ConnectionProfile) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/asset.go
+++ b/sdk/go/google/dataplex/v1/asset.go
@@ -47,9 +47,7 @@ type Asset struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the asset was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
-	Zone         pulumi.StringOutput  `pulumi:"zone"`
+	Zone       pulumi.StringOutput `pulumi:"zone"`
 }
 
 // NewAsset registers a new resource with the given unique name, arguments, and options.
@@ -123,9 +121,7 @@ type assetArgs struct {
 	Project  *string           `pulumi:"project"`
 	// Specification of the resource that is referenced by this asset.
 	ResourceSpec GoogleCloudDataplexV1AssetResourceSpec `pulumi:"resourceSpec"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool   `pulumi:"validateOnly"`
-	Zone         *string `pulumi:"zone"`
+	Zone         *string                                `pulumi:"zone"`
 }
 
 // The set of arguments for constructing a Asset resource.
@@ -145,8 +141,6 @@ type AssetArgs struct {
 	Project  pulumi.StringPtrInput
 	// Specification of the resource that is referenced by this asset.
 	ResourceSpec GoogleCloudDataplexV1AssetResourceSpecInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 	Zone         pulumi.StringPtrInput
 }
 
@@ -267,11 +261,6 @@ func (o AssetOutput) Uid() pulumi.StringOutput {
 // The time when the asset was last updated.
 func (o AssetOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Asset) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o AssetOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Asset) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func (o AssetOutput) Zone() pulumi.StringOutput {

--- a/sdk/go/google/dataplex/v1/attribute.go
+++ b/sdk/go/google/dataplex/v1/attribute.go
@@ -45,8 +45,6 @@ type Attribute struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the DataAttribute was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewAttribute registers a new resource with the given unique name, arguments, and options.
@@ -120,8 +118,6 @@ type attributeArgs struct {
 	Project  *string `pulumi:"project"`
 	// Optional. Specified when applied to a resource (eg: Cloud Storage bucket, BigQuery dataset, BigQuery table).
 	ResourceAccessSpec *GoogleCloudDataplexV1ResourceAccessSpec `pulumi:"resourceAccessSpec"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Attribute resource.
@@ -145,8 +141,6 @@ type AttributeArgs struct {
 	Project  pulumi.StringPtrInput
 	// Optional. Specified when applied to a resource (eg: Cloud Storage bucket, BigQuery dataset, BigQuery table).
 	ResourceAccessSpec GoogleCloudDataplexV1ResourceAccessSpecPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (AttributeArgs) ElementType() reflect.Type {
@@ -261,11 +255,6 @@ func (o AttributeOutput) Uid() pulumi.StringOutput {
 // The time when the DataAttribute was last updated.
 func (o AttributeOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Attribute) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o AttributeOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Attribute) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/content.go
+++ b/sdk/go/google/dataplex/v1/content.go
@@ -39,8 +39,6 @@ type Content struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the content was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewContent registers a new resource with the given unique name, arguments, and options.
@@ -112,8 +110,6 @@ type contentArgs struct {
 	Project *string `pulumi:"project"`
 	// Sql Script related configurations.
 	SqlScript *GoogleCloudDataplexV1ContentSqlScript `pulumi:"sqlScript"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Content resource.
@@ -133,8 +129,6 @@ type ContentArgs struct {
 	Project pulumi.StringPtrInput
 	// Sql Script related configurations.
 	SqlScript GoogleCloudDataplexV1ContentSqlScriptPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ContentArgs) ElementType() reflect.Type {
@@ -234,11 +228,6 @@ func (o ContentOutput) Uid() pulumi.StringOutput {
 // The time when the content was last updated.
 func (o ContentOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Content) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o ContentOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Content) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/contentitem.go
+++ b/sdk/go/google/dataplex/v1/contentitem.go
@@ -39,8 +39,6 @@ type Contentitem struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the content was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewContentitem registers a new resource with the given unique name, arguments, and options.
@@ -112,8 +110,6 @@ type contentitemArgs struct {
 	Project *string `pulumi:"project"`
 	// Sql Script related configurations.
 	SqlScript *GoogleCloudDataplexV1ContentSqlScript `pulumi:"sqlScript"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Contentitem resource.
@@ -133,8 +129,6 @@ type ContentitemArgs struct {
 	Project pulumi.StringPtrInput
 	// Sql Script related configurations.
 	SqlScript GoogleCloudDataplexV1ContentSqlScriptPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ContentitemArgs) ElementType() reflect.Type {
@@ -234,11 +228,6 @@ func (o ContentitemOutput) Uid() pulumi.StringOutput {
 // The time when the content was last updated.
 func (o ContentitemOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Contentitem) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o ContentitemOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Contentitem) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/dataAttributeBinding.go
+++ b/sdk/go/google/dataplex/v1/dataAttributeBinding.go
@@ -42,8 +42,6 @@ type DataAttributeBinding struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the DataAttributeBinding was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewDataAttributeBinding registers a new resource with the given unique name, arguments, and options.
@@ -112,8 +110,6 @@ type dataAttributeBindingArgs struct {
 	Project *string                                         `pulumi:"project"`
 	// Optional. Immutable. The resource name of the resource that is associated to attributes. Presently, only entity resource is supported in the form: projects/{project}/locations/{location}/lakes/{lake}/zones/{zone}/entities/{entity_id} Must belong in the same project and region as the attribute binding, and there can only exist one active binding for a resource.
 	Resource *string `pulumi:"resource"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a DataAttributeBinding resource.
@@ -136,8 +132,6 @@ type DataAttributeBindingArgs struct {
 	Project pulumi.StringPtrInput
 	// Optional. Immutable. The resource name of the resource that is associated to attributes. Presently, only entity resource is supported in the form: projects/{project}/locations/{location}/lakes/{lake}/zones/{zone}/entities/{entity_id} Must belong in the same project and region as the attribute binding, and there can only exist one active binding for a resource.
 	Resource pulumi.StringPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (DataAttributeBindingArgs) ElementType() reflect.Type {
@@ -245,11 +239,6 @@ func (o DataAttributeBindingOutput) Uid() pulumi.StringOutput {
 // The time when the DataAttributeBinding was last updated.
 func (o DataAttributeBindingOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *DataAttributeBinding) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o DataAttributeBindingOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *DataAttributeBinding) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/dataScan.go
+++ b/sdk/go/google/dataplex/v1/dataScan.go
@@ -52,8 +52,6 @@ type DataScan struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the scan was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewDataScan registers a new resource with the given unique name, arguments, and options.
@@ -125,8 +123,6 @@ type dataScanArgs struct {
 	Labels   map[string]string `pulumi:"labels"`
 	Location *string           `pulumi:"location"`
 	Project  *string           `pulumi:"project"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a DataScan resource.
@@ -149,8 +145,6 @@ type DataScanArgs struct {
 	Labels   pulumi.StringMapInput
 	Location pulumi.StringPtrInput
 	Project  pulumi.StringPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (DataScanArgs) ElementType() reflect.Type {
@@ -281,11 +275,6 @@ func (o DataScanOutput) Uid() pulumi.StringOutput {
 // The time when the scan was last updated.
 func (o DataScanOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *DataScan) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o DataScanOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *DataScan) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/dataTaxonomy.go
+++ b/sdk/go/google/dataplex/v1/dataTaxonomy.go
@@ -38,8 +38,6 @@ type DataTaxonomy struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the DataTaxonomy was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewDataTaxonomy registers a new resource with the given unique name, arguments, and options.
@@ -102,8 +100,6 @@ type dataTaxonomyArgs struct {
 	Labels   map[string]string `pulumi:"labels"`
 	Location *string           `pulumi:"location"`
 	Project  *string           `pulumi:"project"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a DataTaxonomy resource.
@@ -120,8 +116,6 @@ type DataTaxonomyArgs struct {
 	Labels   pulumi.StringMapInput
 	Location pulumi.StringPtrInput
 	Project  pulumi.StringPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (DataTaxonomyArgs) ElementType() reflect.Type {
@@ -217,11 +211,6 @@ func (o DataTaxonomyOutput) Uid() pulumi.StringOutput {
 // The time when the DataTaxonomy was last updated.
 func (o DataTaxonomyOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *DataTaxonomy) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o DataTaxonomyOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *DataTaxonomy) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/entity.go
+++ b/sdk/go/google/dataplex/v1/entity.go
@@ -53,9 +53,7 @@ type Entity struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the entity was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
-	Zone         pulumi.StringOutput  `pulumi:"zone"`
+	Zone       pulumi.StringOutput `pulumi:"zone"`
 }
 
 // NewEntity registers a new resource with the given unique name, arguments, and options.
@@ -153,9 +151,7 @@ type entityArgs struct {
 	System EntitySystem `pulumi:"system"`
 	// Immutable. The type of entity.
 	Type EntityType `pulumi:"type"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool   `pulumi:"validateOnly"`
-	Zone         *string `pulumi:"zone"`
+	Zone *string    `pulumi:"zone"`
 }
 
 // The set of arguments for constructing a Entity resource.
@@ -185,9 +181,7 @@ type EntityArgs struct {
 	System EntitySystemInput
 	// Immutable. The type of entity.
 	Type EntityTypeInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
-	Zone         pulumi.StringPtrInput
+	Zone pulumi.StringPtrInput
 }
 
 func (EntityArgs) ElementType() reflect.Type {
@@ -322,11 +316,6 @@ func (o EntityOutput) Uid() pulumi.StringOutput {
 // The time when the entity was last updated.
 func (o EntityOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Entity) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o EntityOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Entity) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func (o EntityOutput) Zone() pulumi.StringOutput {

--- a/sdk/go/google/dataplex/v1/environment.go
+++ b/sdk/go/google/dataplex/v1/environment.go
@@ -45,8 +45,6 @@ type Environment struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the environment was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewEnvironment registers a new resource with the given unique name, arguments, and options.
@@ -119,8 +117,6 @@ type environmentArgs struct {
 	Project  *string           `pulumi:"project"`
 	// Optional. Configuration for sessions created for this environment.
 	SessionSpec *GoogleCloudDataplexV1EnvironmentSessionSpec `pulumi:"sessionSpec"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Environment resource.
@@ -140,8 +136,6 @@ type EnvironmentArgs struct {
 	Project  pulumi.StringPtrInput
 	// Optional. Configuration for sessions created for this environment.
 	SessionSpec GoogleCloudDataplexV1EnvironmentSessionSpecPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (EnvironmentArgs) ElementType() reflect.Type {
@@ -260,11 +254,6 @@ func (o EnvironmentOutput) Uid() pulumi.StringOutput {
 // The time when the environment was last updated.
 func (o EnvironmentOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Environment) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o EnvironmentOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Environment) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/lake.go
+++ b/sdk/go/google/dataplex/v1/lake.go
@@ -44,8 +44,6 @@ type Lake struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the lake was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewLake registers a new resource with the given unique name, arguments, and options.
@@ -108,8 +106,6 @@ type lakeArgs struct {
 	// Optional. Settings to manage lake and Dataproc Metastore service instance association.
 	Metastore *GoogleCloudDataplexV1LakeMetastore `pulumi:"metastore"`
 	Project   *string                             `pulumi:"project"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Lake resource.
@@ -126,8 +122,6 @@ type LakeArgs struct {
 	// Optional. Settings to manage lake and Dataproc Metastore service instance association.
 	Metastore GoogleCloudDataplexV1LakeMetastorePtrInput
 	Project   pulumi.StringPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (LakeArgs) ElementType() reflect.Type {
@@ -238,11 +232,6 @@ func (o LakeOutput) Uid() pulumi.StringOutput {
 // The time when the lake was last updated.
 func (o LakeOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Lake) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o LakeOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Lake) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/partition.go
+++ b/sdk/go/google/dataplex/v1/partition.go
@@ -24,8 +24,6 @@ type Partition struct {
 	// Partition values used in the HTTP URL must be double encoded. For example, url_encode(url_encode(value)) can be used to encode "US:CA/CA#Sunnyvale so that the request URL ends with "/partitions/US%253ACA/CA%2523Sunnyvale". The name field in the response retains the encoded format.
 	Name    pulumi.StringOutput `pulumi:"name"`
 	Project pulumi.StringOutput `pulumi:"project"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 	// Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
 	Values pulumi.StringArrayOutput `pulumi:"values"`
 	Zone   pulumi.StringOutput      `pulumi:"zone"`
@@ -94,8 +92,6 @@ type partitionArgs struct {
 	// Immutable. The location of the entity data within the partition, for example, gs://bucket/path/to/entity/key1=value1/key2=value2. Or projects//datasets//tables/
 	Location *string `pulumi:"location"`
 	Project  *string `pulumi:"project"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 	// Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
 	Values []string `pulumi:"values"`
 	Zone   *string  `pulumi:"zone"`
@@ -110,8 +106,6 @@ type PartitionArgs struct {
 	// Immutable. The location of the entity data within the partition, for example, gs://bucket/path/to/entity/key1=value1/key2=value2. Or projects//datasets//tables/
 	Location pulumi.StringPtrInput
 	Project  pulumi.StringPtrInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 	// Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
 	Values pulumi.StringArrayInput
 	Zone   pulumi.StringPtrInput
@@ -178,11 +172,6 @@ func (o PartitionOutput) Name() pulumi.StringOutput {
 
 func (o PartitionOutput) Project() pulumi.StringOutput {
 	return o.ApplyT(func(v *Partition) pulumi.StringOutput { return v.Project }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o PartitionOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Partition) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 // Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.

--- a/sdk/go/google/dataplex/v1/task.go
+++ b/sdk/go/google/dataplex/v1/task.go
@@ -47,8 +47,6 @@ type Task struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the task was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewTask registers a new resource with the given unique name, arguments, and options.
@@ -128,8 +126,6 @@ type taskArgs struct {
 	TaskId string `pulumi:"taskId"`
 	// Spec related to how often and when a task should be triggered.
 	TriggerSpec GoogleCloudDataplexV1TaskTriggerSpec `pulumi:"triggerSpec"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Task resource.
@@ -153,8 +149,6 @@ type TaskArgs struct {
 	TaskId pulumi.StringInput
 	// Spec related to how often and when a task should be triggered.
 	TriggerSpec GoogleCloudDataplexV1TaskTriggerSpecInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (TaskArgs) ElementType() reflect.Type {
@@ -274,11 +268,6 @@ func (o TaskOutput) Uid() pulumi.StringOutput {
 // The time when the task was last updated.
 func (o TaskOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Task) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o TaskOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Task) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/dataplex/v1/zone.go
+++ b/sdk/go/google/dataplex/v1/zone.go
@@ -43,8 +43,6 @@ type Zone struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The time when the zone was last updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 	// Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")
 	ZoneId pulumi.StringOutput `pulumi:"zoneId"`
 }
@@ -122,8 +120,6 @@ type zoneArgs struct {
 	ResourceSpec GoogleCloudDataplexV1ZoneResourceSpec `pulumi:"resourceSpec"`
 	// Immutable. The type of the zone.
 	Type ZoneType `pulumi:"type"`
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 	// Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")
 	ZoneId string `pulumi:"zoneId"`
 }
@@ -145,8 +141,6 @@ type ZoneArgs struct {
 	ResourceSpec GoogleCloudDataplexV1ZoneResourceSpecInput
 	// Immutable. The type of the zone.
 	Type ZoneTypeInput
-	// Optional. Only validate the request, but do not perform mutations. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 	// Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")
 	ZoneId pulumi.StringInput
 }
@@ -258,11 +252,6 @@ func (o ZoneOutput) Uid() pulumi.StringOutput {
 // The time when the zone was last updated.
 func (o ZoneOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Zone) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the request, but do not perform mutations. The default is false.
-func (o ZoneOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Zone) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 // Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")

--- a/sdk/go/google/datastream/v1/connectionProfile.go
+++ b/sdk/go/google/datastream/v1/connectionProfile.go
@@ -50,8 +50,6 @@ type ConnectionProfile struct {
 	StaticServiceIpConnectivity StaticServiceIpConnectivityResponseOutput `pulumi:"staticServiceIpConnectivity"`
 	// The update time of the resource.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the connection profile, but don't create any resources. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewConnectionProfile registers a new resource with the given unique name, arguments, and options.
@@ -133,8 +131,6 @@ type connectionProfileArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// Static Service IP connectivity.
 	StaticServiceIpConnectivity *StaticServiceIpConnectivity `pulumi:"staticServiceIpConnectivity"`
-	// Optional. Only validate the connection profile, but don't create any resources. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a ConnectionProfile resource.
@@ -167,8 +163,6 @@ type ConnectionProfileArgs struct {
 	RequestId pulumi.StringPtrInput
 	// Static Service IP connectivity.
 	StaticServiceIpConnectivity StaticServiceIpConnectivityPtrInput
-	// Optional. Only validate the connection profile, but don't create any resources. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ConnectionProfileArgs) ElementType() reflect.Type {
@@ -296,11 +290,6 @@ func (o ConnectionProfileOutput) StaticServiceIpConnectivity() StaticServiceIpCo
 // The update time of the resource.
 func (o ConnectionProfileOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *ConnectionProfile) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the connection profile, but don't create any resources. The default is false.
-func (o ConnectionProfileOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *ConnectionProfile) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/datastream/v1/stream.go
+++ b/sdk/go/google/datastream/v1/stream.go
@@ -48,8 +48,6 @@ type Stream struct {
 	StreamId pulumi.StringOutput `pulumi:"streamId"`
 	// The last update time of the stream.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the stream, but don't create any resources. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewStream registers a new resource with the given unique name, arguments, and options.
@@ -133,8 +131,6 @@ type streamArgs struct {
 	State *StreamStateEnum `pulumi:"state"`
 	// Required. The stream identifier.
 	StreamId string `pulumi:"streamId"`
-	// Optional. Only validate the stream, but don't create any resources. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Stream resource.
@@ -163,8 +159,6 @@ type StreamArgs struct {
 	State StreamStateEnumPtrInput
 	// Required. The stream identifier.
 	StreamId pulumi.StringInput
-	// Optional. Only validate the stream, but don't create any resources. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (StreamArgs) ElementType() reflect.Type {
@@ -285,11 +279,6 @@ func (o StreamOutput) StreamId() pulumi.StringOutput {
 // The last update time of the stream.
 func (o StreamOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Stream) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the stream, but don't create any resources. The default is false.
-func (o StreamOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Stream) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/datastream/v1alpha1/stream.go
+++ b/sdk/go/google/datastream/v1alpha1/stream.go
@@ -48,8 +48,6 @@ type Stream struct {
 	StreamId pulumi.StringOutput `pulumi:"streamId"`
 	// The last update time of the stream.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. Only validate the stream, but do not create any resources. The default is false.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewStream registers a new resource with the given unique name, arguments, and options.
@@ -133,8 +131,6 @@ type streamArgs struct {
 	State *StreamStateEnum `pulumi:"state"`
 	// Required. The stream identifier.
 	StreamId string `pulumi:"streamId"`
-	// Optional. Only validate the stream, but do not create any resources. The default is false.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Stream resource.
@@ -163,8 +159,6 @@ type StreamArgs struct {
 	State StreamStateEnumPtrInput
 	// Required. The stream identifier.
 	StreamId pulumi.StringInput
-	// Optional. Only validate the stream, but do not create any resources. The default is false.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (StreamArgs) ElementType() reflect.Type {
@@ -285,11 +279,6 @@ func (o StreamOutput) StreamId() pulumi.StringOutput {
 // The last update time of the stream.
 func (o StreamOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Stream) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. Only validate the stream, but do not create any resources. The default is false.
-func (o StreamOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Stream) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/eventarc/v1/channel.go
+++ b/sdk/go/google/eventarc/v1/channel.go
@@ -37,8 +37,6 @@ type Channel struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The last-modified time.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Required. If set, validate the request and preview the review, but do not post it.
-	ValidateOnly pulumi.BoolOutput `pulumi:"validateOnly"`
 }
 
 // NewChannel registers a new resource with the given unique name, arguments, and options.
@@ -51,14 +49,10 @@ func NewChannel(ctx *pulumi.Context,
 	if args.ChannelId == nil {
 		return nil, errors.New("invalid value for required argument 'ChannelId'")
 	}
-	if args.ValidateOnly == nil {
-		return nil, errors.New("invalid value for required argument 'ValidateOnly'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"channelId",
 		"location",
 		"project",
-		"validateOnly",
 	})
 	opts = append(opts, replaceOnChanges)
 	var resource Channel
@@ -103,8 +97,6 @@ type channelArgs struct {
 	Project *string `pulumi:"project"`
 	// The name of the event provider (e.g. Eventarc SaaS partner) associated with the channel. This provider will be granted permissions to publish events to the channel. Format: `projects/{project}/locations/{location}/providers/{provider_id}`.
 	Provider *string `pulumi:"provider"`
-	// Required. If set, validate the request and preview the review, but do not post it.
-	ValidateOnly bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Channel resource.
@@ -119,8 +111,6 @@ type ChannelArgs struct {
 	Project pulumi.StringPtrInput
 	// The name of the event provider (e.g. Eventarc SaaS partner) associated with the channel. This provider will be granted permissions to publish events to the channel. Format: `projects/{project}/locations/{location}/providers/{provider_id}`.
 	Provider pulumi.StringPtrInput
-	// Required. If set, validate the request and preview the review, but do not post it.
-	ValidateOnly pulumi.BoolInput
 }
 
 func (ChannelArgs) ElementType() reflect.Type {
@@ -216,11 +206,6 @@ func (o ChannelOutput) Uid() pulumi.StringOutput {
 // The last-modified time.
 func (o ChannelOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Channel) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Required. If set, validate the request and preview the review, but do not post it.
-func (o ChannelOutput) ValidateOnly() pulumi.BoolOutput {
-	return o.ApplyT(func(v *Channel) pulumi.BoolOutput { return v.ValidateOnly }).(pulumi.BoolOutput)
 }
 
 func init() {

--- a/sdk/go/google/eventarc/v1/trigger.go
+++ b/sdk/go/google/eventarc/v1/trigger.go
@@ -45,8 +45,6 @@ type Trigger struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The last-modified time.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Required. If set, validate the request and preview the review, but do not post it.
-	ValidateOnly pulumi.BoolOutput `pulumi:"validateOnly"`
 }
 
 // NewTrigger registers a new resource with the given unique name, arguments, and options.
@@ -65,14 +63,10 @@ func NewTrigger(ctx *pulumi.Context,
 	if args.TriggerId == nil {
 		return nil, errors.New("invalid value for required argument 'TriggerId'")
 	}
-	if args.ValidateOnly == nil {
-		return nil, errors.New("invalid value for required argument 'ValidateOnly'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"location",
 		"project",
 		"triggerId",
-		"validateOnly",
 	})
 	opts = append(opts, replaceOnChanges)
 	var resource Trigger
@@ -127,8 +121,6 @@ type triggerArgs struct {
 	Transport *Transport `pulumi:"transport"`
 	// Required. The user-provided ID to be assigned to the trigger.
 	TriggerId string `pulumi:"triggerId"`
-	// Required. If set, validate the request and preview the review, but do not post it.
-	ValidateOnly bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Trigger resource.
@@ -153,8 +145,6 @@ type TriggerArgs struct {
 	Transport TransportPtrInput
 	// Required. The user-provided ID to be assigned to the trigger.
 	TriggerId pulumi.StringInput
-	// Required. If set, validate the request and preview the review, but do not post it.
-	ValidateOnly pulumi.BoolInput
 }
 
 func (TriggerArgs) ElementType() reflect.Type {
@@ -270,11 +260,6 @@ func (o TriggerOutput) Uid() pulumi.StringOutput {
 // The last-modified time.
 func (o TriggerOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Trigger) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Required. If set, validate the request and preview the review, but do not post it.
-func (o TriggerOutput) ValidateOnly() pulumi.BoolOutput {
-	return o.ApplyT(func(v *Trigger) pulumi.BoolOutput { return v.ValidateOnly }).(pulumi.BoolOutput)
 }
 
 func init() {

--- a/sdk/go/google/eventarc/v1beta1/trigger.go
+++ b/sdk/go/google/eventarc/v1beta1/trigger.go
@@ -37,8 +37,6 @@ type Trigger struct {
 	TriggerId pulumi.StringOutput `pulumi:"triggerId"`
 	// The last-modified time.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Required. If set, validate the request and preview the review, but do not actually post it.
-	ValidateOnly pulumi.BoolOutput `pulumi:"validateOnly"`
 }
 
 // NewTrigger registers a new resource with the given unique name, arguments, and options.
@@ -57,14 +55,10 @@ func NewTrigger(ctx *pulumi.Context,
 	if args.TriggerId == nil {
 		return nil, errors.New("invalid value for required argument 'TriggerId'")
 	}
-	if args.ValidateOnly == nil {
-		return nil, errors.New("invalid value for required argument 'ValidateOnly'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"location",
 		"project",
 		"triggerId",
-		"validateOnly",
 	})
 	opts = append(opts, replaceOnChanges)
 	var resource Trigger
@@ -113,8 +107,6 @@ type triggerArgs struct {
 	ServiceAccount *string `pulumi:"serviceAccount"`
 	// Required. The user-provided ID to be assigned to the trigger.
 	TriggerId string `pulumi:"triggerId"`
-	// Required. If set, validate the request and preview the review, but do not actually post it.
-	ValidateOnly bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Trigger resource.
@@ -133,8 +125,6 @@ type TriggerArgs struct {
 	ServiceAccount pulumi.StringPtrInput
 	// Required. The user-provided ID to be assigned to the trigger.
 	TriggerId pulumi.StringInput
-	// Required. If set, validate the request and preview the review, but do not actually post it.
-	ValidateOnly pulumi.BoolInput
 }
 
 func (TriggerArgs) ElementType() reflect.Type {
@@ -230,11 +220,6 @@ func (o TriggerOutput) TriggerId() pulumi.StringOutput {
 // The last-modified time.
 func (o TriggerOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Trigger) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Required. If set, validate the request and preview the review, but do not actually post it.
-func (o TriggerOutput) ValidateOnly() pulumi.BoolOutput {
-	return o.ApplyT(func(v *Trigger) pulumi.BoolOutput { return v.ValidateOnly }).(pulumi.BoolOutput)
 }
 
 func init() {

--- a/sdk/go/google/firebasedatabase/v1beta/instance.go
+++ b/sdk/go/google/firebasedatabase/v1beta/instance.go
@@ -26,8 +26,6 @@ type Instance struct {
 	State pulumi.StringOutput `pulumi:"state"`
 	// Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
 	Type pulumi.StringOutput `pulumi:"type"`
-	// When set to true, the request will be validated but not submitted.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewInstance registers a new resource with the given unique name, arguments, and options.
@@ -82,8 +80,6 @@ type instanceArgs struct {
 	Project *string `pulumi:"project"`
 	// Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
 	Type *InstanceType `pulumi:"type"`
-	// When set to true, the request will be validated but not submitted.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Instance resource.
@@ -96,8 +92,6 @@ type InstanceArgs struct {
 	Project pulumi.StringPtrInput
 	// Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
 	Type InstanceTypePtrInput
-	// When set to true, the request will be validated but not submitted.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (InstanceArgs) ElementType() reflect.Type {
@@ -168,11 +162,6 @@ func (o InstanceOutput) State() pulumi.StringOutput {
 // Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
 func (o InstanceOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *Instance) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
-}
-
-// When set to true, the request will be validated but not submitted.
-func (o InstanceOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Instance) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/monitoring/v1/dashboard.go
+++ b/sdk/go/google/monitoring/v1/dashboard.go
@@ -34,8 +34,6 @@ type Dashboard struct {
 	Project pulumi.StringOutput `pulumi:"project"`
 	// The content is divided into equally spaced rows and the widgets are arranged horizontally.
 	RowLayout RowLayoutResponseOutput `pulumi:"rowLayout"`
-	// If set, validate the request and preview the review, but do not actually save it.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewDashboard registers a new resource with the given unique name, arguments, and options.
@@ -103,8 +101,6 @@ type dashboardArgs struct {
 	Project *string `pulumi:"project"`
 	// The content is divided into equally spaced rows and the widgets are arranged horizontally.
 	RowLayout *RowLayout `pulumi:"rowLayout"`
-	// If set, validate the request and preview the review, but do not actually save it.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Dashboard resource.
@@ -128,8 +124,6 @@ type DashboardArgs struct {
 	Project pulumi.StringPtrInput
 	// The content is divided into equally spaced rows and the widgets are arranged horizontally.
 	RowLayout RowLayoutPtrInput
-	// If set, validate the request and preview the review, but do not actually save it.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (DashboardArgs) ElementType() reflect.Type {
@@ -216,11 +210,6 @@ func (o DashboardOutput) Project() pulumi.StringOutput {
 // The content is divided into equally spaced rows and the widgets are arranged horizontally.
 func (o DashboardOutput) RowLayout() RowLayoutResponseOutput {
 	return o.ApplyT(func(v *Dashboard) RowLayoutResponseOutput { return v.RowLayout }).(RowLayoutResponseOutput)
-}
-
-// If set, validate the request and preview the review, but do not actually save it.
-func (o DashboardOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Dashboard) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/monitoring/v3/group.go
+++ b/sdk/go/google/monitoring/v3/group.go
@@ -26,8 +26,6 @@ type Group struct {
 	// The name of the group's parent, if it has one. The format is: projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID] For groups with no parent, parent_name is the empty string, "".
 	ParentName pulumi.StringOutput `pulumi:"parentName"`
 	Project    pulumi.StringOutput `pulumi:"project"`
-	// If true, validate this request but do not create the group.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewGroup registers a new resource with the given unique name, arguments, and options.
@@ -82,8 +80,6 @@ type groupArgs struct {
 	// The name of the group's parent, if it has one. The format is: projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID] For groups with no parent, parent_name is the empty string, "".
 	ParentName *string `pulumi:"parentName"`
 	Project    *string `pulumi:"project"`
-	// If true, validate this request but do not create the group.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Group resource.
@@ -97,8 +93,6 @@ type GroupArgs struct {
 	// The name of the group's parent, if it has one. The format is: projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID] For groups with no parent, parent_name is the empty string, "".
 	ParentName pulumi.StringPtrInput
 	Project    pulumi.StringPtrInput
-	// If true, validate this request but do not create the group.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (GroupArgs) ElementType() reflect.Type {
@@ -165,11 +159,6 @@ func (o GroupOutput) ParentName() pulumi.StringOutput {
 
 func (o GroupOutput) Project() pulumi.StringOutput {
 	return o.ApplyT(func(v *Group) pulumi.StringOutput { return v.Project }).(pulumi.StringOutput)
-}
-
-// If true, validate this request but do not create the group.
-func (o GroupOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Group) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/privateca/v1/certificate.go
+++ b/sdk/go/google/privateca/v1/certificate.go
@@ -55,8 +55,6 @@ type Certificate struct {
 	SubjectMode pulumi.StringOutput `pulumi:"subjectMode"`
 	// The time at which this Certificate was updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewCertificate registers a new resource with the given unique name, arguments, and options.
@@ -131,8 +129,6 @@ type certificateArgs struct {
 	RequestId *string `pulumi:"requestId"`
 	// Immutable. Specifies how the Certificate's identity fields are to be decided. If this is omitted, the `DEFAULT` subject mode will be used.
 	SubjectMode *CertificateSubjectMode `pulumi:"subjectMode"`
-	// Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Certificate resource.
@@ -158,8 +154,6 @@ type CertificateArgs struct {
 	RequestId pulumi.StringPtrInput
 	// Immutable. Specifies how the Certificate's identity fields are to be decided. If this is omitted, the `DEFAULT` subject mode will be used.
 	SubjectMode CertificateSubjectModePtrInput
-	// Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (CertificateArgs) ElementType() reflect.Type {
@@ -294,11 +288,6 @@ func (o CertificateOutput) SubjectMode() pulumi.StringOutput {
 // The time at which this Certificate was updated.
 func (o CertificateOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Certificate) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-func (o CertificateOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Certificate) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/run/v2/job.go
+++ b/sdk/go/google/run/v2/job.go
@@ -67,8 +67,6 @@ type Job struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// The last-modified time.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewJob registers a new resource with the given unique name, arguments, and options.
@@ -142,8 +140,6 @@ type jobArgs struct {
 	Project *string `pulumi:"project"`
 	// The template used to create executions for this Job.
 	Template GoogleCloudRunV2ExecutionTemplate `pulumi:"template"`
-	// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Job resource.
@@ -168,8 +164,6 @@ type JobArgs struct {
 	Project pulumi.StringPtrInput
 	// The template used to create executions for this Job.
 	Template GoogleCloudRunV2ExecutionTemplateInput
-	// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (JobArgs) ElementType() reflect.Type {
@@ -340,11 +334,6 @@ func (o JobOutput) Uid() pulumi.StringOutput {
 // The last-modified time.
 func (o JobOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Job) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-func (o JobOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Job) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/run/v2/service.go
+++ b/sdk/go/google/run/v2/service.go
@@ -77,8 +77,6 @@ type Service struct {
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
 	// The main URI in which this Service is serving traffic.
 	Uri pulumi.StringOutput `pulumi:"uri"`
-	// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 }
 
 // NewService registers a new resource with the given unique name, arguments, and options.
@@ -158,8 +156,6 @@ type serviceArgs struct {
 	Template GoogleCloudRunV2RevisionTemplate `pulumi:"template"`
 	// Specifies how to distribute traffic over a collection of Revisions belonging to the Service. If traffic is empty or not provided, defaults to 100% traffic to the latest `Ready` Revision.
 	Traffic []GoogleCloudRunV2TrafficTarget `pulumi:"traffic"`
-	// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 }
 
 // The set of arguments for constructing a Service resource.
@@ -190,8 +186,6 @@ type ServiceArgs struct {
 	Template GoogleCloudRunV2RevisionTemplateInput
 	// Specifies how to distribute traffic over a collection of Revisions belonging to the Service. If traffic is empty or not provided, defaults to 100% traffic to the latest `Ready` Revision.
 	Traffic GoogleCloudRunV2TrafficTargetArrayInput
-	// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-	ValidateOnly pulumi.BoolPtrInput
 }
 
 func (ServiceArgs) ElementType() reflect.Type {
@@ -387,11 +381,6 @@ func (o ServiceOutput) UpdateTime() pulumi.StringOutput {
 // The main URI in which this Service is serving traffic.
 func (o ServiceOutput) Uri() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.Uri }).(pulumi.StringOutput)
-}
-
-// Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-func (o ServiceOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Service) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/sdk/go/google/workstations/v1beta/workstation.go
+++ b/sdk/go/google/workstations/v1beta/workstation.go
@@ -40,11 +40,9 @@ type Workstation struct {
 	// A system-assigned unique identified for this resource.
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Time when this resource was most recently updated.
-	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly         pulumi.BoolPtrOutput `pulumi:"validateOnly"`
-	WorkstationClusterId pulumi.StringOutput  `pulumi:"workstationClusterId"`
-	WorkstationConfigId  pulumi.StringOutput  `pulumi:"workstationConfigId"`
+	UpdateTime           pulumi.StringOutput `pulumi:"updateTime"`
+	WorkstationClusterId pulumi.StringOutput `pulumi:"workstationClusterId"`
+	WorkstationConfigId  pulumi.StringOutput `pulumi:"workstationConfigId"`
 	// Required. ID to use for the workstation.
 	WorkstationId pulumi.StringOutput `pulumi:"workstationId"`
 }
@@ -115,12 +113,10 @@ type workstationArgs struct {
 	Labels   map[string]string `pulumi:"labels"`
 	Location *string           `pulumi:"location"`
 	// Full name of this resource.
-	Name    *string `pulumi:"name"`
-	Project *string `pulumi:"project"`
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly         *bool  `pulumi:"validateOnly"`
-	WorkstationClusterId string `pulumi:"workstationClusterId"`
-	WorkstationConfigId  string `pulumi:"workstationConfigId"`
+	Name                 *string `pulumi:"name"`
+	Project              *string `pulumi:"project"`
+	WorkstationClusterId string  `pulumi:"workstationClusterId"`
+	WorkstationConfigId  string  `pulumi:"workstationConfigId"`
 	// Required. ID to use for the workstation.
 	WorkstationId string `pulumi:"workstationId"`
 }
@@ -137,10 +133,8 @@ type WorkstationArgs struct {
 	Labels   pulumi.StringMapInput
 	Location pulumi.StringPtrInput
 	// Full name of this resource.
-	Name    pulumi.StringPtrInput
-	Project pulumi.StringPtrInput
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly         pulumi.BoolPtrInput
+	Name                 pulumi.StringPtrInput
+	Project              pulumi.StringPtrInput
 	WorkstationClusterId pulumi.StringInput
 	WorkstationConfigId  pulumi.StringInput
 	// Required. ID to use for the workstation.
@@ -250,11 +244,6 @@ func (o WorkstationOutput) Uid() pulumi.StringOutput {
 // Time when this resource was most recently updated.
 func (o WorkstationOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *Workstation) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// If set, validate the request and preview the review, but do not actually apply it.
-func (o WorkstationOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *Workstation) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func (o WorkstationOutput) WorkstationClusterId() pulumi.StringOutput {

--- a/sdk/go/google/workstations/v1beta/workstationCluster.go
+++ b/sdk/go/google/workstations/v1beta/workstationCluster.go
@@ -47,8 +47,6 @@ type WorkstationCluster struct {
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Time when this resource was most recently updated.
 	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly pulumi.BoolPtrOutput `pulumi:"validateOnly"`
 	// Required. ID to use for the workstation cluster.
 	WorkstationClusterId pulumi.StringOutput `pulumi:"workstationClusterId"`
 }
@@ -119,8 +117,6 @@ type workstationClusterArgs struct {
 	Project              *string               `pulumi:"project"`
 	// Immutable. Name of the Compute Engine subnetwork in which instances associated with this cluster will be created. Must be part of the subnetwork specified for this cluster.
 	Subnetwork *string `pulumi:"subnetwork"`
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly *bool `pulumi:"validateOnly"`
 	// Required. ID to use for the workstation cluster.
 	WorkstationClusterId string `pulumi:"workstationClusterId"`
 }
@@ -145,8 +141,6 @@ type WorkstationClusterArgs struct {
 	Project              pulumi.StringPtrInput
 	// Immutable. Name of the Compute Engine subnetwork in which instances associated with this cluster will be created. Must be part of the subnetwork specified for this cluster.
 	Subnetwork pulumi.StringPtrInput
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly pulumi.BoolPtrInput
 	// Required. ID to use for the workstation cluster.
 	WorkstationClusterId pulumi.StringInput
 }
@@ -269,11 +263,6 @@ func (o WorkstationClusterOutput) Uid() pulumi.StringOutput {
 // Time when this resource was most recently updated.
 func (o WorkstationClusterOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *WorkstationCluster) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// If set, validate the request and preview the review, but do not actually apply it.
-func (o WorkstationClusterOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *WorkstationCluster) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 // Required. ID to use for the workstation cluster.

--- a/sdk/go/google/workstations/v1beta/workstationConfig.go
+++ b/sdk/go/google/workstations/v1beta/workstationConfig.go
@@ -52,10 +52,8 @@ type WorkstationConfig struct {
 	// A system-assigned unique identified for this resource.
 	Uid pulumi.StringOutput `pulumi:"uid"`
 	// Time when this resource was most recently updated.
-	UpdateTime pulumi.StringOutput `pulumi:"updateTime"`
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly         pulumi.BoolPtrOutput `pulumi:"validateOnly"`
-	WorkstationClusterId pulumi.StringOutput  `pulumi:"workstationClusterId"`
+	UpdateTime           pulumi.StringOutput `pulumi:"updateTime"`
+	WorkstationClusterId pulumi.StringOutput `pulumi:"workstationClusterId"`
 	// Required. ID to use for the config.
 	WorkstationConfigId pulumi.StringOutput `pulumi:"workstationConfigId"`
 }
@@ -135,10 +133,8 @@ type workstationConfigArgs struct {
 	PersistentDirectories []PersistentDirectory `pulumi:"persistentDirectories"`
 	Project               *string               `pulumi:"project"`
 	// How long to wait before automatically stopping a workstation after it started. A value of 0 indicates that workstations using this configuration should never time out. Must be greater than 0 and less than 24 hours if encryption_key is set. Defaults to 12 hours.
-	RunningTimeout *string `pulumi:"runningTimeout"`
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly         *bool  `pulumi:"validateOnly"`
-	WorkstationClusterId string `pulumi:"workstationClusterId"`
+	RunningTimeout       *string `pulumi:"runningTimeout"`
+	WorkstationClusterId string  `pulumi:"workstationClusterId"`
 	// Required. ID to use for the config.
 	WorkstationConfigId string `pulumi:"workstationConfigId"`
 }
@@ -168,9 +164,7 @@ type WorkstationConfigArgs struct {
 	PersistentDirectories PersistentDirectoryArrayInput
 	Project               pulumi.StringPtrInput
 	// How long to wait before automatically stopping a workstation after it started. A value of 0 indicates that workstations using this configuration should never time out. Must be greater than 0 and less than 24 hours if encryption_key is set. Defaults to 12 hours.
-	RunningTimeout pulumi.StringPtrInput
-	// If set, validate the request and preview the review, but do not actually apply it.
-	ValidateOnly         pulumi.BoolPtrInput
+	RunningTimeout       pulumi.StringPtrInput
 	WorkstationClusterId pulumi.StringInput
 	// Required. ID to use for the config.
 	WorkstationConfigId pulumi.StringInput
@@ -309,11 +303,6 @@ func (o WorkstationConfigOutput) Uid() pulumi.StringOutput {
 // Time when this resource was most recently updated.
 func (o WorkstationConfigOutput) UpdateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *WorkstationConfig) pulumi.StringOutput { return v.UpdateTime }).(pulumi.StringOutput)
-}
-
-// If set, validate the request and preview the review, but do not actually apply it.
-func (o WorkstationConfigOutput) ValidateOnly() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *WorkstationConfig) pulumi.BoolPtrOutput { return v.ValidateOnly }).(pulumi.BoolPtrOutput)
 }
 
 func (o WorkstationConfigOutput) WorkstationClusterId() pulumi.StringOutput {

--- a/sdk/nodejs/beyondcorp/v1/appConnection.ts
+++ b/sdk/nodejs/beyondcorp/v1/appConnection.ts
@@ -91,10 +91,6 @@ export class AppConnection extends pulumi.CustomResource {
      * Timestamp when the resource was last modified.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a AppConnection resource with the given unique name, arguments, and options.
@@ -124,7 +120,6 @@ export class AppConnection extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -145,7 +140,6 @@ export class AppConnection extends pulumi.CustomResource {
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -196,8 +190,4 @@ export interface AppConnectionArgs {
      * The type of network connectivity used by the AppConnection.
      */
     type: pulumi.Input<enums.beyondcorp.v1.AppConnectionType>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1/appConnector.ts
+++ b/sdk/nodejs/beyondcorp/v1/appConnector.ts
@@ -83,10 +83,6 @@ export class AppConnector extends pulumi.CustomResource {
      * Timestamp when the resource was last modified.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a AppConnector resource with the given unique name, arguments, and options.
@@ -111,7 +107,6 @@ export class AppConnector extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["resourceInfo"] = args ? args.resourceInfo : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -130,7 +125,6 @@ export class AppConnector extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -173,8 +167,4 @@ export interface AppConnectorArgs {
      * Optional. Resource info of the connector.
      */
     resourceInfo?: pulumi.Input<inputs.beyondcorp.v1.GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1/appGateway.ts
+++ b/sdk/nodejs/beyondcorp/v1/appGateway.ts
@@ -91,10 +91,6 @@ export class AppGateway extends pulumi.CustomResource {
      * Server-defined URI for this resource.
      */
     public /*out*/ readonly uri!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a AppGateway resource with the given unique name, arguments, and options.
@@ -122,7 +118,6 @@ export class AppGateway extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["allocatedConnections"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
@@ -145,7 +140,6 @@ export class AppGateway extends pulumi.CustomResource {
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
             resourceInputs["uri"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -188,8 +182,4 @@ export interface AppGatewayArgs {
      * The type of network connectivity used by the AppGateway.
      */
     type: pulumi.Input<enums.beyondcorp.v1.AppGatewayType>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1/clientConnectorService.ts
+++ b/sdk/nodejs/beyondcorp/v1/clientConnectorService.ts
@@ -75,10 +75,6 @@ export class ClientConnectorService extends pulumi.CustomResource {
      * [Output only] Update time stamp.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a ClientConnectorService resource with the given unique name, arguments, and options.
@@ -105,7 +101,6 @@ export class ClientConnectorService extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
@@ -121,7 +116,6 @@ export class ClientConnectorService extends pulumi.CustomResource {
             resourceInputs["requestId"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -160,8 +154,4 @@ export interface ClientConnectorServiceArgs {
      * Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
      */
     requestId?: pulumi.Input<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1/clientGateway.ts
+++ b/sdk/nodejs/beyondcorp/v1/clientGateway.ts
@@ -64,10 +64,6 @@ export class ClientGateway extends pulumi.CustomResource {
      * [Output only] Update time stamp.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a ClientGateway resource with the given unique name, arguments, and options.
@@ -85,7 +81,6 @@ export class ClientGateway extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["clientConnectorService"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
@@ -100,7 +95,6 @@ export class ClientGateway extends pulumi.CustomResource {
             resourceInputs["requestId"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -127,8 +121,4 @@ export interface ClientGatewayArgs {
      * Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
      */
     requestId?: pulumi.Input<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1alpha/appConnection.ts
+++ b/sdk/nodejs/beyondcorp/v1alpha/appConnection.ts
@@ -91,10 +91,6 @@ export class AppConnection extends pulumi.CustomResource {
      * Timestamp when the resource was last modified.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a AppConnection resource with the given unique name, arguments, and options.
@@ -124,7 +120,6 @@ export class AppConnection extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -145,7 +140,6 @@ export class AppConnection extends pulumi.CustomResource {
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -196,8 +190,4 @@ export interface AppConnectionArgs {
      * The type of network connectivity used by the AppConnection.
      */
     type: pulumi.Input<enums.beyondcorp.v1alpha.AppConnectionType>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1alpha/appConnector.ts
+++ b/sdk/nodejs/beyondcorp/v1alpha/appConnector.ts
@@ -83,10 +83,6 @@ export class AppConnector extends pulumi.CustomResource {
      * Timestamp when the resource was last modified.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a AppConnector resource with the given unique name, arguments, and options.
@@ -111,7 +107,6 @@ export class AppConnector extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["resourceInfo"] = args ? args.resourceInfo : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -130,7 +125,6 @@ export class AppConnector extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -173,8 +167,4 @@ export interface AppConnectorArgs {
      * Optional. Resource info of the connector.
      */
     resourceInfo?: pulumi.Input<inputs.beyondcorp.v1alpha.GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1alpha/appGateway.ts
+++ b/sdk/nodejs/beyondcorp/v1alpha/appGateway.ts
@@ -91,10 +91,6 @@ export class AppGateway extends pulumi.CustomResource {
      * Server-defined URI for this resource.
      */
     public /*out*/ readonly uri!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a AppGateway resource with the given unique name, arguments, and options.
@@ -122,7 +118,6 @@ export class AppGateway extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["allocatedConnections"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
@@ -145,7 +140,6 @@ export class AppGateway extends pulumi.CustomResource {
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
             resourceInputs["uri"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -188,8 +182,4 @@ export interface AppGatewayArgs {
      * The type of network connectivity used by the AppGateway.
      */
     type: pulumi.Input<enums.beyondcorp.v1alpha.AppGatewayType>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1alpha/clientConnectorService.ts
+++ b/sdk/nodejs/beyondcorp/v1alpha/clientConnectorService.ts
@@ -75,10 +75,6 @@ export class ClientConnectorService extends pulumi.CustomResource {
      * [Output only] Update time stamp.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a ClientConnectorService resource with the given unique name, arguments, and options.
@@ -105,7 +101,6 @@ export class ClientConnectorService extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
@@ -121,7 +116,6 @@ export class ClientConnectorService extends pulumi.CustomResource {
             resourceInputs["requestId"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -160,8 +154,4 @@ export interface ClientConnectorServiceArgs {
      * Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
      */
     requestId?: pulumi.Input<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1alpha/clientGateway.ts
+++ b/sdk/nodejs/beyondcorp/v1alpha/clientGateway.ts
@@ -64,10 +64,6 @@ export class ClientGateway extends pulumi.CustomResource {
      * [Output only] Update time stamp.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a ClientGateway resource with the given unique name, arguments, and options.
@@ -85,7 +81,6 @@ export class ClientGateway extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["clientConnectorService"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
@@ -100,7 +95,6 @@ export class ClientGateway extends pulumi.CustomResource {
             resourceInputs["requestId"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -127,8 +121,4 @@ export interface ClientGatewayArgs {
      * Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
      */
     requestId?: pulumi.Input<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1alpha/connection.ts
+++ b/sdk/nodejs/beyondcorp/v1alpha/connection.ts
@@ -91,10 +91,6 @@ export class Connection extends pulumi.CustomResource {
      * Timestamp when the resource was last modified.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Connection resource with the given unique name, arguments, and options.
@@ -124,7 +120,6 @@ export class Connection extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -145,7 +140,6 @@ export class Connection extends pulumi.CustomResource {
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -196,8 +190,4 @@ export interface ConnectionArgs {
      * The type of network connectivity used by the connection.
      */
     type: pulumi.Input<enums.beyondcorp.v1alpha.ConnectionType>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/beyondcorp/v1alpha/connector.ts
+++ b/sdk/nodejs/beyondcorp/v1alpha/connector.ts
@@ -83,10 +83,6 @@ export class Connector extends pulumi.CustomResource {
      * Timestamp when the resource was last modified.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Connector resource with the given unique name, arguments, and options.
@@ -111,7 +107,6 @@ export class Connector extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["resourceInfo"] = args ? args.resourceInfo : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -130,7 +125,6 @@ export class Connector extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -173,8 +167,4 @@ export interface ConnectorArgs {
      * Optional. Resource info of the connector.
      */
     resourceInfo?: pulumi.Input<inputs.beyondcorp.v1alpha.ResourceInfoArgs>;
-    /**
-     * Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/cloudbuild/v1/workerPool.ts
+++ b/sdk/nodejs/cloudbuild/v1/workerPool.ts
@@ -81,10 +81,6 @@ export class WorkerPool extends pulumi.CustomResource {
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
     /**
-     * If set, validate the request and preview the response, but do not actually post it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
-    /**
      * Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
      */
     public readonly workerPoolId!: pulumi.Output<string>;
@@ -108,7 +104,6 @@ export class WorkerPool extends pulumi.CustomResource {
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["privatePoolV1Config"] = args ? args.privatePoolV1Config : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["workerPoolId"] = args ? args.workerPoolId : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["deleteTime"] = undefined /*out*/;
@@ -130,7 +125,6 @@ export class WorkerPool extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["workerPoolId"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -158,10 +152,6 @@ export interface WorkerPoolArgs {
      */
     privatePoolV1Config?: pulumi.Input<inputs.cloudbuild.v1.PrivatePoolV1ConfigArgs>;
     project?: pulumi.Input<string>;
-    /**
-     * If set, validate the request and preview the response, but do not actually post it.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     /**
      * Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
      */

--- a/sdk/nodejs/clouddeploy/v1/deliveryPipeline.ts
+++ b/sdk/nodejs/clouddeploy/v1/deliveryPipeline.ts
@@ -92,10 +92,6 @@ export class DeliveryPipeline extends pulumi.CustomResource {
      * Most recent time at which the pipeline was updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a DeliveryPipeline resource with the given unique name, arguments, and options.
@@ -122,7 +118,6 @@ export class DeliveryPipeline extends pulumi.CustomResource {
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["serialPipeline"] = args ? args.serialPipeline : undefined;
             resourceInputs["suspended"] = args ? args.suspended : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["condition"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -143,7 +138,6 @@ export class DeliveryPipeline extends pulumi.CustomResource {
             resourceInputs["suspended"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["deliveryPipelineId", "location", "project"] };
@@ -194,8 +188,4 @@ export interface DeliveryPipelineArgs {
      * When suspended, no new releases or rollouts can be created, but in-progress ones will complete.
      */
     suspended?: pulumi.Input<boolean>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/clouddeploy/v1/release.ts
+++ b/sdk/nodejs/clouddeploy/v1/release.ts
@@ -131,10 +131,6 @@ export class Release extends pulumi.CustomResource {
      * Unique identifier of the `Release`.
      */
     public /*out*/ readonly uid!: pulumi.Output<string>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Release resource with the given unique name, arguments, and options.
@@ -167,7 +163,6 @@ export class Release extends pulumi.CustomResource {
             resourceInputs["skaffoldConfigPath"] = args ? args.skaffoldConfigPath : undefined;
             resourceInputs["skaffoldConfigUri"] = args ? args.skaffoldConfigUri : undefined;
             resourceInputs["skaffoldVersion"] = args ? args.skaffoldVersion : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["abandoned"] = undefined /*out*/;
             resourceInputs["condition"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
@@ -205,7 +200,6 @@ export class Release extends pulumi.CustomResource {
             resourceInputs["targetRenders"] = undefined /*out*/;
             resourceInputs["targetSnapshots"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["deliveryPipelineId", "location", "project", "releaseId"] };
@@ -265,8 +259,4 @@ export interface ReleaseArgs {
      * The Skaffold version to use when operating on this release, such as "1.20.0". Not all versions are valid; Google Cloud Deploy supports a specific set of versions. If unset, the most recent supported Skaffold version will be used.
      */
     skaffoldVersion?: pulumi.Input<string>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/clouddeploy/v1/rollout.ts
+++ b/sdk/nodejs/clouddeploy/v1/rollout.ts
@@ -136,10 +136,6 @@ export class Rollout extends pulumi.CustomResource {
      * Unique identifier of the `Rollout`.
      */
     public /*out*/ readonly uid!: pulumi.Output<string>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Rollout resource with the given unique name, arguments, and options.
@@ -177,7 +173,6 @@ export class Rollout extends pulumi.CustomResource {
             resourceInputs["rolloutId"] = args ? args.rolloutId : undefined;
             resourceInputs["startingPhaseId"] = args ? args.startingPhaseId : undefined;
             resourceInputs["targetId"] = args ? args.targetId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["approvalState"] = undefined /*out*/;
             resourceInputs["approveTime"] = undefined /*out*/;
             resourceInputs["controllerRollout"] = undefined /*out*/;
@@ -220,7 +215,6 @@ export class Rollout extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["targetId"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["deliveryPipelineId", "location", "project", "releaseId", "rolloutId"] };
@@ -273,8 +267,4 @@ export interface RolloutArgs {
      * The ID of Target to which this `Rollout` is deploying.
      */
     targetId: pulumi.Input<string>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/clouddeploy/v1/target.ts
+++ b/sdk/nodejs/clouddeploy/v1/target.ts
@@ -103,10 +103,6 @@ export class Target extends pulumi.CustomResource {
      * Most recent time at which the `Target` was updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Target resource with the given unique name, arguments, and options.
@@ -137,7 +133,6 @@ export class Target extends pulumi.CustomResource {
             resourceInputs["requireApproval"] = args ? args.requireApproval : undefined;
             resourceInputs["run"] = args ? args.run : undefined;
             resourceInputs["targetId"] = args ? args.targetId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
@@ -160,7 +155,6 @@ export class Target extends pulumi.CustomResource {
             resourceInputs["targetId"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project", "targetId"] };
@@ -227,8 +221,4 @@ export interface TargetArgs {
      * Required. ID of the `Target`.
      */
     targetId: pulumi.Input<string>;
-    /**
-     * Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/cloudresourcemanager/v3/tagKey.ts
+++ b/sdk/nodejs/cloudresourcemanager/v3/tagKey.ts
@@ -77,10 +77,6 @@ export class TagKey extends pulumi.CustomResource {
      * Update time.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a TagKey resource with the given unique name, arguments, and options.
@@ -103,7 +99,6 @@ export class TagKey extends pulumi.CustomResource {
             resourceInputs["purpose"] = args ? args.purpose : undefined;
             resourceInputs["purposeData"] = args ? args.purposeData : undefined;
             resourceInputs["shortName"] = args ? args.shortName : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["namespacedName"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
@@ -118,7 +113,6 @@ export class TagKey extends pulumi.CustomResource {
             resourceInputs["purposeData"] = undefined /*out*/;
             resourceInputs["shortName"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(TagKey.__pulumiType, name, resourceInputs, opts);
@@ -157,8 +151,4 @@ export interface TagKeyArgs {
      * Immutable. The user friendly name for a TagKey. The short name should be unique for TagKeys within the same tag namespace. The short name must be 1-63 characters, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
      */
     shortName: pulumi.Input<string>;
-    /**
-     * Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/cloudresourcemanager/v3/tagValue.ts
+++ b/sdk/nodejs/cloudresourcemanager/v3/tagValue.ts
@@ -66,10 +66,6 @@ export class TagValue extends pulumi.CustomResource {
      * Update time.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a TagValue resource with the given unique name, arguments, and options.
@@ -90,7 +86,6 @@ export class TagValue extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["parent"] = args ? args.parent : undefined;
             resourceInputs["shortName"] = args ? args.shortName : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["namespacedName"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
@@ -103,7 +98,6 @@ export class TagValue extends pulumi.CustomResource {
             resourceInputs["parent"] = undefined /*out*/;
             resourceInputs["shortName"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(TagValue.__pulumiType, name, resourceInputs, opts);
@@ -134,8 +128,4 @@ export interface TagValueArgs {
      * Immutable. User-assigned short name for TagValue. The short name should be unique for TagValues within the same parent TagKey. The short name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
      */
     shortName: pulumi.Input<string>;
-    /**
-     * Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/alpha/interconnectAttachment.ts
+++ b/sdk/nodejs/compute/alpha/interconnectAttachment.ts
@@ -198,10 +198,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
      */
     public readonly type!: pulumi.Output<string>;
     /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
-    /**
      * The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
      */
     public readonly vlanTag8021q!: pulumi.Output<number>;
@@ -244,7 +240,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
             resourceInputs["stackType"] = args ? args.stackType : undefined;
             resourceInputs["subnetLength"] = args ? args.subnetLength : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["vlanTag8021q"] = args ? args.vlanTag8021q : undefined;
             resourceInputs["cloudRouterIpAddress"] = undefined /*out*/;
             resourceInputs["cloudRouterIpv6Address"] = undefined /*out*/;
@@ -305,7 +300,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["subnetLength"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["vlanTag8021q"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -409,10 +403,6 @@ export interface InterconnectAttachmentArgs {
      * The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
      */
     type?: pulumi.Input<enums.compute.alpha.InterconnectAttachmentType>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     /**
      * The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
      */

--- a/sdk/nodejs/compute/alpha/networkEdgeSecurityService.ts
+++ b/sdk/nodejs/compute/alpha/networkEdgeSecurityService.ts
@@ -72,10 +72,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
      * Server-defined URL for this resource with the resource id.
      */
     public /*out*/ readonly selfLinkWithId!: pulumi.Output<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a NetworkEdgeSecurityService resource with the given unique name, arguments, and options.
@@ -97,7 +93,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["securityPolicy"] = args ? args.securityPolicy : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -115,7 +110,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
             resourceInputs["securityPolicy"] = undefined /*out*/;
             resourceInputs["selfLink"] = undefined /*out*/;
             resourceInputs["selfLinkWithId"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project", "region"] };
@@ -146,8 +140,4 @@ export interface NetworkEdgeSecurityServiceArgs {
      * The resource URL for the network edge security service associated with this network edge security service.
      */
     securityPolicy?: pulumi.Input<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/alpha/regionSecurityPolicy.ts
+++ b/sdk/nodejs/compute/alpha/regionSecurityPolicy.ts
@@ -112,10 +112,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
      * Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
      */
     public readonly userDefinedFields!: pulumi.Output<outputs.compute.alpha.SecurityPolicyUserDefinedFieldResponse[]>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a RegionSecurityPolicy resource with the given unique name, arguments, and options.
@@ -147,7 +143,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
             resourceInputs["rules"] = args ? args.rules : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
             resourceInputs["userDefinedFields"] = args ? args.userDefinedFields : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -181,7 +176,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
             resourceInputs["selfLinkWithId"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["userDefinedFields"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project", "region"] };
@@ -237,8 +231,4 @@ export interface RegionSecurityPolicyArgs {
      * Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
      */
     userDefinedFields?: pulumi.Input<pulumi.Input<inputs.compute.alpha.SecurityPolicyUserDefinedFieldArgs>[]>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/alpha/securityPolicy.ts
+++ b/sdk/nodejs/compute/alpha/securityPolicy.ts
@@ -115,10 +115,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
      * Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
      */
     public readonly userDefinedFields!: pulumi.Output<outputs.compute.alpha.SecurityPolicyUserDefinedFieldResponse[]>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a SecurityPolicy resource with the given unique name, arguments, and options.
@@ -146,7 +142,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
             resourceInputs["rules"] = args ? args.rules : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
             resourceInputs["userDefinedFields"] = args ? args.userDefinedFields : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -181,7 +176,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
             resourceInputs["selfLinkWithId"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["userDefinedFields"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project"] };
@@ -236,8 +230,4 @@ export interface SecurityPolicyArgs {
      * Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
      */
     userDefinedFields?: pulumi.Input<pulumi.Input<inputs.compute.alpha.SecurityPolicyUserDefinedFieldArgs>[]>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/beta/interconnectAttachment.ts
+++ b/sdk/nodejs/compute/beta/interconnectAttachment.ts
@@ -182,10 +182,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
      */
     public readonly type!: pulumi.Output<string>;
     /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
-    /**
      * The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
      */
     public readonly vlanTag8021q!: pulumi.Output<number>;
@@ -227,7 +223,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
             resourceInputs["router"] = args ? args.router : undefined;
             resourceInputs["stackType"] = args ? args.stackType : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["vlanTag8021q"] = args ? args.vlanTag8021q : undefined;
             resourceInputs["cloudRouterIpAddress"] = undefined /*out*/;
             resourceInputs["cloudRouterIpv6Address"] = undefined /*out*/;
@@ -281,7 +276,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
             resourceInputs["stackType"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["vlanTag8021q"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -381,10 +375,6 @@ export interface InterconnectAttachmentArgs {
      * The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
      */
     type?: pulumi.Input<enums.compute.beta.InterconnectAttachmentType>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     /**
      * The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
      */

--- a/sdk/nodejs/compute/beta/networkEdgeSecurityService.ts
+++ b/sdk/nodejs/compute/beta/networkEdgeSecurityService.ts
@@ -72,10 +72,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
      * Server-defined URL for this resource with the resource id.
      */
     public /*out*/ readonly selfLinkWithId!: pulumi.Output<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a NetworkEdgeSecurityService resource with the given unique name, arguments, and options.
@@ -97,7 +93,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["securityPolicy"] = args ? args.securityPolicy : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -115,7 +110,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
             resourceInputs["securityPolicy"] = undefined /*out*/;
             resourceInputs["selfLink"] = undefined /*out*/;
             resourceInputs["selfLinkWithId"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project", "region"] };
@@ -146,8 +140,4 @@ export interface NetworkEdgeSecurityServiceArgs {
      * The resource URL for the network edge security service associated with this network edge security service.
      */
     securityPolicy?: pulumi.Input<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/beta/regionSecurityPolicy.ts
+++ b/sdk/nodejs/compute/beta/regionSecurityPolicy.ts
@@ -107,10 +107,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     public readonly type!: pulumi.Output<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a RegionSecurityPolicy resource with the given unique name, arguments, and options.
@@ -140,7 +136,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["rules"] = args ? args.rules : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -172,7 +167,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
             resourceInputs["selfLink"] = undefined /*out*/;
             resourceInputs["selfLinkWithId"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project", "region"] };
@@ -223,8 +217,4 @@ export interface RegionSecurityPolicyArgs {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     type?: pulumi.Input<enums.compute.beta.RegionSecurityPolicyType>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/beta/securityPolicy.ts
+++ b/sdk/nodejs/compute/beta/securityPolicy.ts
@@ -110,10 +110,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     public readonly type!: pulumi.Output<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a SecurityPolicy resource with the given unique name, arguments, and options.
@@ -139,7 +135,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["rules"] = args ? args.rules : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -172,7 +167,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
             resourceInputs["selfLink"] = undefined /*out*/;
             resourceInputs["selfLinkWithId"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project"] };
@@ -222,8 +216,4 @@ export interface SecurityPolicyArgs {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     type?: pulumi.Input<enums.compute.beta.SecurityPolicyType>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/v1/interconnectAttachment.ts
+++ b/sdk/nodejs/compute/v1/interconnectAttachment.ts
@@ -174,10 +174,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
      */
     public readonly type!: pulumi.Output<string>;
     /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
-    /**
      * The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
      */
     public readonly vlanTag8021q!: pulumi.Output<number>;
@@ -218,7 +214,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
             resourceInputs["router"] = args ? args.router : undefined;
             resourceInputs["stackType"] = args ? args.stackType : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["vlanTag8021q"] = args ? args.vlanTag8021q : undefined;
             resourceInputs["cloudRouterIpAddress"] = undefined /*out*/;
             resourceInputs["cloudRouterIpv6Address"] = undefined /*out*/;
@@ -269,7 +264,6 @@ export class InterconnectAttachment extends pulumi.CustomResource {
             resourceInputs["stackType"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["vlanTag8021q"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -365,10 +359,6 @@ export interface InterconnectAttachmentArgs {
      * The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
      */
     type?: pulumi.Input<enums.compute.v1.InterconnectAttachmentType>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     /**
      * The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
      */

--- a/sdk/nodejs/compute/v1/networkEdgeSecurityService.ts
+++ b/sdk/nodejs/compute/v1/networkEdgeSecurityService.ts
@@ -72,10 +72,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
      * Server-defined URL for this resource with the resource id.
      */
     public /*out*/ readonly selfLinkWithId!: pulumi.Output<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a NetworkEdgeSecurityService resource with the given unique name, arguments, and options.
@@ -97,7 +93,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["securityPolicy"] = args ? args.securityPolicy : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -115,7 +110,6 @@ export class NetworkEdgeSecurityService extends pulumi.CustomResource {
             resourceInputs["securityPolicy"] = undefined /*out*/;
             resourceInputs["selfLink"] = undefined /*out*/;
             resourceInputs["selfLinkWithId"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project", "region"] };
@@ -146,8 +140,4 @@ export interface NetworkEdgeSecurityServiceArgs {
      * The resource URL for the network edge security service associated with this network edge security service.
      */
     securityPolicy?: pulumi.Input<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/v1/regionSecurityPolicy.ts
+++ b/sdk/nodejs/compute/v1/regionSecurityPolicy.ts
@@ -79,10 +79,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     public readonly type!: pulumi.Output<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a RegionSecurityPolicy resource with the given unique name, arguments, and options.
@@ -109,7 +105,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["rules"] = args ? args.rules : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -130,7 +125,6 @@ export class RegionSecurityPolicy extends pulumi.CustomResource {
             resourceInputs["rules"] = undefined /*out*/;
             resourceInputs["selfLink"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project", "region"] };
@@ -169,8 +163,4 @@ export interface RegionSecurityPolicyArgs {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     type?: pulumi.Input<enums.compute.v1.RegionSecurityPolicyType>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/compute/v1/securityPolicy.ts
+++ b/sdk/nodejs/compute/v1/securityPolicy.ts
@@ -82,10 +82,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     public readonly type!: pulumi.Output<string>;
-    /**
-     * If true, the request will not be committed.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a SecurityPolicy resource with the given unique name, arguments, and options.
@@ -108,7 +104,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["rules"] = args ? args.rules : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["creationTimestamp"] = undefined /*out*/;
             resourceInputs["fingerprint"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
@@ -130,7 +125,6 @@ export class SecurityPolicy extends pulumi.CustomResource {
             resourceInputs["rules"] = undefined /*out*/;
             resourceInputs["selfLink"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project"] };
@@ -168,8 +162,4 @@ export interface SecurityPolicyArgs {
      * The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
      */
     type?: pulumi.Input<enums.compute.v1.SecurityPolicyType>;
-    /**
-     * If true, the request will not be committed.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/datamigration/v1/connectionProfile.ts
+++ b/sdk/nodejs/datamigration/v1/connectionProfile.ts
@@ -103,10 +103,6 @@ export class ConnectionProfile extends pulumi.CustomResource {
      * The timestamp when the resource was last updated. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a ConnectionProfile resource with the given unique name, arguments, and options.
@@ -137,7 +133,6 @@ export class ConnectionProfile extends pulumi.CustomResource {
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["skipValidation"] = args ? args.skipValidation : undefined;
             resourceInputs["state"] = args ? args.state : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["error"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
@@ -160,7 +155,6 @@ export class ConnectionProfile extends pulumi.CustomResource {
             resourceInputs["skipValidation"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["connectionProfileId", "location", "project"] };
@@ -227,8 +221,4 @@ export interface ConnectionProfileArgs {
      * The current connection profile state (e.g. DRAFT, READY, or FAILED).
      */
     state?: pulumi.Input<enums.datamigration.v1.ConnectionProfileState>;
-    /**
-     * Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/asset.ts
+++ b/sdk/nodejs/dataplex/v1/asset.ts
@@ -97,10 +97,6 @@ export class Asset extends pulumi.CustomResource {
      * The time when the asset was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
     public readonly zone!: pulumi.Output<string>;
 
     /**
@@ -132,7 +128,6 @@ export class Asset extends pulumi.CustomResource {
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["resourceSpec"] = args ? args.resourceSpec : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["zone"] = args ? args.zone : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["discoveryStatus"] = undefined /*out*/;
@@ -160,7 +155,6 @@ export class Asset extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["zone"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -201,9 +195,5 @@ export interface AssetArgs {
      * Specification of the resource that is referenced by this asset.
      */
     resourceSpec: pulumi.Input<inputs.dataplex.v1.GoogleCloudDataplexV1AssetResourceSpecArgs>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     zone?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/dataplex/v1/attribute.ts
+++ b/sdk/nodejs/dataplex/v1/attribute.ts
@@ -93,10 +93,6 @@ export class Attribute extends pulumi.CustomResource {
      * The time when the DataAttribute was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Attribute resource with the given unique name, arguments, and options.
@@ -126,7 +122,6 @@ export class Attribute extends pulumi.CustomResource {
             resourceInputs["parentId"] = args ? args.parentId : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["resourceAccessSpec"] = args ? args.resourceAccessSpec : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["attributeCount"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
@@ -149,7 +144,6 @@ export class Attribute extends pulumi.CustomResource {
             resourceInputs["resourceAccessSpec"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["dataAttributeId", "dataTaxonomyId", "location", "project"] };
@@ -197,8 +191,4 @@ export interface AttributeArgs {
      * Optional. Specified when applied to a resource (eg: Cloud Storage bucket, BigQuery dataset, BigQuery table).
      */
     resourceAccessSpec?: pulumi.Input<inputs.dataplex.v1.GoogleCloudDataplexV1ResourceAccessSpecArgs>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/content.ts
+++ b/sdk/nodejs/dataplex/v1/content.ts
@@ -81,10 +81,6 @@ export class Content extends pulumi.CustomResource {
      * The time when the content was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Content resource with the given unique name, arguments, and options.
@@ -115,7 +111,6 @@ export class Content extends pulumi.CustomResource {
             resourceInputs["path"] = args ? args.path : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["sqlScript"] = args ? args.sqlScript : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -134,7 +129,6 @@ export class Content extends pulumi.CustomResource {
             resourceInputs["sqlScript"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["lakeId", "location", "project"] };
@@ -174,8 +168,4 @@ export interface ContentArgs {
      * Sql Script related configurations.
      */
     sqlScript?: pulumi.Input<inputs.dataplex.v1.GoogleCloudDataplexV1ContentSqlScriptArgs>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/contentitem.ts
+++ b/sdk/nodejs/dataplex/v1/contentitem.ts
@@ -81,10 +81,6 @@ export class Contentitem extends pulumi.CustomResource {
      * The time when the content was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Contentitem resource with the given unique name, arguments, and options.
@@ -115,7 +111,6 @@ export class Contentitem extends pulumi.CustomResource {
             resourceInputs["path"] = args ? args.path : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["sqlScript"] = args ? args.sqlScript : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -134,7 +129,6 @@ export class Contentitem extends pulumi.CustomResource {
             resourceInputs["sqlScript"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["lakeId", "location", "project"] };
@@ -174,8 +168,4 @@ export interface ContentitemArgs {
      * Sql Script related configurations.
      */
     sqlScript?: pulumi.Input<inputs.dataplex.v1.GoogleCloudDataplexV1ContentSqlScriptArgs>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/dataAttributeBinding.ts
+++ b/sdk/nodejs/dataplex/v1/dataAttributeBinding.ts
@@ -88,10 +88,6 @@ export class DataAttributeBinding extends pulumi.CustomResource {
      * The time when the DataAttributeBinding was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a DataAttributeBinding resource with the given unique name, arguments, and options.
@@ -117,7 +113,6 @@ export class DataAttributeBinding extends pulumi.CustomResource {
             resourceInputs["paths"] = args ? args.paths : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["resource"] = args ? args.resource : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
@@ -137,7 +132,6 @@ export class DataAttributeBinding extends pulumi.CustomResource {
             resourceInputs["resource"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["dataAttributeBindingId", "location", "project"] };
@@ -184,8 +178,4 @@ export interface DataAttributeBindingArgs {
      * Optional. Immutable. The resource name of the resource that is associated to attributes. Presently, only entity resource is supported in the form: projects/{project}/locations/{location}/lakes/{lake}/zones/{zone}/entities/{entity_id} Must belong in the same project and region as the attribute binding, and there can only exist one active binding for a resource.
      */
     resource?: pulumi.Input<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/dataScan.ts
+++ b/sdk/nodejs/dataplex/v1/dataScan.ts
@@ -108,10 +108,6 @@ export class DataScan extends pulumi.CustomResource {
      * The time when the scan was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a DataScan resource with the given unique name, arguments, and options.
@@ -140,7 +136,6 @@ export class DataScan extends pulumi.CustomResource {
             resourceInputs["labels"] = args ? args.labels : undefined;
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["dataProfileResult"] = undefined /*out*/;
             resourceInputs["dataQualityResult"] = undefined /*out*/;
@@ -170,7 +165,6 @@ export class DataScan extends pulumi.CustomResource {
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["dataScanId", "location", "project"] };
@@ -217,8 +211,4 @@ export interface DataScanArgs {
     labels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     location?: pulumi.Input<string>;
     project?: pulumi.Input<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/dataTaxonomy.ts
+++ b/sdk/nodejs/dataplex/v1/dataTaxonomy.ts
@@ -77,10 +77,6 @@ export class DataTaxonomy extends pulumi.CustomResource {
      * The time when the DataTaxonomy was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a DataTaxonomy resource with the given unique name, arguments, and options.
@@ -103,7 +99,6 @@ export class DataTaxonomy extends pulumi.CustomResource {
             resourceInputs["labels"] = args ? args.labels : undefined;
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["attributeCount"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
@@ -122,7 +117,6 @@ export class DataTaxonomy extends pulumi.CustomResource {
             resourceInputs["project"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["dataTaxonomyId", "location", "project"] };
@@ -157,8 +151,4 @@ export interface DataTaxonomyArgs {
     labels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     location?: pulumi.Input<string>;
     project?: pulumi.Input<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/entity.ts
+++ b/sdk/nodejs/dataplex/v1/entity.ts
@@ -109,10 +109,6 @@ export class Entity extends pulumi.CustomResource {
      * The time when the entity was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
     public readonly zone!: pulumi.Output<string>;
 
     /**
@@ -164,7 +160,6 @@ export class Entity extends pulumi.CustomResource {
             resourceInputs["schema"] = args ? args.schema : undefined;
             resourceInputs["system"] = args ? args.system : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["zone"] = args ? args.zone : undefined;
             resourceInputs["access"] = undefined /*out*/;
             resourceInputs["catalogEntry"] = undefined /*out*/;
@@ -194,7 +189,6 @@ export class Entity extends pulumi.CustomResource {
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["zone"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -255,9 +249,5 @@ export interface EntityArgs {
      * Immutable. The type of entity.
      */
     type: pulumi.Input<enums.dataplex.v1.EntityType>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     zone?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/dataplex/v1/environment.ts
+++ b/sdk/nodejs/dataplex/v1/environment.ts
@@ -93,10 +93,6 @@ export class Environment extends pulumi.CustomResource {
      * The time when the environment was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Environment resource with the given unique name, arguments, and options.
@@ -127,7 +123,6 @@ export class Environment extends pulumi.CustomResource {
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["sessionSpec"] = args ? args.sessionSpec : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["endpoints"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
@@ -152,7 +147,6 @@ export class Environment extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["environmentId", "lakeId", "location", "project"] };
@@ -192,8 +186,4 @@ export interface EnvironmentArgs {
      * Optional. Configuration for sessions created for this environment.
      */
     sessionSpec?: pulumi.Input<inputs.dataplex.v1.GoogleCloudDataplexV1EnvironmentSessionSpecArgs>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/lake.ts
+++ b/sdk/nodejs/dataplex/v1/lake.ts
@@ -92,10 +92,6 @@ export class Lake extends pulumi.CustomResource {
      * The time when the lake was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Lake resource with the given unique name, arguments, and options.
@@ -118,7 +114,6 @@ export class Lake extends pulumi.CustomResource {
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["metastore"] = args ? args.metastore : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["assetStatus"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["metastoreStatus"] = undefined /*out*/;
@@ -143,7 +138,6 @@ export class Lake extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["lakeId", "location", "project"] };
@@ -178,8 +172,4 @@ export interface LakeArgs {
      */
     metastore?: pulumi.Input<inputs.dataplex.v1.GoogleCloudDataplexV1LakeMetastoreArgs>;
     project?: pulumi.Input<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/partition.ts
+++ b/sdk/nodejs/dataplex/v1/partition.ts
@@ -48,10 +48,6 @@ export class Partition extends pulumi.CustomResource {
     public /*out*/ readonly name!: pulumi.Output<string>;
     public readonly project!: pulumi.Output<string>;
     /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
-    /**
      * Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
      */
     public readonly values!: pulumi.Output<string[]>;
@@ -82,7 +78,6 @@ export class Partition extends pulumi.CustomResource {
             resourceInputs["lakeId"] = args ? args.lakeId : undefined;
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["values"] = args ? args.values : undefined;
             resourceInputs["zone"] = args ? args.zone : undefined;
             resourceInputs["name"] = undefined /*out*/;
@@ -93,7 +88,6 @@ export class Partition extends pulumi.CustomResource {
             resourceInputs["location"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["project"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["values"] = undefined /*out*/;
             resourceInputs["zone"] = undefined /*out*/;
         }
@@ -119,10 +113,6 @@ export interface PartitionArgs {
      */
     location?: pulumi.Input<string>;
     project?: pulumi.Input<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     /**
      * Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
      */

--- a/sdk/nodejs/dataplex/v1/task.ts
+++ b/sdk/nodejs/dataplex/v1/task.ts
@@ -97,10 +97,6 @@ export class Task extends pulumi.CustomResource {
      * The time when the task was last updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Task resource with the given unique name, arguments, and options.
@@ -136,7 +132,6 @@ export class Task extends pulumi.CustomResource {
             resourceInputs["spark"] = args ? args.spark : undefined;
             resourceInputs["taskId"] = args ? args.taskId : undefined;
             resourceInputs["triggerSpec"] = args ? args.triggerSpec : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["executionStatus"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
@@ -161,7 +156,6 @@ export class Task extends pulumi.CustomResource {
             resourceInputs["triggerSpec"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["lakeId", "location", "project", "taskId"] };
@@ -209,8 +203,4 @@ export interface TaskArgs {
      * Spec related to how often and when a task should be triggered.
      */
     triggerSpec: pulumi.Input<inputs.dataplex.v1.GoogleCloudDataplexV1TaskTriggerSpecArgs>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/dataplex/v1/zone.ts
+++ b/sdk/nodejs/dataplex/v1/zone.ts
@@ -90,10 +90,6 @@ export class Zone extends pulumi.CustomResource {
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
     /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
-    /**
      * Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")
      */
     public readonly zoneId!: pulumi.Output<string>;
@@ -130,7 +126,6 @@ export class Zone extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["resourceSpec"] = args ? args.resourceSpec : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["zoneId"] = args ? args.zoneId : undefined;
             resourceInputs["assetStatus"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
@@ -154,7 +149,6 @@ export class Zone extends pulumi.CustomResource {
             resourceInputs["type"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["zoneId"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -195,10 +189,6 @@ export interface ZoneArgs {
      * Immutable. The type of the zone.
      */
     type: pulumi.Input<enums.dataplex.v1.ZoneType>;
-    /**
-     * Optional. Only validate the request, but do not perform mutations. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     /**
      * Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")
      */

--- a/sdk/nodejs/datastream/v1/connectionProfile.ts
+++ b/sdk/nodejs/datastream/v1/connectionProfile.ts
@@ -104,10 +104,6 @@ export class ConnectionProfile extends pulumi.CustomResource {
      * The update time of the resource.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the connection profile, but don't create any resources. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a ConnectionProfile resource with the given unique name, arguments, and options.
@@ -141,7 +137,6 @@ export class ConnectionProfile extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["staticServiceIpConnectivity"] = args ? args.staticServiceIpConnectivity : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
@@ -164,7 +159,6 @@ export class ConnectionProfile extends pulumi.CustomResource {
             resourceInputs["requestId"] = undefined /*out*/;
             resourceInputs["staticServiceIpConnectivity"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["connectionProfileId", "location", "project"] };
@@ -231,8 +225,4 @@ export interface ConnectionProfileArgs {
      * Static Service IP connectivity.
      */
     staticServiceIpConnectivity?: pulumi.Input<inputs.datastream.v1.StaticServiceIpConnectivityArgs>;
-    /**
-     * Optional. Only validate the connection profile, but don't create any resources. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/datastream/v1/stream.ts
+++ b/sdk/nodejs/datastream/v1/stream.ts
@@ -100,10 +100,6 @@ export class Stream extends pulumi.CustomResource {
      * The last update time of the stream.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the stream, but don't create any resources. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Stream resource with the given unique name, arguments, and options.
@@ -141,7 +137,6 @@ export class Stream extends pulumi.CustomResource {
             resourceInputs["sourceConfig"] = args ? args.sourceConfig : undefined;
             resourceInputs["state"] = args ? args.state : undefined;
             resourceInputs["streamId"] = args ? args.streamId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["errors"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
@@ -164,7 +159,6 @@ export class Stream extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["streamId"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project", "streamId"] };
@@ -223,8 +217,4 @@ export interface StreamArgs {
      * Required. The stream identifier.
      */
     streamId: pulumi.Input<string>;
-    /**
-     * Optional. Only validate the stream, but don't create any resources. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/datastream/v1alpha1/stream.ts
+++ b/sdk/nodejs/datastream/v1alpha1/stream.ts
@@ -100,10 +100,6 @@ export class Stream extends pulumi.CustomResource {
      * The last update time of the stream.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. Only validate the stream, but do not create any resources. The default is false.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Stream resource with the given unique name, arguments, and options.
@@ -141,7 +137,6 @@ export class Stream extends pulumi.CustomResource {
             resourceInputs["sourceConfig"] = args ? args.sourceConfig : undefined;
             resourceInputs["state"] = args ? args.state : undefined;
             resourceInputs["streamId"] = args ? args.streamId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["errors"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
@@ -164,7 +159,6 @@ export class Stream extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["streamId"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project", "streamId"] };
@@ -223,8 +217,4 @@ export interface StreamArgs {
      * Required. The stream identifier.
      */
     streamId: pulumi.Input<string>;
-    /**
-     * Optional. Only validate the stream, but do not create any resources. The default is false.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/eventarc/v1/channel.ts
+++ b/sdk/nodejs/eventarc/v1/channel.ts
@@ -76,10 +76,6 @@ export class Channel extends pulumi.CustomResource {
      * The last-modified time.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Required. If set, validate the request and preview the review, but do not post it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean>;
 
     /**
      * Create a Channel resource with the given unique name, arguments, and options.
@@ -95,16 +91,12 @@ export class Channel extends pulumi.CustomResource {
             if ((!args || args.channelId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'channelId'");
             }
-            if ((!args || args.validateOnly === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'validateOnly'");
-            }
             resourceInputs["channelId"] = args ? args.channelId : undefined;
             resourceInputs["cryptoKeyName"] = args ? args.cryptoKeyName : undefined;
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["provider"] = args ? args.provider : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["activationToken"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["pubsubTopic"] = undefined /*out*/;
@@ -124,10 +116,9 @@ export class Channel extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const replaceOnChanges = { replaceOnChanges: ["channelId", "location", "project", "validateOnly"] };
+        const replaceOnChanges = { replaceOnChanges: ["channelId", "location", "project"] };
         opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(Channel.__pulumiType, name, resourceInputs, opts);
     }
@@ -155,8 +146,4 @@ export interface ChannelArgs {
      * The name of the event provider (e.g. Eventarc SaaS partner) associated with the channel. This provider will be granted permissions to publish events to the channel. Format: `projects/{project}/locations/{location}/providers/{provider_id}`.
      */
     provider?: pulumi.Input<string>;
-    /**
-     * Required. If set, validate the request and preview the review, but do not post it.
-     */
-    validateOnly: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/eventarc/v1/trigger.ts
+++ b/sdk/nodejs/eventarc/v1/trigger.ts
@@ -95,10 +95,6 @@ export class Trigger extends pulumi.CustomResource {
      * The last-modified time.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Required. If set, validate the request and preview the review, but do not post it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean>;
 
     /**
      * Create a Trigger resource with the given unique name, arguments, and options.
@@ -120,9 +116,6 @@ export class Trigger extends pulumi.CustomResource {
             if ((!args || args.triggerId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'triggerId'");
             }
-            if ((!args || args.validateOnly === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'validateOnly'");
-            }
             resourceInputs["channel"] = args ? args.channel : undefined;
             resourceInputs["destination"] = args ? args.destination : undefined;
             resourceInputs["eventDataContentType"] = args ? args.eventDataContentType : undefined;
@@ -134,7 +127,6 @@ export class Trigger extends pulumi.CustomResource {
             resourceInputs["serviceAccount"] = args ? args.serviceAccount : undefined;
             resourceInputs["transport"] = args ? args.transport : undefined;
             resourceInputs["triggerId"] = args ? args.triggerId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["conditions"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["etag"] = undefined /*out*/;
@@ -157,10 +149,9 @@ export class Trigger extends pulumi.CustomResource {
             resourceInputs["triggerId"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const replaceOnChanges = { replaceOnChanges: ["location", "project", "triggerId", "validateOnly"] };
+        const replaceOnChanges = { replaceOnChanges: ["location", "project", "triggerId"] };
         opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(Trigger.__pulumiType, name, resourceInputs, opts);
     }
@@ -208,8 +199,4 @@ export interface TriggerArgs {
      * Required. The user-provided ID to be assigned to the trigger.
      */
     triggerId: pulumi.Input<string>;
-    /**
-     * Required. If set, validate the request and preview the review, but do not post it.
-     */
-    validateOnly: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/eventarc/v1beta1/trigger.ts
+++ b/sdk/nodejs/eventarc/v1beta1/trigger.ts
@@ -79,10 +79,6 @@ export class Trigger extends pulumi.CustomResource {
      * The last-modified time.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Required. If set, validate the request and preview the review, but do not actually post it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean>;
 
     /**
      * Create a Trigger resource with the given unique name, arguments, and options.
@@ -104,9 +100,6 @@ export class Trigger extends pulumi.CustomResource {
             if ((!args || args.triggerId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'triggerId'");
             }
-            if ((!args || args.validateOnly === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'validateOnly'");
-            }
             resourceInputs["destination"] = args ? args.destination : undefined;
             resourceInputs["labels"] = args ? args.labels : undefined;
             resourceInputs["location"] = args ? args.location : undefined;
@@ -115,7 +108,6 @@ export class Trigger extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["serviceAccount"] = args ? args.serviceAccount : undefined;
             resourceInputs["triggerId"] = args ? args.triggerId : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["etag"] = undefined /*out*/;
             resourceInputs["transport"] = undefined /*out*/;
@@ -133,10 +125,9 @@ export class Trigger extends pulumi.CustomResource {
             resourceInputs["transport"] = undefined /*out*/;
             resourceInputs["triggerId"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const replaceOnChanges = { replaceOnChanges: ["location", "project", "triggerId", "validateOnly"] };
+        const replaceOnChanges = { replaceOnChanges: ["location", "project", "triggerId"] };
         opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(Trigger.__pulumiType, name, resourceInputs, opts);
     }
@@ -172,8 +163,4 @@ export interface TriggerArgs {
      * Required. The user-provided ID to be assigned to the trigger.
      */
     triggerId: pulumi.Input<string>;
-    /**
-     * Required. If set, validate the request and preview the review, but do not actually post it.
-     */
-    validateOnly: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/firebasedatabase/v1beta/instance.ts
+++ b/sdk/nodejs/firebasedatabase/v1beta/instance.ts
@@ -59,10 +59,6 @@ export class Instance extends pulumi.CustomResource {
      * Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
      */
     public readonly type!: pulumi.Output<string>;
-    /**
-     * When set to true, the request will be validated but not submitted.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Instance resource with the given unique name, arguments, and options.
@@ -80,7 +76,6 @@ export class Instance extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["databaseUrl"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
         } else {
@@ -91,7 +86,6 @@ export class Instance extends pulumi.CustomResource {
             resourceInputs["project"] = undefined /*out*/;
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["type"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project"] };
@@ -118,8 +112,4 @@ export interface InstanceArgs {
      * Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
      */
     type?: pulumi.Input<enums.firebasedatabase.v1beta.InstanceType>;
-    /**
-     * When set to true, the request will be validated but not submitted.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/monitoring/v1/dashboard.ts
+++ b/sdk/nodejs/monitoring/v1/dashboard.ts
@@ -74,10 +74,6 @@ export class Dashboard extends pulumi.CustomResource {
      * The content is divided into equally spaced rows and the widgets are arranged horizontally.
      */
     public readonly rowLayout!: pulumi.Output<outputs.monitoring.v1.RowLayoutResponse>;
-    /**
-     * If set, validate the request and preview the review, but do not actually save it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Dashboard resource with the given unique name, arguments, and options.
@@ -103,7 +99,6 @@ export class Dashboard extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["rowLayout"] = args ? args.rowLayout : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
         } else {
             resourceInputs["columnLayout"] = undefined /*out*/;
             resourceInputs["dashboardFilters"] = undefined /*out*/;
@@ -115,7 +110,6 @@ export class Dashboard extends pulumi.CustomResource {
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["project"] = undefined /*out*/;
             resourceInputs["rowLayout"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project"] };
@@ -165,8 +159,4 @@ export interface DashboardArgs {
      * The content is divided into equally spaced rows and the widgets are arranged horizontally.
      */
     rowLayout?: pulumi.Input<inputs.monitoring.v1.RowLayoutArgs>;
-    /**
-     * If set, validate the request and preview the review, but do not actually save it.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/monitoring/v3/group.ts
+++ b/sdk/nodejs/monitoring/v3/group.ts
@@ -56,10 +56,6 @@ export class Group extends pulumi.CustomResource {
      */
     public readonly parentName!: pulumi.Output<string>;
     public readonly project!: pulumi.Output<string>;
-    /**
-     * If true, validate this request but do not create the group.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Group resource with the given unique name, arguments, and options.
@@ -77,7 +73,6 @@ export class Group extends pulumi.CustomResource {
             resourceInputs["isCluster"] = args ? args.isCluster : undefined;
             resourceInputs["parentName"] = args ? args.parentName : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["name"] = undefined /*out*/;
         } else {
             resourceInputs["displayName"] = undefined /*out*/;
@@ -86,7 +81,6 @@ export class Group extends pulumi.CustomResource {
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["parentName"] = undefined /*out*/;
             resourceInputs["project"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["project"] };
@@ -116,8 +110,4 @@ export interface GroupArgs {
      */
     parentName?: pulumi.Input<string>;
     project?: pulumi.Input<string>;
-    /**
-     * If true, validate this request but do not create the group.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/privateca/v1/certificate.ts
+++ b/sdk/nodejs/privateca/v1/certificate.ts
@@ -111,10 +111,6 @@ export class Certificate extends pulumi.CustomResource {
      * The time at which this Certificate was updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Certificate resource with the given unique name, arguments, and options.
@@ -145,7 +141,6 @@ export class Certificate extends pulumi.CustomResource {
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["requestId"] = args ? args.requestId : undefined;
             resourceInputs["subjectMode"] = args ? args.subjectMode : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["certificateDescription"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["issuerCertificateAuthority"] = undefined /*out*/;
@@ -175,7 +170,6 @@ export class Certificate extends pulumi.CustomResource {
             resourceInputs["revocationDetails"] = undefined /*out*/;
             resourceInputs["subjectMode"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["caPoolId", "location", "project"] };
@@ -227,8 +221,4 @@ export interface CertificateArgs {
      * Immutable. Specifies how the Certificate's identity fields are to be decided. If this is omitted, the `DEFAULT` subject mode will be used.
      */
     subjectMode?: pulumi.Input<enums.privateca.v1.CertificateSubjectMode>;
-    /**
-     * Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/run/v2/job.ts
+++ b/sdk/nodejs/run/v2/job.ts
@@ -139,10 +139,6 @@ export class Job extends pulumi.CustomResource {
      * The last-modified time.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Job resource with the given unique name, arguments, and options.
@@ -172,7 +168,6 @@ export class Job extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["template"] = args ? args.template : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["conditions"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["creator"] = undefined /*out*/;
@@ -217,7 +212,6 @@ export class Job extends pulumi.CustomResource {
             resourceInputs["terminalCondition"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["jobId", "location", "project"] };
@@ -268,8 +262,4 @@ export interface JobArgs {
      * The template used to create executions for this Job.
      */
     template: pulumi.Input<inputs.run.v2.GoogleCloudRunV2ExecutionTemplateArgs>;
-    /**
-     * Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/run/v2/service.ts
+++ b/sdk/nodejs/run/v2/service.ts
@@ -159,10 +159,6 @@ export class Service extends pulumi.CustomResource {
      * The main URI in which this Service is serving traffic.
      */
     public /*out*/ readonly uri!: pulumi.Output<string>;
-    /**
-     * Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a Service resource with the given unique name, arguments, and options.
@@ -195,7 +191,6 @@ export class Service extends pulumi.CustomResource {
             resourceInputs["serviceId"] = args ? args.serviceId : undefined;
             resourceInputs["template"] = args ? args.template : undefined;
             resourceInputs["traffic"] = args ? args.traffic : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["conditions"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
             resourceInputs["creator"] = undefined /*out*/;
@@ -247,7 +242,6 @@ export class Service extends pulumi.CustomResource {
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
             resourceInputs["uri"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const replaceOnChanges = { replaceOnChanges: ["location", "project", "serviceId"] };
@@ -310,8 +304,4 @@ export interface ServiceArgs {
      * Specifies how to distribute traffic over a collection of Revisions belonging to the Service. If traffic is empty or not provided, defaults to 100% traffic to the latest `Ready` Revision.
      */
     traffic?: pulumi.Input<pulumi.Input<inputs.run.v2.GoogleCloudRunV2TrafficTargetArgs>[]>;
-    /**
-     * Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-     */
-    validateOnly?: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/workstations/v1beta/workstation.ts
+++ b/sdk/nodejs/workstations/v1beta/workstation.ts
@@ -84,10 +84,6 @@ export class Workstation extends pulumi.CustomResource {
      * Time when this resource was most recently updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * If set, validate the request and preview the review, but do not actually apply it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
     public readonly workstationClusterId!: pulumi.Output<string>;
     public readonly workstationConfigId!: pulumi.Output<string>;
     /**
@@ -122,7 +118,6 @@ export class Workstation extends pulumi.CustomResource {
             resourceInputs["location"] = args ? args.location : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["workstationClusterId"] = args ? args.workstationClusterId : undefined;
             resourceInputs["workstationConfigId"] = args ? args.workstationConfigId : undefined;
             resourceInputs["workstationId"] = args ? args.workstationId : undefined;
@@ -148,7 +143,6 @@ export class Workstation extends pulumi.CustomResource {
             resourceInputs["state"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["workstationClusterId"] = undefined /*out*/;
             resourceInputs["workstationConfigId"] = undefined /*out*/;
             resourceInputs["workstationId"] = undefined /*out*/;
@@ -186,10 +180,6 @@ export interface WorkstationArgs {
      */
     name?: pulumi.Input<string>;
     project?: pulumi.Input<string>;
-    /**
-     * If set, validate the request and preview the review, but do not actually apply it.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     workstationClusterId: pulumi.Input<string>;
     workstationConfigId: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/workstations/v1beta/workstationCluster.ts
+++ b/sdk/nodejs/workstations/v1beta/workstationCluster.ts
@@ -100,10 +100,6 @@ export class WorkstationCluster extends pulumi.CustomResource {
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
     /**
-     * If set, validate the request and preview the review, but do not actually apply it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
-    /**
      * Required. ID to use for the workstation cluster.
      */
     public readonly workstationClusterId!: pulumi.Output<string>;
@@ -132,7 +128,6 @@ export class WorkstationCluster extends pulumi.CustomResource {
             resourceInputs["privateClusterConfig"] = args ? args.privateClusterConfig : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["subnetwork"] = args ? args.subnetwork : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["workstationClusterId"] = args ? args.workstationClusterId : undefined;
             resourceInputs["conditions"] = undefined /*out*/;
             resourceInputs["createTime"] = undefined /*out*/;
@@ -159,7 +154,6 @@ export class WorkstationCluster extends pulumi.CustomResource {
             resourceInputs["subnetwork"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["workstationClusterId"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
@@ -207,10 +201,6 @@ export interface WorkstationClusterArgs {
      * Immutable. Name of the Compute Engine subnetwork in which instances associated with this cluster will be created. Must be part of the subnetwork specified for this cluster.
      */
     subnetwork?: pulumi.Input<string>;
-    /**
-     * If set, validate the request and preview the review, but do not actually apply it.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     /**
      * Required. ID to use for the workstation cluster.
      */

--- a/sdk/nodejs/workstations/v1beta/workstationConfig.ts
+++ b/sdk/nodejs/workstations/v1beta/workstationConfig.ts
@@ -111,10 +111,6 @@ export class WorkstationConfig extends pulumi.CustomResource {
      * Time when this resource was most recently updated.
      */
     public /*out*/ readonly updateTime!: pulumi.Output<string>;
-    /**
-     * If set, validate the request and preview the review, but do not actually apply it.
-     */
-    public readonly validateOnly!: pulumi.Output<boolean | undefined>;
     public readonly workstationClusterId!: pulumi.Output<string>;
     /**
      * Required. ID to use for the config.
@@ -151,7 +147,6 @@ export class WorkstationConfig extends pulumi.CustomResource {
             resourceInputs["persistentDirectories"] = args ? args.persistentDirectories : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["runningTimeout"] = args ? args.runningTimeout : undefined;
-            resourceInputs["validateOnly"] = args ? args.validateOnly : undefined;
             resourceInputs["workstationClusterId"] = args ? args.workstationClusterId : undefined;
             resourceInputs["workstationConfigId"] = args ? args.workstationConfigId : undefined;
             resourceInputs["conditions"] = undefined /*out*/;
@@ -182,7 +177,6 @@ export class WorkstationConfig extends pulumi.CustomResource {
             resourceInputs["runningTimeout"] = undefined /*out*/;
             resourceInputs["uid"] = undefined /*out*/;
             resourceInputs["updateTime"] = undefined /*out*/;
-            resourceInputs["validateOnly"] = undefined /*out*/;
             resourceInputs["workstationClusterId"] = undefined /*out*/;
             resourceInputs["workstationConfigId"] = undefined /*out*/;
         }
@@ -243,10 +237,6 @@ export interface WorkstationConfigArgs {
      * How long to wait before automatically stopping a workstation after it started. A value of 0 indicates that workstations using this configuration should never time out. Must be greater than 0 and less than 24 hours if encryption_key is set. Defaults to 12 hours.
      */
     runningTimeout?: pulumi.Input<string>;
-    /**
-     * If set, validate the request and preview the review, but do not actually apply it.
-     */
-    validateOnly?: pulumi.Input<boolean>;
     workstationClusterId: pulumi.Input<string>;
     /**
      * Required. ID to use for the config.

--- a/sdk/python/pulumi_google_native/beyondcorp/v1/app_connection.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1/app_connection.py
@@ -27,8 +27,7 @@ class AppConnectionArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a AppConnection resource.
         :param pulumi.Input['GoogleCloudBeyondcorpAppconnectionsV1AppConnectionApplicationEndpointArgs'] application_endpoint: Address of the remote application endpoint for the BeyondCorp AppConnection.
@@ -40,7 +39,6 @@ class AppConnectionArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. Resource labels to represent user provided metadata.
         :param pulumi.Input[str] name: Unique resource name of the AppConnection. The name is ignored when creating a AppConnection.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "application_endpoint", application_endpoint)
         pulumi.set(__self__, "type", type)
@@ -62,8 +60,6 @@ class AppConnectionArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="applicationEndpoint")
@@ -191,18 +187,6 @@ class AppConnectionArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class AppConnection(pulumi.CustomResource):
     @overload
@@ -220,7 +204,6 @@ class AppConnection(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppConnectionType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new AppConnection in a given project and location.
@@ -236,7 +219,6 @@ class AppConnection(pulumi.CustomResource):
         :param pulumi.Input[str] name: Unique resource name of the AppConnection. The name is ignored when creating a AppConnection.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['AppConnectionType'] type: The type of network connectivity used by the AppConnection.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -273,7 +255,6 @@ class AppConnection(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppConnectionType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -298,7 +279,6 @@ class AppConnection(pulumi.CustomResource):
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["uid"] = None
@@ -342,7 +322,6 @@ class AppConnection(pulumi.CustomResource):
         __props__.__dict__["type"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return AppConnection(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -458,12 +437,4 @@ class AppConnection(pulumi.CustomResource):
         Timestamp when the resource was last modified.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1/app_connector.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1/app_connector.py
@@ -25,8 +25,7 @@ class AppConnectorArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 resource_info: Optional[pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 resource_info: Optional[pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs']] = None):
         """
         The set of arguments for constructing a AppConnector resource.
         :param pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1AppConnectorPrincipalInfoArgs'] principal_info: Principal information about the Identity of the AppConnector.
@@ -36,7 +35,6 @@ class AppConnectorArgs:
         :param pulumi.Input[str] name: Unique resource name of the AppConnector. The name is ignored when creating a AppConnector.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs'] resource_info: Optional. Resource info of the connector.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "principal_info", principal_info)
         if app_connector_id is not None:
@@ -55,8 +53,6 @@ class AppConnectorArgs:
             pulumi.set(__self__, "request_id", request_id)
         if resource_info is not None:
             pulumi.set(__self__, "resource_info", resource_info)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="principalInfo")
@@ -160,18 +156,6 @@ class AppConnectorArgs:
     def resource_info(self, value: Optional[pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs']]):
         pulumi.set(self, "resource_info", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class AppConnector(pulumi.CustomResource):
     @overload
@@ -187,7 +171,6 @@ class AppConnector(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  resource_info: Optional[pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new AppConnector in a given project and location.
@@ -201,7 +184,6 @@ class AppConnector(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1AppConnectorPrincipalInfoArgs']] principal_info: Principal information about the Identity of the AppConnector.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs']] resource_info: Optional. Resource info of the connector.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -236,7 +218,6 @@ class AppConnector(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  resource_info: Optional[pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1ResourceInfoArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -257,7 +238,6 @@ class AppConnector(pulumi.CustomResource):
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["resource_info"] = resource_info
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["uid"] = None
@@ -299,7 +279,6 @@ class AppConnector(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return AppConnector(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -399,12 +378,4 @@ class AppConnector(pulumi.CustomResource):
         Timestamp when the resource was last modified.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1/app_gateway.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1/app_gateway.py
@@ -24,8 +24,7 @@ class AppGatewayArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a AppGateway resource.
         :param pulumi.Input['AppGatewayHostType'] host_type: The type of hosting used by the AppGateway.
@@ -35,7 +34,6 @@ class AppGatewayArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. Resource labels to represent user provided metadata.
         :param pulumi.Input[str] name: Unique resource name of the AppGateway. The name is ignored when creating an AppGateway.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "host_type", host_type)
         pulumi.set(__self__, "type", type)
@@ -53,8 +51,6 @@ class AppGatewayArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="hostType")
@@ -158,18 +154,6 @@ class AppGatewayArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class AppGateway(pulumi.CustomResource):
     @overload
@@ -185,7 +169,6 @@ class AppGateway(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppGatewayType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new AppGateway in a given project and location.
@@ -199,7 +182,6 @@ class AppGateway(pulumi.CustomResource):
         :param pulumi.Input[str] name: Unique resource name of the AppGateway. The name is ignored when creating an AppGateway.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['AppGatewayType'] type: The type of network connectivity used by the AppGateway.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -234,7 +216,6 @@ class AppGateway(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppGatewayType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -257,7 +238,6 @@ class AppGateway(pulumi.CustomResource):
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["allocated_connections"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
@@ -303,7 +283,6 @@ class AppGateway(pulumi.CustomResource):
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
         __props__.__dict__["uri"] = None
-        __props__.__dict__["validate_only"] = None
         return AppGateway(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -419,12 +398,4 @@ class AppGateway(pulumi.CustomResource):
         Server-defined URI for this resource.
         """
         return pulumi.get(self, "uri")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1/client_connector_service.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1/client_connector_service.py
@@ -24,8 +24,7 @@ class ClientConnectorServiceArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ClientConnectorService resource.
         :param pulumi.Input['EgressArgs'] egress: The details of the egress settings.
@@ -34,7 +33,6 @@ class ClientConnectorServiceArgs:
         :param pulumi.Input[str] display_name: Optional. User-provided name. The display name should follow certain format. * Must be 6 to 30 characters in length. * Can only contain lowercase letters, numbers, and hyphens. * Must start with a letter.
         :param pulumi.Input[str] name: Name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "egress", egress)
         pulumi.set(__self__, "ingress", ingress)
@@ -50,8 +48,6 @@ class ClientConnectorServiceArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -143,18 +139,6 @@ class ClientConnectorServiceArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class ClientConnectorService(pulumi.CustomResource):
     @overload
@@ -169,7 +153,6 @@ class ClientConnectorService(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new ClientConnectorService in a given project and location.
@@ -182,7 +165,6 @@ class ClientConnectorService(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['IngressArgs']] ingress: The details of the ingress settings.
         :param pulumi.Input[str] name: Name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -216,7 +198,6 @@ class ClientConnectorService(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -238,7 +219,6 @@ class ClientConnectorService(pulumi.CustomResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["update_time"] = None
@@ -277,7 +257,6 @@ class ClientConnectorService(pulumi.CustomResource):
         __props__.__dict__["request_id"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return ClientConnectorService(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -361,12 +340,4 @@ class ClientConnectorService(pulumi.CustomResource):
         [Output only] Update time stamp.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1/client_gateway.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1/client_gateway.py
@@ -18,14 +18,12 @@ class ClientGatewayArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ClientGateway resource.
         :param pulumi.Input[str] client_gateway_id: Optional. User-settable client gateway resource ID. * Must start with a letter. * Must contain between 4-63 characters from `/a-z-/`. * Must end with a number or a letter.
         :param pulumi.Input[str] name: name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         if client_gateway_id is not None:
             pulumi.set(__self__, "client_gateway_id", client_gateway_id)
@@ -37,8 +35,6 @@ class ClientGatewayArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="clientGatewayId")
@@ -94,18 +90,6 @@ class ClientGatewayArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class ClientGateway(pulumi.CustomResource):
     @overload
@@ -117,7 +101,6 @@ class ClientGateway(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new ClientGateway in a given project and location.
@@ -127,7 +110,6 @@ class ClientGateway(pulumi.CustomResource):
         :param pulumi.Input[str] client_gateway_id: Optional. User-settable client gateway resource ID. * Must start with a letter. * Must contain between 4-63 characters from `/a-z-/`. * Must end with a number or a letter.
         :param pulumi.Input[str] name: name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -158,7 +140,6 @@ class ClientGateway(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -173,7 +154,6 @@ class ClientGateway(pulumi.CustomResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["client_connector_service"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
@@ -211,7 +191,6 @@ class ClientGateway(pulumi.CustomResource):
         __props__.__dict__["request_id"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return ClientGateway(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -279,12 +258,4 @@ class ClientGateway(pulumi.CustomResource):
         [Output only] Update time stamp.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1alpha/app_connection.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1alpha/app_connection.py
@@ -27,8 +27,7 @@ class AppConnectionArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a AppConnection resource.
         :param pulumi.Input['GoogleCloudBeyondcorpAppconnectionsV1alphaAppConnectionApplicationEndpointArgs'] application_endpoint: Address of the remote application endpoint for the BeyondCorp AppConnection.
@@ -40,7 +39,6 @@ class AppConnectionArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. Resource labels to represent user provided metadata.
         :param pulumi.Input[str] name: Unique resource name of the AppConnection. The name is ignored when creating a AppConnection.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "application_endpoint", application_endpoint)
         pulumi.set(__self__, "type", type)
@@ -62,8 +60,6 @@ class AppConnectionArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="applicationEndpoint")
@@ -191,18 +187,6 @@ class AppConnectionArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class AppConnection(pulumi.CustomResource):
     @overload
@@ -220,7 +204,6 @@ class AppConnection(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppConnectionType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new AppConnection in a given project and location.
@@ -236,7 +219,6 @@ class AppConnection(pulumi.CustomResource):
         :param pulumi.Input[str] name: Unique resource name of the AppConnection. The name is ignored when creating a AppConnection.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['AppConnectionType'] type: The type of network connectivity used by the AppConnection.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -273,7 +255,6 @@ class AppConnection(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppConnectionType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -298,7 +279,6 @@ class AppConnection(pulumi.CustomResource):
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["uid"] = None
@@ -342,7 +322,6 @@ class AppConnection(pulumi.CustomResource):
         __props__.__dict__["type"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return AppConnection(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -458,12 +437,4 @@ class AppConnection(pulumi.CustomResource):
         Timestamp when the resource was last modified.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1alpha/app_connector.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1alpha/app_connector.py
@@ -25,8 +25,7 @@ class AppConnectorArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 resource_info: Optional[pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 resource_info: Optional[pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs']] = None):
         """
         The set of arguments for constructing a AppConnector resource.
         :param pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1alphaAppConnectorPrincipalInfoArgs'] principal_info: Principal information about the Identity of the AppConnector.
@@ -36,7 +35,6 @@ class AppConnectorArgs:
         :param pulumi.Input[str] name: Unique resource name of the AppConnector. The name is ignored when creating a AppConnector.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs'] resource_info: Optional. Resource info of the connector.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "principal_info", principal_info)
         if app_connector_id is not None:
@@ -55,8 +53,6 @@ class AppConnectorArgs:
             pulumi.set(__self__, "request_id", request_id)
         if resource_info is not None:
             pulumi.set(__self__, "resource_info", resource_info)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="principalInfo")
@@ -160,18 +156,6 @@ class AppConnectorArgs:
     def resource_info(self, value: Optional[pulumi.Input['GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs']]):
         pulumi.set(self, "resource_info", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class AppConnector(pulumi.CustomResource):
     @overload
@@ -187,7 +171,6 @@ class AppConnector(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  resource_info: Optional[pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new AppConnector in a given project and location.
@@ -201,7 +184,6 @@ class AppConnector(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1alphaAppConnectorPrincipalInfoArgs']] principal_info: Principal information about the Identity of the AppConnector.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs']] resource_info: Optional. Resource info of the connector.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -236,7 +218,6 @@ class AppConnector(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  resource_info: Optional[pulumi.Input[pulumi.InputType['GoogleCloudBeyondcorpAppconnectorsV1alphaResourceInfoArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -257,7 +238,6 @@ class AppConnector(pulumi.CustomResource):
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["resource_info"] = resource_info
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["uid"] = None
@@ -299,7 +279,6 @@ class AppConnector(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return AppConnector(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -399,12 +378,4 @@ class AppConnector(pulumi.CustomResource):
         Timestamp when the resource was last modified.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1alpha/app_gateway.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1alpha/app_gateway.py
@@ -24,8 +24,7 @@ class AppGatewayArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a AppGateway resource.
         :param pulumi.Input['AppGatewayHostType'] host_type: The type of hosting used by the AppGateway.
@@ -35,7 +34,6 @@ class AppGatewayArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. Resource labels to represent user provided metadata.
         :param pulumi.Input[str] name: Unique resource name of the AppGateway. The name is ignored when creating an AppGateway.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "host_type", host_type)
         pulumi.set(__self__, "type", type)
@@ -53,8 +51,6 @@ class AppGatewayArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="hostType")
@@ -158,18 +154,6 @@ class AppGatewayArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class AppGateway(pulumi.CustomResource):
     @overload
@@ -185,7 +169,6 @@ class AppGateway(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppGatewayType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new AppGateway in a given project and location.
@@ -199,7 +182,6 @@ class AppGateway(pulumi.CustomResource):
         :param pulumi.Input[str] name: Unique resource name of the AppGateway. The name is ignored when creating an AppGateway.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['AppGatewayType'] type: The type of network connectivity used by the AppGateway.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -234,7 +216,6 @@ class AppGateway(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['AppGatewayType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -257,7 +238,6 @@ class AppGateway(pulumi.CustomResource):
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["allocated_connections"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
@@ -303,7 +283,6 @@ class AppGateway(pulumi.CustomResource):
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
         __props__.__dict__["uri"] = None
-        __props__.__dict__["validate_only"] = None
         return AppGateway(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -419,12 +398,4 @@ class AppGateway(pulumi.CustomResource):
         Server-defined URI for this resource.
         """
         return pulumi.get(self, "uri")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1alpha/client_connector_service.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1alpha/client_connector_service.py
@@ -24,8 +24,7 @@ class ClientConnectorServiceArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ClientConnectorService resource.
         :param pulumi.Input['EgressArgs'] egress: The details of the egress settings.
@@ -34,7 +33,6 @@ class ClientConnectorServiceArgs:
         :param pulumi.Input[str] display_name: Optional. User-provided name. The display name should follow certain format. * Must be 6 to 30 characters in length. * Can only contain lowercase letters, numbers, and hyphens. * Must start with a letter.
         :param pulumi.Input[str] name: Name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "egress", egress)
         pulumi.set(__self__, "ingress", ingress)
@@ -50,8 +48,6 @@ class ClientConnectorServiceArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -143,18 +139,6 @@ class ClientConnectorServiceArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class ClientConnectorService(pulumi.CustomResource):
     @overload
@@ -169,7 +153,6 @@ class ClientConnectorService(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new ClientConnectorService in a given project and location.
@@ -182,7 +165,6 @@ class ClientConnectorService(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['IngressArgs']] ingress: The details of the ingress settings.
         :param pulumi.Input[str] name: Name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -216,7 +198,6 @@ class ClientConnectorService(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -238,7 +219,6 @@ class ClientConnectorService(pulumi.CustomResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["update_time"] = None
@@ -277,7 +257,6 @@ class ClientConnectorService(pulumi.CustomResource):
         __props__.__dict__["request_id"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return ClientConnectorService(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -361,12 +340,4 @@ class ClientConnectorService(pulumi.CustomResource):
         [Output only] Update time stamp.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1alpha/client_gateway.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1alpha/client_gateway.py
@@ -18,14 +18,12 @@ class ClientGatewayArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ClientGateway resource.
         :param pulumi.Input[str] client_gateway_id: Optional. User-settable client gateway resource ID. * Must start with a letter. * Must contain between 4-63 characters from `/a-z-/`. * Must end with a number or a letter.
         :param pulumi.Input[str] name: name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         if client_gateway_id is not None:
             pulumi.set(__self__, "client_gateway_id", client_gateway_id)
@@ -37,8 +35,6 @@ class ClientGatewayArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="clientGatewayId")
@@ -94,18 +90,6 @@ class ClientGatewayArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class ClientGateway(pulumi.CustomResource):
     @overload
@@ -117,7 +101,6 @@ class ClientGateway(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new ClientGateway in a given project and location.
@@ -127,7 +110,6 @@ class ClientGateway(pulumi.CustomResource):
         :param pulumi.Input[str] client_gateway_id: Optional. User-settable client gateway resource ID. * Must start with a letter. * Must contain between 4-63 characters from `/a-z-/`. * Must end with a number or a letter.
         :param pulumi.Input[str] name: name of resource. The name is ignored during creation.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -158,7 +140,6 @@ class ClientGateway(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -173,7 +154,6 @@ class ClientGateway(pulumi.CustomResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["client_connector_service"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
@@ -211,7 +191,6 @@ class ClientGateway(pulumi.CustomResource):
         __props__.__dict__["request_id"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return ClientGateway(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -279,12 +258,4 @@ class ClientGateway(pulumi.CustomResource):
         [Output only] Update time stamp.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1alpha/connection.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1alpha/connection.py
@@ -27,8 +27,7 @@ class ConnectionArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 request_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 request_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Connection resource.
         :param pulumi.Input['ApplicationEndpointArgs'] application_endpoint: Address of the remote application endpoint for the BeyondCorp Connection.
@@ -40,7 +39,6 @@ class ConnectionArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. Resource labels to represent user provided metadata.
         :param pulumi.Input[str] name: Unique resource name of the connection. The name is ignored when creating a connection.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "application_endpoint", application_endpoint)
         pulumi.set(__self__, "type", type)
@@ -62,8 +60,6 @@ class ConnectionArgs:
             pulumi.set(__self__, "project", project)
         if request_id is not None:
             pulumi.set(__self__, "request_id", request_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="applicationEndpoint")
@@ -191,18 +187,6 @@ class ConnectionArgs:
     def request_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "request_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Connection(pulumi.CustomResource):
     @overload
@@ -220,7 +204,6 @@ class Connection(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['ConnectionType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new Connection in a given project and location.
@@ -236,7 +219,6 @@ class Connection(pulumi.CustomResource):
         :param pulumi.Input[str] name: Unique resource name of the connection. The name is ignored when creating a connection.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['ConnectionType'] type: The type of network connectivity used by the connection.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -273,7 +255,6 @@ class Connection(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['ConnectionType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -298,7 +279,6 @@ class Connection(pulumi.CustomResource):
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["uid"] = None
@@ -342,7 +322,6 @@ class Connection(pulumi.CustomResource):
         __props__.__dict__["type"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Connection(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -458,12 +437,4 @@ class Connection(pulumi.CustomResource):
         Timestamp when the resource was last modified.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/beyondcorp/v1alpha/connector.py
+++ b/sdk/python/pulumi_google_native/beyondcorp/v1alpha/connector.py
@@ -25,8 +25,7 @@ class ConnectorArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 resource_info: Optional[pulumi.Input['ResourceInfoArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 resource_info: Optional[pulumi.Input['ResourceInfoArgs']] = None):
         """
         The set of arguments for constructing a Connector resource.
         :param pulumi.Input['PrincipalInfoArgs'] principal_info: Principal information about the Identity of the connector.
@@ -36,7 +35,6 @@ class ConnectorArgs:
         :param pulumi.Input[str] name: Unique resource name of the connector. The name is ignored when creating a connector.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['ResourceInfoArgs'] resource_info: Optional. Resource info of the connector.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         pulumi.set(__self__, "principal_info", principal_info)
         if connector_id is not None:
@@ -55,8 +53,6 @@ class ConnectorArgs:
             pulumi.set(__self__, "request_id", request_id)
         if resource_info is not None:
             pulumi.set(__self__, "resource_info", resource_info)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="principalInfo")
@@ -160,18 +156,6 @@ class ConnectorArgs:
     def resource_info(self, value: Optional[pulumi.Input['ResourceInfoArgs']]):
         pulumi.set(self, "resource_info", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Connector(pulumi.CustomResource):
     @overload
@@ -187,7 +171,6 @@ class Connector(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  resource_info: Optional[pulumi.Input[pulumi.InputType['ResourceInfoArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new Connector in a given project and location.
@@ -201,7 +184,6 @@ class Connector(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['PrincipalInfoArgs']] principal_info: Principal information about the Identity of the connector.
         :param pulumi.Input[str] request_id: Optional. An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[pulumi.InputType['ResourceInfoArgs']] resource_info: Optional. Resource info of the connector.
-        :param pulumi.Input[bool] validate_only: Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
         """
         ...
     @overload
@@ -236,7 +218,6 @@ class Connector(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  resource_info: Optional[pulumi.Input[pulumi.InputType['ResourceInfoArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -257,7 +238,6 @@ class Connector(pulumi.CustomResource):
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["resource_info"] = resource_info
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["uid"] = None
@@ -299,7 +279,6 @@ class Connector(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Connector(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -399,12 +378,4 @@ class Connector(pulumi.CustomResource):
         Timestamp when the resource was last modified.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set, validates request by executing a dry-run which would not alter the resource in any way.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/cloudbuild/v1/worker_pool.py
+++ b/sdk/python/pulumi_google_native/cloudbuild/v1/worker_pool.py
@@ -22,15 +22,13 @@ class WorkerPoolArgs:
                  display_name: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  private_pool_v1_config: Optional[pulumi.Input['PrivatePoolV1ConfigArgs']] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a WorkerPool resource.
         :param pulumi.Input[str] worker_pool_id: Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] annotations: User specified annotations. See https://google.aip.dev/128#annotations for more details such as format and size limitations.
         :param pulumi.Input[str] display_name: A user-specified, human-readable name for the `WorkerPool`. If provided, this value must be 1-63 characters.
         :param pulumi.Input['PrivatePoolV1ConfigArgs'] private_pool_v1_config: Legacy Private Pool configuration.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the response, but do not actually post it.
         """
         pulumi.set(__self__, "worker_pool_id", worker_pool_id)
         if annotations is not None:
@@ -43,8 +41,6 @@ class WorkerPoolArgs:
             pulumi.set(__self__, "private_pool_v1_config", private_pool_v1_config)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="workerPoolId")
@@ -112,18 +108,6 @@ class WorkerPoolArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If set, validate the request and preview the response, but do not actually post it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class WorkerPool(pulumi.CustomResource):
     @overload
@@ -135,7 +119,6 @@ class WorkerPool(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  private_pool_v1_config: Optional[pulumi.Input[pulumi.InputType['PrivatePoolV1ConfigArgs']]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  worker_pool_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -147,7 +130,6 @@ class WorkerPool(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] annotations: User specified annotations. See https://google.aip.dev/128#annotations for more details such as format and size limitations.
         :param pulumi.Input[str] display_name: A user-specified, human-readable name for the `WorkerPool`. If provided, this value must be 1-63 characters.
         :param pulumi.Input[pulumi.InputType['PrivatePoolV1ConfigArgs']] private_pool_v1_config: Legacy Private Pool configuration.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the response, but do not actually post it.
         :param pulumi.Input[str] worker_pool_id: Required. Immutable. The ID to use for the `WorkerPool`, which will become the final component of the resource name. This value should be 1-63 characters, and valid characters are /a-z-/.
         """
         ...
@@ -180,7 +162,6 @@ class WorkerPool(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  private_pool_v1_config: Optional[pulumi.Input[pulumi.InputType['PrivatePoolV1ConfigArgs']]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  worker_pool_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -196,7 +177,6 @@ class WorkerPool(pulumi.CustomResource):
             __props__.__dict__["location"] = location
             __props__.__dict__["private_pool_v1_config"] = private_pool_v1_config
             __props__.__dict__["project"] = project
-            __props__.__dict__["validate_only"] = validate_only
             if worker_pool_id is None and not opts.urn:
                 raise TypeError("Missing required property 'worker_pool_id'")
             __props__.__dict__["worker_pool_id"] = worker_pool_id
@@ -243,7 +223,6 @@ class WorkerPool(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["worker_pool_id"] = None
         return WorkerPool(resource_name, opts=opts, __props__=__props__)
 
@@ -336,14 +315,6 @@ class WorkerPool(pulumi.CustomResource):
         Time at which the request to update the `WorkerPool` was received.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If set, validate the request and preview the response, but do not actually post it.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="workerPoolId")

--- a/sdk/python/pulumi_google_native/clouddeploy/v1/delivery_pipeline.py
+++ b/sdk/python/pulumi_google_native/clouddeploy/v1/delivery_pipeline.py
@@ -26,8 +26,7 @@ class DeliveryPipelineArgs:
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  serial_pipeline: Optional[pulumi.Input['SerialPipelineArgs']] = None,
-                 suspended: Optional[pulumi.Input[bool]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 suspended: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a DeliveryPipeline resource.
         :param pulumi.Input[str] delivery_pipeline_id: Required. ID of the `DeliveryPipeline`.
@@ -39,7 +38,6 @@ class DeliveryPipelineArgs:
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['SerialPipelineArgs'] serial_pipeline: SerialPipeline defines a sequential set of stages for a `DeliveryPipeline`.
         :param pulumi.Input[bool] suspended: When suspended, no new releases or rollouts can be created, but in-progress ones will complete.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         pulumi.set(__self__, "delivery_pipeline_id", delivery_pipeline_id)
         if annotations is not None:
@@ -62,8 +60,6 @@ class DeliveryPipelineArgs:
             pulumi.set(__self__, "serial_pipeline", serial_pipeline)
         if suspended is not None:
             pulumi.set(__self__, "suspended", suspended)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="deliveryPipelineId")
@@ -191,18 +187,6 @@ class DeliveryPipelineArgs:
     def suspended(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "suspended", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class DeliveryPipeline(pulumi.CustomResource):
     @overload
@@ -220,7 +204,6 @@ class DeliveryPipeline(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  serial_pipeline: Optional[pulumi.Input[pulumi.InputType['SerialPipelineArgs']]] = None,
                  suspended: Optional[pulumi.Input[bool]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new DeliveryPipeline in a given project and location.
@@ -237,7 +220,6 @@ class DeliveryPipeline(pulumi.CustomResource):
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[pulumi.InputType['SerialPipelineArgs']] serial_pipeline: SerialPipeline defines a sequential set of stages for a `DeliveryPipeline`.
         :param pulumi.Input[bool] suspended: When suspended, no new releases or rollouts can be created, but in-progress ones will complete.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         ...
     @overload
@@ -275,7 +257,6 @@ class DeliveryPipeline(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  serial_pipeline: Optional[pulumi.Input[pulumi.InputType['SerialPipelineArgs']]] = None,
                  suspended: Optional[pulumi.Input[bool]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -298,7 +279,6 @@ class DeliveryPipeline(pulumi.CustomResource):
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["serial_pipeline"] = serial_pipeline
             __props__.__dict__["suspended"] = suspended
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["condition"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["uid"] = None
@@ -342,7 +322,6 @@ class DeliveryPipeline(pulumi.CustomResource):
         __props__.__dict__["suspended"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return DeliveryPipeline(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -458,12 +437,4 @@ class DeliveryPipeline(pulumi.CustomResource):
         Most recent time at which the pipeline was updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/clouddeploy/v1/release.py
+++ b/sdk/python/pulumi_google_native/clouddeploy/v1/release.py
@@ -29,8 +29,7 @@ class ReleaseArgs:
                  request_id: Optional[pulumi.Input[str]] = None,
                  skaffold_config_path: Optional[pulumi.Input[str]] = None,
                  skaffold_config_uri: Optional[pulumi.Input[str]] = None,
-                 skaffold_version: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 skaffold_version: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Release resource.
         :param pulumi.Input[str] release_id: Required. ID of the `Release`.
@@ -44,7 +43,6 @@ class ReleaseArgs:
         :param pulumi.Input[str] skaffold_config_path: Filepath of the Skaffold config inside of the config URI.
         :param pulumi.Input[str] skaffold_config_uri: Cloud Storage URI of tar.gz archive containing Skaffold configuration.
         :param pulumi.Input[str] skaffold_version: The Skaffold version to use when operating on this release, such as "1.20.0". Not all versions are valid; Google Cloud Deploy supports a specific set of versions. If unset, the most recent supported Skaffold version will be used.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         pulumi.set(__self__, "delivery_pipeline_id", delivery_pipeline_id)
         pulumi.set(__self__, "release_id", release_id)
@@ -72,8 +70,6 @@ class ReleaseArgs:
             pulumi.set(__self__, "skaffold_config_uri", skaffold_config_uri)
         if skaffold_version is not None:
             pulumi.set(__self__, "skaffold_version", skaffold_version)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="deliveryPipelineId")
@@ -234,18 +230,6 @@ class ReleaseArgs:
     def skaffold_version(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "skaffold_version", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Release(pulumi.CustomResource):
     @overload
@@ -266,7 +250,6 @@ class Release(pulumi.CustomResource):
                  skaffold_config_path: Optional[pulumi.Input[str]] = None,
                  skaffold_config_uri: Optional[pulumi.Input[str]] = None,
                  skaffold_version: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new Release in a given project and location.
@@ -287,7 +270,6 @@ class Release(pulumi.CustomResource):
         :param pulumi.Input[str] skaffold_config_path: Filepath of the Skaffold config inside of the config URI.
         :param pulumi.Input[str] skaffold_config_uri: Cloud Storage URI of tar.gz archive containing Skaffold configuration.
         :param pulumi.Input[str] skaffold_version: The Skaffold version to use when operating on this release, such as "1.20.0". Not all versions are valid; Google Cloud Deploy supports a specific set of versions. If unset, the most recent supported Skaffold version will be used.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         ...
     @overload
@@ -330,7 +312,6 @@ class Release(pulumi.CustomResource):
                  skaffold_config_path: Optional[pulumi.Input[str]] = None,
                  skaffold_config_uri: Optional[pulumi.Input[str]] = None,
                  skaffold_version: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -358,7 +339,6 @@ class Release(pulumi.CustomResource):
             __props__.__dict__["skaffold_config_path"] = skaffold_config_path
             __props__.__dict__["skaffold_config_uri"] = skaffold_config_uri
             __props__.__dict__["skaffold_version"] = skaffold_version
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["abandoned"] = None
             __props__.__dict__["condition"] = None
             __props__.__dict__["create_time"] = None
@@ -419,7 +399,6 @@ class Release(pulumi.CustomResource):
         __props__.__dict__["target_renders"] = None
         __props__.__dict__["target_snapshots"] = None
         __props__.__dict__["uid"] = None
-        __props__.__dict__["validate_only"] = None
         return Release(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -612,12 +591,4 @@ class Release(pulumi.CustomResource):
         Unique identifier of the `Release`.
         """
         return pulumi.get(self, "uid")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/clouddeploy/v1/rollout.py
+++ b/sdk/python/pulumi_google_native/clouddeploy/v1/rollout.py
@@ -27,8 +27,7 @@ class RolloutArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 starting_phase_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 starting_phase_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Rollout resource.
         :param pulumi.Input[str] rollout_id: Required. ID of the `Rollout`.
@@ -40,7 +39,6 @@ class RolloutArgs:
         :param pulumi.Input[str] name: Optional. Name of the `Rollout`. Format is projects/{project}/ locations/{location}/deliveryPipelines/{deliveryPipeline}/ releases/{release}/rollouts/a-z{0,62}.
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[str] starting_phase_id: Optional. The starting phase ID for the `Rollout`. If empty the `Rollout` will start at the first phase.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         pulumi.set(__self__, "delivery_pipeline_id", delivery_pipeline_id)
         pulumi.set(__self__, "release_id", release_id)
@@ -64,8 +62,6 @@ class RolloutArgs:
             pulumi.set(__self__, "request_id", request_id)
         if starting_phase_id is not None:
             pulumi.set(__self__, "starting_phase_id", starting_phase_id)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="deliveryPipelineId")
@@ -211,18 +207,6 @@ class RolloutArgs:
     def starting_phase_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "starting_phase_id", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Rollout(pulumi.CustomResource):
     @overload
@@ -242,7 +226,6 @@ class Rollout(pulumi.CustomResource):
                  rollout_id: Optional[pulumi.Input[str]] = None,
                  starting_phase_id: Optional[pulumi.Input[str]] = None,
                  target_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new Rollout in a given project and location.
@@ -261,7 +244,6 @@ class Rollout(pulumi.CustomResource):
         :param pulumi.Input[str] rollout_id: Required. ID of the `Rollout`.
         :param pulumi.Input[str] starting_phase_id: Optional. The starting phase ID for the `Rollout`. If empty the `Rollout` will start at the first phase.
         :param pulumi.Input[str] target_id: The ID of Target to which this `Rollout` is deploying.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         ...
     @overload
@@ -303,7 +285,6 @@ class Rollout(pulumi.CustomResource):
                  rollout_id: Optional[pulumi.Input[str]] = None,
                  starting_phase_id: Optional[pulumi.Input[str]] = None,
                  target_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -334,7 +315,6 @@ class Rollout(pulumi.CustomResource):
             if target_id is None and not opts.urn:
                 raise TypeError("Missing required property 'target_id'")
             __props__.__dict__["target_id"] = target_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["approval_state"] = None
             __props__.__dict__["approve_time"] = None
             __props__.__dict__["controller_rollout"] = None
@@ -400,7 +380,6 @@ class Rollout(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["target_id"] = None
         __props__.__dict__["uid"] = None
-        __props__.__dict__["validate_only"] = None
         return Rollout(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -606,12 +585,4 @@ class Rollout(pulumi.CustomResource):
         Unique identifier of the `Rollout`.
         """
         return pulumi.get(self, "uid")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/clouddeploy/v1/target.py
+++ b/sdk/python/pulumi_google_native/clouddeploy/v1/target.py
@@ -31,8 +31,7 @@ class TargetArgs:
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  require_approval: Optional[pulumi.Input[bool]] = None,
-                 run: Optional[pulumi.Input['CloudRunLocationArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 run: Optional[pulumi.Input['CloudRunLocationArgs']] = None):
         """
         The set of arguments for constructing a Target resource.
         :param pulumi.Input[str] target_id: Required. ID of the `Target`.
@@ -48,7 +47,6 @@ class TargetArgs:
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[bool] require_approval: Optional. Whether or not the `Target` requires approval.
         :param pulumi.Input['CloudRunLocationArgs'] run: Information specifying a Cloud Run deployment target.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         pulumi.set(__self__, "target_id", target_id)
         if annotations is not None:
@@ -79,8 +77,6 @@ class TargetArgs:
             pulumi.set(__self__, "require_approval", require_approval)
         if run is not None:
             pulumi.set(__self__, "run", run)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="targetId")
@@ -256,18 +252,6 @@ class TargetArgs:
     def run(self, value: Optional[pulumi.Input['CloudRunLocationArgs']]):
         pulumi.set(self, "run", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Target(pulumi.CustomResource):
     @overload
@@ -289,7 +273,6 @@ class Target(pulumi.CustomResource):
                  require_approval: Optional[pulumi.Input[bool]] = None,
                  run: Optional[pulumi.Input[pulumi.InputType['CloudRunLocationArgs']]] = None,
                  target_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new Target in a given project and location.
@@ -309,7 +292,6 @@ class Target(pulumi.CustomResource):
         :param pulumi.Input[bool] require_approval: Optional. Whether or not the `Target` requires approval.
         :param pulumi.Input[pulumi.InputType['CloudRunLocationArgs']] run: Information specifying a Cloud Run deployment target.
         :param pulumi.Input[str] target_id: Required. ID of the `Target`.
-        :param pulumi.Input[bool] validate_only: Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
         """
         ...
     @overload
@@ -350,7 +332,6 @@ class Target(pulumi.CustomResource):
                  require_approval: Optional[pulumi.Input[bool]] = None,
                  run: Optional[pulumi.Input[pulumi.InputType['CloudRunLocationArgs']]] = None,
                  target_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -377,7 +358,6 @@ class Target(pulumi.CustomResource):
             if target_id is None and not opts.urn:
                 raise TypeError("Missing required property 'target_id'")
             __props__.__dict__["target_id"] = target_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["uid"] = None
             __props__.__dict__["update_time"] = None
@@ -423,7 +403,6 @@ class Target(pulumi.CustomResource):
         __props__.__dict__["target_id"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Target(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -563,12 +542,4 @@ class Target(pulumi.CustomResource):
         Most recent time at which the `Target` was updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If set to true, the request is validated and the user is provided with an expected result, but no actual change is made.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v3/tag_key.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v3/tag_key.py
@@ -21,8 +21,7 @@ class TagKeyArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input[str]] = None,
                  purpose: Optional[pulumi.Input['TagKeyPurpose']] = None,
-                 purpose_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 purpose_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a TagKey resource.
         :param pulumi.Input[str] short_name: Immutable. The user friendly name for a TagKey. The short name should be unique for TagKeys within the same tag namespace. The short name must be 1-63 characters, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
@@ -32,7 +31,6 @@ class TagKeyArgs:
         :param pulumi.Input[str] parent: Immutable. The resource name of the new TagKey's parent. Must be of the form `organizations/{org_id}`.
         :param pulumi.Input['TagKeyPurpose'] purpose: Optional. A purpose denotes that this Tag is intended for use in policies of a specific policy engine, and will involve that policy engine in management operations involving this Tag. A purpose does not grant a policy engine exclusive rights to the Tag, and it may be referenced by other policy engines. A purpose cannot be changed once set.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] purpose_data: Optional. Purpose data corresponds to the policy system that the tag is intended for. See documentation for `Purpose` for formatting of this field. Purpose data cannot be changed once set.
-        :param pulumi.Input[bool] validate_only: Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
         """
         pulumi.set(__self__, "short_name", short_name)
         if description is not None:
@@ -47,8 +45,6 @@ class TagKeyArgs:
             pulumi.set(__self__, "purpose", purpose)
         if purpose_data is not None:
             pulumi.set(__self__, "purpose_data", purpose_data)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="shortName")
@@ -134,18 +130,6 @@ class TagKeyArgs:
     def purpose_data(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "purpose_data", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class TagKey(pulumi.CustomResource):
     @overload
@@ -159,7 +143,6 @@ class TagKey(pulumi.CustomResource):
                  purpose: Optional[pulumi.Input['TagKeyPurpose']] = None,
                  purpose_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  short_name: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new TagKey. If another request with the same parameters is sent while the original request is in process, the second request will receive an error. A maximum of 1000 TagKeys can exist under a parent at any given time.
@@ -173,7 +156,6 @@ class TagKey(pulumi.CustomResource):
         :param pulumi.Input['TagKeyPurpose'] purpose: Optional. A purpose denotes that this Tag is intended for use in policies of a specific policy engine, and will involve that policy engine in management operations involving this Tag. A purpose does not grant a policy engine exclusive rights to the Tag, and it may be referenced by other policy engines. A purpose cannot be changed once set.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] purpose_data: Optional. Purpose data corresponds to the policy system that the tag is intended for. See documentation for `Purpose` for formatting of this field. Purpose data cannot be changed once set.
         :param pulumi.Input[str] short_name: Immutable. The user friendly name for a TagKey. The short name should be unique for TagKeys within the same tag namespace. The short name must be 1-63 characters, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
-        :param pulumi.Input[bool] validate_only: Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
         """
         ...
     @overload
@@ -206,7 +188,6 @@ class TagKey(pulumi.CustomResource):
                  purpose: Optional[pulumi.Input['TagKeyPurpose']] = None,
                  purpose_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  short_name: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -225,7 +206,6 @@ class TagKey(pulumi.CustomResource):
             if short_name is None and not opts.urn:
                 raise TypeError("Missing required property 'short_name'")
             __props__.__dict__["short_name"] = short_name
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["namespaced_name"] = None
             __props__.__dict__["update_time"] = None
@@ -261,7 +241,6 @@ class TagKey(pulumi.CustomResource):
         __props__.__dict__["purpose_data"] = None
         __props__.__dict__["short_name"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return TagKey(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -343,12 +322,4 @@ class TagKey(pulumi.CustomResource):
         Update time.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Set to true to perform validations necessary for creating the resource, but not actually perform the action.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/cloudresourcemanager/v3/tag_value.py
+++ b/sdk/python/pulumi_google_native/cloudresourcemanager/v3/tag_value.py
@@ -18,8 +18,7 @@ class TagValueArgs:
                  description: Optional[pulumi.Input[str]] = None,
                  etag: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
-                 parent: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 parent: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a TagValue resource.
         :param pulumi.Input[str] short_name: Immutable. User-assigned short name for TagValue. The short name should be unique for TagValues within the same parent TagKey. The short name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
@@ -27,7 +26,6 @@ class TagValueArgs:
         :param pulumi.Input[str] etag: Optional. Entity tag which users can pass to prevent race conditions. This field is always set in server responses. See UpdateTagValueRequest for details.
         :param pulumi.Input[str] name: Immutable. Resource name for TagValue in the format `tagValues/456`.
         :param pulumi.Input[str] parent: Immutable. The resource name of the new TagValue's parent TagKey. Must be of the form `tagKeys/{tag_key_id}`.
-        :param pulumi.Input[bool] validate_only: Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
         """
         pulumi.set(__self__, "short_name", short_name)
         if description is not None:
@@ -38,8 +36,6 @@ class TagValueArgs:
             pulumi.set(__self__, "name", name)
         if parent is not None:
             pulumi.set(__self__, "parent", parent)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="shortName")
@@ -101,18 +97,6 @@ class TagValueArgs:
     def parent(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "parent", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class TagValue(pulumi.CustomResource):
     @overload
@@ -124,7 +108,6 @@ class TagValue(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input[str]] = None,
                  short_name: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a TagValue as a child of the specified TagKey. If a another request with the same parameters is sent while the original request is in process the second request will receive an error. A maximum of 1000 TagValues can exist under a TagKey at any given time.
@@ -136,7 +119,6 @@ class TagValue(pulumi.CustomResource):
         :param pulumi.Input[str] name: Immutable. Resource name for TagValue in the format `tagValues/456`.
         :param pulumi.Input[str] parent: Immutable. The resource name of the new TagValue's parent TagKey. Must be of the form `tagKeys/{tag_key_id}`.
         :param pulumi.Input[str] short_name: Immutable. User-assigned short name for TagValue. The short name should be unique for TagValues within the same parent TagKey. The short name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
-        :param pulumi.Input[bool] validate_only: Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
         """
         ...
     @overload
@@ -167,7 +149,6 @@ class TagValue(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  parent: Optional[pulumi.Input[str]] = None,
                  short_name: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -184,7 +165,6 @@ class TagValue(pulumi.CustomResource):
             if short_name is None and not opts.urn:
                 raise TypeError("Missing required property 'short_name'")
             __props__.__dict__["short_name"] = short_name
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["namespaced_name"] = None
             __props__.__dict__["update_time"] = None
@@ -218,7 +198,6 @@ class TagValue(pulumi.CustomResource):
         __props__.__dict__["parent"] = None
         __props__.__dict__["short_name"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return TagValue(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -284,12 +263,4 @@ class TagValue(pulumi.CustomResource):
         Update time.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Set as true to perform the validations necessary for creating the resource, but not actually perform the action.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/alpha/interconnect_attachment.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/interconnect_attachment.py
@@ -41,7 +41,6 @@ class InterconnectAttachmentArgs:
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  subnet_length: Optional[pulumi.Input[int]] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None):
         """
         The set of arguments for constructing a InterconnectAttachment resource.
@@ -67,7 +66,6 @@ class InterconnectAttachmentArgs:
         :param pulumi.Input['InterconnectAttachmentStackType'] stack_type: The stack type for this interconnect attachment to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. This field can be both set at interconnect attachments creation and update interconnect attachment operations.
         :param pulumi.Input[int] subnet_length: Length of the IPv4 subnet mask. Allowed values: - 29 (default) - 30 The default value is 29, except for Cross-Cloud Interconnect connections that use an InterconnectRemoteLocation with a constraints.subnetLengthRange.min equal to 30. For example, connections that use an Azure remote location fall into this category. In these cases, the default value is 30, and requesting 29 returns an error. Where both 29 and 30 are allowed, 29 is preferred, because it gives Google Cloud Support more debugging visibility. 
         :param pulumi.Input['InterconnectAttachmentType'] type: The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         :param pulumi.Input[int] vlan_tag8021q: The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         """
         pulumi.set(__self__, "region", region)
@@ -117,8 +115,6 @@ class InterconnectAttachmentArgs:
             pulumi.set(__self__, "subnet_length", subnet_length)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
         if vlan_tag8021q is not None:
             pulumi.set(__self__, "vlan_tag8021q", vlan_tag8021q)
 
@@ -405,18 +401,6 @@ class InterconnectAttachmentArgs:
         pulumi.set(self, "type", value)
 
     @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
-    @property
     @pulumi.getter(name="vlanTag8021q")
     def vlan_tag8021q(self) -> Optional[pulumi.Input[int]]:
         """
@@ -458,7 +442,6 @@ class InterconnectAttachment(pulumi.CustomResource):
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  subnet_length: Optional[pulumi.Input[int]] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -488,7 +471,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         :param pulumi.Input['InterconnectAttachmentStackType'] stack_type: The stack type for this interconnect attachment to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. This field can be both set at interconnect attachments creation and update interconnect attachment operations.
         :param pulumi.Input[int] subnet_length: Length of the IPv4 subnet mask. Allowed values: - 29 (default) - 30 The default value is 29, except for Cross-Cloud Interconnect connections that use an InterconnectRemoteLocation with a constraints.subnetLengthRange.min equal to 30. For example, connections that use an Azure remote location fall into this category. In these cases, the default value is 30, and requesting 29 returns an error. Where both 29 and 30 are allowed, 29 is preferred, because it gives Google Cloud Support more debugging visibility. 
         :param pulumi.Input['InterconnectAttachmentType'] type: The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         :param pulumi.Input[int] vlan_tag8021q: The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         """
         ...
@@ -539,7 +521,6 @@ class InterconnectAttachment(pulumi.CustomResource):
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  subnet_length: Optional[pulumi.Input[int]] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -576,7 +557,6 @@ class InterconnectAttachment(pulumi.CustomResource):
             __props__.__dict__["stack_type"] = stack_type
             __props__.__dict__["subnet_length"] = subnet_length
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["vlan_tag8021q"] = vlan_tag8021q
             __props__.__dict__["cloud_router_ip_address"] = None
             __props__.__dict__["cloud_router_ipv6_address"] = None
@@ -660,7 +640,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["subnet_length"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["vlan_tag8021q"] = None
         return InterconnectAttachment(resource_name, opts=opts, __props__=__props__)
 
@@ -985,14 +964,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="vlanTag8021q")

--- a/sdk/python/pulumi_google_native/compute/alpha/network_edge_security_service.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/network_edge_security_service.py
@@ -19,15 +19,13 @@ class NetworkEdgeSecurityServiceArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 security_policy: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a NetworkEdgeSecurityService resource.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] name: Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[str] security_policy: The resource URL for the network edge security service associated with this network edge security service.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         pulumi.set(__self__, "region", region)
         if description is not None:
@@ -40,8 +38,6 @@ class NetworkEdgeSecurityServiceArgs:
             pulumi.set(__self__, "request_id", request_id)
         if security_policy is not None:
             pulumi.set(__self__, "security_policy", security_policy)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -109,18 +105,6 @@ class NetworkEdgeSecurityServiceArgs:
     def security_policy(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "security_policy", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class NetworkEdgeSecurityService(pulumi.CustomResource):
     @overload
@@ -133,7 +117,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
                  region: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new service in the specified project using the data included in the request.
@@ -144,7 +127,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[str] security_policy: The resource URL for the network edge security service associated with this network edge security service.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -176,7 +158,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
                  region: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -194,7 +175,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
             __props__.__dict__["region"] = region
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["security_policy"] = security_policy
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -235,7 +215,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         __props__.__dict__["security_policy"] = None
         __props__.__dict__["self_link"] = None
         __props__.__dict__["self_link_with_id"] = None
-        __props__.__dict__["validate_only"] = None
         return NetworkEdgeSecurityService(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -319,12 +298,4 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         Server-defined URL for this resource with the resource id.
         """
         return pulumi.get(self, "self_link_with_id")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/alpha/region_security_policy.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/region_security_policy.py
@@ -32,8 +32,7 @@ class RegionSecurityPolicyArgs:
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]]] = None,
                  type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
-                 user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]]] = None):
         """
         The set of arguments for constructing a RegionSecurityPolicy resource.
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyAssociationArgs']]] associations: A list of associations that belong to this policy.
@@ -45,7 +44,6 @@ class RegionSecurityPolicyArgs:
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['RegionSecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]] user_defined_fields: Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         pulumi.set(__self__, "region", region)
         if adaptive_protection_config is not None:
@@ -78,8 +76,6 @@ class RegionSecurityPolicyArgs:
             pulumi.set(__self__, "type", type)
         if user_defined_fields is not None:
             pulumi.set(__self__, "user_defined_fields", user_defined_fields)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -252,18 +248,6 @@ class RegionSecurityPolicyArgs:
     def user_defined_fields(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]]]):
         pulumi.set(self, "user_defined_fields", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class RegionSecurityPolicy(pulumi.CustomResource):
     @overload
@@ -286,7 +270,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
                  user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyUserDefinedFieldArgs']]]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new policy in the specified project using the data included in the request.
@@ -302,7 +285,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['RegionSecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyUserDefinedFieldArgs']]]] user_defined_fields: Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -344,7 +326,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
                  user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyUserDefinedFieldArgs']]]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -372,7 +353,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
             __props__.__dict__["rules"] = rules
             __props__.__dict__["type"] = type
             __props__.__dict__["user_defined_fields"] = user_defined_fields
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -429,7 +409,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         __props__.__dict__["self_link_with_id"] = None
         __props__.__dict__["type"] = None
         __props__.__dict__["user_defined_fields"] = None
-        __props__.__dict__["validate_only"] = None
         return RegionSecurityPolicy(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -602,12 +581,4 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
         """
         return pulumi.get(self, "user_defined_fields")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/alpha/security_policy.py
+++ b/sdk/python/pulumi_google_native/compute/alpha/security_policy.py
@@ -31,8 +31,7 @@ class SecurityPolicyArgs:
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]]] = None,
                  type: Optional[pulumi.Input['SecurityPolicyType']] = None,
-                 user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]]] = None):
         """
         The set of arguments for constructing a SecurityPolicy resource.
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyAssociationArgs']]] associations: A list of associations that belong to this policy.
@@ -44,7 +43,6 @@ class SecurityPolicyArgs:
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['SecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]] user_defined_fields: Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         if adaptive_protection_config is not None:
             pulumi.set(__self__, "adaptive_protection_config", adaptive_protection_config)
@@ -76,8 +74,6 @@ class SecurityPolicyArgs:
             pulumi.set(__self__, "type", type)
         if user_defined_fields is not None:
             pulumi.set(__self__, "user_defined_fields", user_defined_fields)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="adaptiveProtectionConfig")
@@ -241,18 +237,6 @@ class SecurityPolicyArgs:
     def user_defined_fields(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyUserDefinedFieldArgs']]]]):
         pulumi.set(self, "user_defined_fields", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class SecurityPolicy(pulumi.CustomResource):
     @overload
@@ -274,7 +258,6 @@ class SecurityPolicy(pulumi.CustomResource):
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['SecurityPolicyType']] = None,
                  user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyUserDefinedFieldArgs']]]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new policy in the specified project using the data included in the request.
@@ -290,7 +273,6 @@ class SecurityPolicy(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['SecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyUserDefinedFieldArgs']]]] user_defined_fields: Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -331,7 +313,6 @@ class SecurityPolicy(pulumi.CustomResource):
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['SecurityPolicyType']] = None,
                  user_defined_fields: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyUserDefinedFieldArgs']]]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -356,7 +337,6 @@ class SecurityPolicy(pulumi.CustomResource):
             __props__.__dict__["rules"] = rules
             __props__.__dict__["type"] = type
             __props__.__dict__["user_defined_fields"] = user_defined_fields
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -414,7 +394,6 @@ class SecurityPolicy(pulumi.CustomResource):
         __props__.__dict__["self_link_with_id"] = None
         __props__.__dict__["type"] = None
         __props__.__dict__["user_defined_fields"] = None
-        __props__.__dict__["validate_only"] = None
         return SecurityPolicy(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -590,12 +569,4 @@ class SecurityPolicy(pulumi.CustomResource):
         Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies. A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits. Rules may then specify matching values for these fields. Example: userDefinedFields: - name: "ipv4_fragment_offset" base: IPV4 offset: 6 size: 2 mask: "0x1fff"
         """
         return pulumi.get(self, "user_defined_fields")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/beta/interconnect_attachment.py
+++ b/sdk/python/pulumi_google_native/compute/beta/interconnect_attachment.py
@@ -40,7 +40,6 @@ class InterconnectAttachmentArgs:
                  router: Optional[pulumi.Input[str]] = None,
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None):
         """
         The set of arguments for constructing a InterconnectAttachment resource.
@@ -65,7 +64,6 @@ class InterconnectAttachmentArgs:
         :param pulumi.Input[str] router: URL of the Cloud Router to be used for dynamic routing. This router must be in the same region as this InterconnectAttachment. The InterconnectAttachment will automatically connect the Interconnect to the network & region within which the Cloud Router is configured.
         :param pulumi.Input['InterconnectAttachmentStackType'] stack_type: The stack type for this interconnect attachment to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. This field can be both set at interconnect attachments creation and update interconnect attachment operations.
         :param pulumi.Input['InterconnectAttachmentType'] type: The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         :param pulumi.Input[int] vlan_tag8021q: The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         """
         pulumi.set(__self__, "region", region)
@@ -113,8 +111,6 @@ class InterconnectAttachmentArgs:
             pulumi.set(__self__, "stack_type", stack_type)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
         if vlan_tag8021q is not None:
             pulumi.set(__self__, "vlan_tag8021q", vlan_tag8021q)
 
@@ -389,18 +385,6 @@ class InterconnectAttachmentArgs:
         pulumi.set(self, "type", value)
 
     @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
-    @property
     @pulumi.getter(name="vlanTag8021q")
     def vlan_tag8021q(self) -> Optional[pulumi.Input[int]]:
         """
@@ -441,7 +425,6 @@ class InterconnectAttachment(pulumi.CustomResource):
                  router: Optional[pulumi.Input[str]] = None,
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -470,7 +453,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         :param pulumi.Input[str] router: URL of the Cloud Router to be used for dynamic routing. This router must be in the same region as this InterconnectAttachment. The InterconnectAttachment will automatically connect the Interconnect to the network & region within which the Cloud Router is configured.
         :param pulumi.Input['InterconnectAttachmentStackType'] stack_type: The stack type for this interconnect attachment to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. This field can be both set at interconnect attachments creation and update interconnect attachment operations.
         :param pulumi.Input['InterconnectAttachmentType'] type: The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         :param pulumi.Input[int] vlan_tag8021q: The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         """
         ...
@@ -520,7 +502,6 @@ class InterconnectAttachment(pulumi.CustomResource):
                  router: Optional[pulumi.Input[str]] = None,
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -556,7 +537,6 @@ class InterconnectAttachment(pulumi.CustomResource):
             __props__.__dict__["router"] = router
             __props__.__dict__["stack_type"] = stack_type
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["vlan_tag8021q"] = vlan_tag8021q
             __props__.__dict__["cloud_router_ip_address"] = None
             __props__.__dict__["cloud_router_ipv6_address"] = None
@@ -633,7 +613,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         __props__.__dict__["stack_type"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["vlan_tag8021q"] = None
         return InterconnectAttachment(resource_name, opts=opts, __props__=__props__)
 
@@ -926,14 +905,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="vlanTag8021q")

--- a/sdk/python/pulumi_google_native/compute/beta/network_edge_security_service.py
+++ b/sdk/python/pulumi_google_native/compute/beta/network_edge_security_service.py
@@ -19,15 +19,13 @@ class NetworkEdgeSecurityServiceArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 security_policy: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a NetworkEdgeSecurityService resource.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] name: Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[str] security_policy: The resource URL for the network edge security service associated with this network edge security service.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         pulumi.set(__self__, "region", region)
         if description is not None:
@@ -40,8 +38,6 @@ class NetworkEdgeSecurityServiceArgs:
             pulumi.set(__self__, "request_id", request_id)
         if security_policy is not None:
             pulumi.set(__self__, "security_policy", security_policy)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -109,18 +105,6 @@ class NetworkEdgeSecurityServiceArgs:
     def security_policy(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "security_policy", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class NetworkEdgeSecurityService(pulumi.CustomResource):
     @overload
@@ -133,7 +117,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
                  region: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new service in the specified project using the data included in the request.
@@ -144,7 +127,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[str] security_policy: The resource URL for the network edge security service associated with this network edge security service.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -176,7 +158,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
                  region: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -194,7 +175,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
             __props__.__dict__["region"] = region
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["security_policy"] = security_policy
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -235,7 +215,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         __props__.__dict__["security_policy"] = None
         __props__.__dict__["self_link"] = None
         __props__.__dict__["self_link_with_id"] = None
-        __props__.__dict__["validate_only"] = None
         return NetworkEdgeSecurityService(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -319,12 +298,4 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         Server-defined URL for this resource with the resource id.
         """
         return pulumi.get(self, "self_link_with_id")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/beta/region_security_policy.py
+++ b/sdk/python/pulumi_google_native/compute/beta/region_security_policy.py
@@ -30,8 +30,7 @@ class RegionSecurityPolicyArgs:
                  recaptcha_options_config: Optional[pulumi.Input['SecurityPolicyRecaptchaOptionsConfigArgs']] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]]] = None,
-                 type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None):
         """
         The set of arguments for constructing a RegionSecurityPolicy resource.
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyAssociationArgs']]] associations: A list of associations that belong to this policy.
@@ -42,7 +41,6 @@ class RegionSecurityPolicyArgs:
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['RegionSecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         pulumi.set(__self__, "region", region)
         if adaptive_protection_config is not None:
@@ -71,8 +69,6 @@ class RegionSecurityPolicyArgs:
             pulumi.set(__self__, "rules", rules)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -224,18 +220,6 @@ class RegionSecurityPolicyArgs:
     def type(self, value: Optional[pulumi.Input['RegionSecurityPolicyType']]):
         pulumi.set(self, "type", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class RegionSecurityPolicy(pulumi.CustomResource):
     @overload
@@ -256,7 +240,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new policy in the specified project using the data included in the request.
@@ -271,7 +254,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['RegionSecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -311,7 +293,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -337,7 +318,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["rules"] = rules
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -392,7 +372,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         __props__.__dict__["self_link"] = None
         __props__.__dict__["self_link_with_id"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         return RegionSecurityPolicy(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -552,12 +531,4 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/beta/security_policy.py
+++ b/sdk/python/pulumi_google_native/compute/beta/security_policy.py
@@ -29,8 +29,7 @@ class SecurityPolicyArgs:
                  recaptcha_options_config: Optional[pulumi.Input['SecurityPolicyRecaptchaOptionsConfigArgs']] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]]] = None,
-                 type: Optional[pulumi.Input['SecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 type: Optional[pulumi.Input['SecurityPolicyType']] = None):
         """
         The set of arguments for constructing a SecurityPolicy resource.
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyAssociationArgs']]] associations: A list of associations that belong to this policy.
@@ -41,7 +40,6 @@ class SecurityPolicyArgs:
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['SecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         if adaptive_protection_config is not None:
             pulumi.set(__self__, "adaptive_protection_config", adaptive_protection_config)
@@ -69,8 +67,6 @@ class SecurityPolicyArgs:
             pulumi.set(__self__, "rules", rules)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="adaptiveProtectionConfig")
@@ -213,18 +209,6 @@ class SecurityPolicyArgs:
     def type(self, value: Optional[pulumi.Input['SecurityPolicyType']]):
         pulumi.set(self, "type", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class SecurityPolicy(pulumi.CustomResource):
     @overload
@@ -244,7 +228,6 @@ class SecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['SecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new policy in the specified project using the data included in the request.
@@ -259,7 +242,6 @@ class SecurityPolicy(pulumi.CustomResource):
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['SecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -298,7 +280,6 @@ class SecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['SecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -321,7 +302,6 @@ class SecurityPolicy(pulumi.CustomResource):
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["rules"] = rules
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -377,7 +357,6 @@ class SecurityPolicy(pulumi.CustomResource):
         __props__.__dict__["self_link"] = None
         __props__.__dict__["self_link_with_id"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         return SecurityPolicy(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -540,12 +519,4 @@ class SecurityPolicy(pulumi.CustomResource):
         The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/v1/interconnect_attachment.py
+++ b/sdk/python/pulumi_google_native/compute/v1/interconnect_attachment.py
@@ -39,7 +39,6 @@ class InterconnectAttachmentArgs:
                  router: Optional[pulumi.Input[str]] = None,
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None):
         """
         The set of arguments for constructing a InterconnectAttachment resource.
@@ -63,7 +62,6 @@ class InterconnectAttachmentArgs:
         :param pulumi.Input[str] router: URL of the Cloud Router to be used for dynamic routing. This router must be in the same region as this InterconnectAttachment. The InterconnectAttachment will automatically connect the Interconnect to the network & region within which the Cloud Router is configured.
         :param pulumi.Input['InterconnectAttachmentStackType'] stack_type: The stack type for this interconnect attachment to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. This field can be both set at interconnect attachments creation and update interconnect attachment operations.
         :param pulumi.Input['InterconnectAttachmentType'] type: The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         :param pulumi.Input[int] vlan_tag8021q: The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         """
         pulumi.set(__self__, "region", region)
@@ -109,8 +107,6 @@ class InterconnectAttachmentArgs:
             pulumi.set(__self__, "stack_type", stack_type)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
         if vlan_tag8021q is not None:
             pulumi.set(__self__, "vlan_tag8021q", vlan_tag8021q)
 
@@ -373,18 +369,6 @@ class InterconnectAttachmentArgs:
         pulumi.set(self, "type", value)
 
     @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
-    @property
     @pulumi.getter(name="vlanTag8021q")
     def vlan_tag8021q(self) -> Optional[pulumi.Input[int]]:
         """
@@ -424,7 +408,6 @@ class InterconnectAttachment(pulumi.CustomResource):
                  router: Optional[pulumi.Input[str]] = None,
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -452,7 +435,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         :param pulumi.Input[str] router: URL of the Cloud Router to be used for dynamic routing. This router must be in the same region as this InterconnectAttachment. The InterconnectAttachment will automatically connect the Interconnect to the network & region within which the Cloud Router is configured.
         :param pulumi.Input['InterconnectAttachmentStackType'] stack_type: The stack type for this interconnect attachment to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. This field can be both set at interconnect attachments creation and update interconnect attachment operations.
         :param pulumi.Input['InterconnectAttachmentType'] type: The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         :param pulumi.Input[int] vlan_tag8021q: The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4093. Only specified at creation time.
         """
         ...
@@ -501,7 +483,6 @@ class InterconnectAttachment(pulumi.CustomResource):
                  router: Optional[pulumi.Input[str]] = None,
                  stack_type: Optional[pulumi.Input['InterconnectAttachmentStackType']] = None,
                  type: Optional[pulumi.Input['InterconnectAttachmentType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  vlan_tag8021q: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -536,7 +517,6 @@ class InterconnectAttachment(pulumi.CustomResource):
             __props__.__dict__["router"] = router
             __props__.__dict__["stack_type"] = stack_type
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["vlan_tag8021q"] = vlan_tag8021q
             __props__.__dict__["cloud_router_ip_address"] = None
             __props__.__dict__["cloud_router_ipv6_address"] = None
@@ -610,7 +590,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         __props__.__dict__["stack_type"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["vlan_tag8021q"] = None
         return InterconnectAttachment(resource_name, opts=opts, __props__=__props__)
 
@@ -887,14 +866,6 @@ class InterconnectAttachment(pulumi.CustomResource):
         The type of interconnect attachment this is, which can take one of the following values: - DEDICATED: an attachment to a Dedicated Interconnect. - PARTNER: an attachment to a Partner Interconnect, created by the customer. - PARTNER_PROVIDER: an attachment to a Partner Interconnect, created by the partner. 
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="vlanTag8021q")

--- a/sdk/python/pulumi_google_native/compute/v1/network_edge_security_service.py
+++ b/sdk/python/pulumi_google_native/compute/v1/network_edge_security_service.py
@@ -19,15 +19,13 @@ class NetworkEdgeSecurityServiceArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 security_policy: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a NetworkEdgeSecurityService resource.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
         :param pulumi.Input[str] name: Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[str] security_policy: The resource URL for the network edge security service associated with this network edge security service.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         pulumi.set(__self__, "region", region)
         if description is not None:
@@ -40,8 +38,6 @@ class NetworkEdgeSecurityServiceArgs:
             pulumi.set(__self__, "request_id", request_id)
         if security_policy is not None:
             pulumi.set(__self__, "security_policy", security_policy)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -109,18 +105,6 @@ class NetworkEdgeSecurityServiceArgs:
     def security_policy(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "security_policy", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class NetworkEdgeSecurityService(pulumi.CustomResource):
     @overload
@@ -133,7 +117,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
                  region: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new service in the specified project using the data included in the request.
@@ -144,7 +127,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         :param pulumi.Input[str] name: Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[str] security_policy: The resource URL for the network edge security service associated with this network edge security service.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -176,7 +158,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
                  region: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  security_policy: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -194,7 +175,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
             __props__.__dict__["region"] = region
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["security_policy"] = security_policy
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -235,7 +215,6 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         __props__.__dict__["security_policy"] = None
         __props__.__dict__["self_link"] = None
         __props__.__dict__["self_link_with_id"] = None
-        __props__.__dict__["validate_only"] = None
         return NetworkEdgeSecurityService(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -319,12 +298,4 @@ class NetworkEdgeSecurityService(pulumi.CustomResource):
         Server-defined URL for this resource with the resource id.
         """
         return pulumi.get(self, "self_link_with_id")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/v1/region_security_policy.py
+++ b/sdk/python/pulumi_google_native/compute/v1/region_security_policy.py
@@ -27,8 +27,7 @@ class RegionSecurityPolicyArgs:
                  recaptcha_options_config: Optional[pulumi.Input['SecurityPolicyRecaptchaOptionsConfigArgs']] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]]] = None,
-                 type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None):
         """
         The set of arguments for constructing a RegionSecurityPolicy resource.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
@@ -36,7 +35,6 @@ class RegionSecurityPolicyArgs:
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['RegionSecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         pulumi.set(__self__, "region", region)
         if adaptive_protection_config is not None:
@@ -59,8 +57,6 @@ class RegionSecurityPolicyArgs:
             pulumi.set(__self__, "rules", rules)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -176,18 +172,6 @@ class RegionSecurityPolicyArgs:
     def type(self, value: Optional[pulumi.Input['RegionSecurityPolicyType']]):
         pulumi.set(self, "type", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class RegionSecurityPolicy(pulumi.CustomResource):
     @overload
@@ -205,7 +189,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new policy in the specified project using the data included in the request.
@@ -217,7 +200,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['RegionSecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -254,7 +236,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['RegionSecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -277,7 +258,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["rules"] = rules
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -321,7 +301,6 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         __props__.__dict__["rules"] = None
         __props__.__dict__["self_link"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         return RegionSecurityPolicy(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -425,12 +404,4 @@ class RegionSecurityPolicy(pulumi.CustomResource):
         The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/compute/v1/security_policy.py
+++ b/sdk/python/pulumi_google_native/compute/v1/security_policy.py
@@ -26,8 +26,7 @@ class SecurityPolicyArgs:
                  recaptcha_options_config: Optional[pulumi.Input['SecurityPolicyRecaptchaOptionsConfigArgs']] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]]] = None,
-                 type: Optional[pulumi.Input['SecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 type: Optional[pulumi.Input['SecurityPolicyType']] = None):
         """
         The set of arguments for constructing a SecurityPolicy resource.
         :param pulumi.Input[str] description: An optional description of this resource. Provide this property when you create the resource.
@@ -35,7 +34,6 @@ class SecurityPolicyArgs:
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input['SecurityPolicyRuleArgs']]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['SecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         if adaptive_protection_config is not None:
             pulumi.set(__self__, "adaptive_protection_config", adaptive_protection_config)
@@ -57,8 +55,6 @@ class SecurityPolicyArgs:
             pulumi.set(__self__, "rules", rules)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="adaptiveProtectionConfig")
@@ -165,18 +161,6 @@ class SecurityPolicyArgs:
     def type(self, value: Optional[pulumi.Input['SecurityPolicyType']]):
         pulumi.set(self, "type", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class SecurityPolicy(pulumi.CustomResource):
     @overload
@@ -193,7 +177,6 @@ class SecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['SecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new policy in the specified project using the data included in the request.
@@ -205,7 +188,6 @@ class SecurityPolicy(pulumi.CustomResource):
         :param pulumi.Input[str] request_id: An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported ( 00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]] rules: A list of rules that belong to this policy. There must always be a default rule which is a rule with priority 2147483647 and match all condition (for the match condition this means match "*" for srcIpRanges and for the networkMatch condition every field must be either match "*" or not set). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
         :param pulumi.Input['SecurityPolicyType'] type: The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
-        :param pulumi.Input[bool] validate_only: If true, the request will not be committed.
         """
         ...
     @overload
@@ -241,7 +223,6 @@ class SecurityPolicy(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecurityPolicyRuleArgs']]]]] = None,
                  type: Optional[pulumi.Input['SecurityPolicyType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -261,7 +242,6 @@ class SecurityPolicy(pulumi.CustomResource):
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["rules"] = rules
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["creation_timestamp"] = None
             __props__.__dict__["fingerprint"] = None
             __props__.__dict__["kind"] = None
@@ -306,7 +286,6 @@ class SecurityPolicy(pulumi.CustomResource):
         __props__.__dict__["rules"] = None
         __props__.__dict__["self_link"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         return SecurityPolicy(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -413,12 +392,4 @@ class SecurityPolicy(pulumi.CustomResource):
         The type indicates the intended use of the security policy. - CLOUD_ARMOR: Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache. - CLOUD_ARMOR_INTERNAL_SERVICE: Cloud Armor internal service policies can be configured to filter HTTP requests targeting services managed by Traffic Director in a service mesh. They filter requests before the request is served from the application. - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application. This field can be set only at resource creation time.
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, the request will not be committed.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/datamigration/v1/connection_profile.py
+++ b/sdk/python/pulumi_google_native/datamigration/v1/connection_profile.py
@@ -31,8 +31,7 @@ class ConnectionProfileArgs:
                  provider: Optional[pulumi.Input['ConnectionProfileProvider']] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  skip_validation: Optional[pulumi.Input[bool]] = None,
-                 state: Optional[pulumi.Input['ConnectionProfileState']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 state: Optional[pulumi.Input['ConnectionProfileState']] = None):
         """
         The set of arguments for constructing a ConnectionProfile resource.
         :param pulumi.Input[str] connection_profile_id: Required. The connection profile identifier.
@@ -48,7 +47,6 @@ class ConnectionProfileArgs:
         :param pulumi.Input[str] request_id: Optional. A unique ID used to identify the request. If the server receives two requests with the same ID, then the second request is ignored. It is recommended to always set this value to a UUID. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.
         :param pulumi.Input[bool] skip_validation: Optional. Create the connection profile without validating it. The default is false. Only supported for Oracle connection profiles.
         :param pulumi.Input['ConnectionProfileState'] state: The current connection profile state (e.g. DRAFT, READY, or FAILED).
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
         """
         pulumi.set(__self__, "connection_profile_id", connection_profile_id)
         if alloydb is not None:
@@ -79,8 +77,6 @@ class ConnectionProfileArgs:
             pulumi.set(__self__, "skip_validation", skip_validation)
         if state is not None:
             pulumi.set(__self__, "state", state)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="connectionProfileId")
@@ -256,18 +252,6 @@ class ConnectionProfileArgs:
     def state(self, value: Optional[pulumi.Input['ConnectionProfileState']]):
         pulumi.set(self, "state", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class ConnectionProfile(pulumi.CustomResource):
     @overload
@@ -289,7 +273,6 @@ class ConnectionProfile(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  skip_validation: Optional[pulumi.Input[bool]] = None,
                  state: Optional[pulumi.Input['ConnectionProfileState']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new connection profile in a given project and location.
@@ -309,7 +292,6 @@ class ConnectionProfile(pulumi.CustomResource):
         :param pulumi.Input[str] request_id: Optional. A unique ID used to identify the request. If the server receives two requests with the same ID, then the second request is ignored. It is recommended to always set this value to a UUID. The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), and hyphens (-). The maximum length is 40 characters.
         :param pulumi.Input[bool] skip_validation: Optional. Create the connection profile without validating it. The default is false. Only supported for Oracle connection profiles.
         :param pulumi.Input['ConnectionProfileState'] state: The current connection profile state (e.g. DRAFT, READY, or FAILED).
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
         """
         ...
     @overload
@@ -350,7 +332,6 @@ class ConnectionProfile(pulumi.CustomResource):
                  request_id: Optional[pulumi.Input[str]] = None,
                  skip_validation: Optional[pulumi.Input[bool]] = None,
                  state: Optional[pulumi.Input['ConnectionProfileState']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -377,7 +358,6 @@ class ConnectionProfile(pulumi.CustomResource):
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["skip_validation"] = skip_validation
             __props__.__dict__["state"] = state
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["error"] = None
             __props__.__dict__["update_time"] = None
@@ -423,7 +403,6 @@ class ConnectionProfile(pulumi.CustomResource):
         __props__.__dict__["skip_validation"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return ConnectionProfile(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -563,12 +542,4 @@ class ConnectionProfile(pulumi.CustomResource):
         The timestamp when the resource was last updated. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the connection profile, but don't create any resources. The default is false. Only supported for Oracle connection profiles.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/asset.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/asset.py
@@ -26,7 +26,6 @@ class AssetArgs:
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Asset resource.
@@ -36,7 +35,6 @@ class AssetArgs:
         :param pulumi.Input['GoogleCloudDataplexV1AssetDiscoverySpecArgs'] discovery_spec: Optional. Specification of the discovery feature applied to data referenced by this asset. When this spec is left unset, the asset will use the spec set on the parent zone.
         :param pulumi.Input[str] display_name: Optional. User friendly display name.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the asset.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "asset_id", asset_id)
         pulumi.set(__self__, "lake_id", lake_id)
@@ -53,8 +51,6 @@ class AssetArgs:
             pulumi.set(__self__, "location", location)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
         if zone is not None:
             pulumi.set(__self__, "zone", zone)
 
@@ -158,18 +154,6 @@ class AssetArgs:
         pulumi.set(self, "project", value)
 
     @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
-    @property
     @pulumi.getter
     def zone(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "zone")
@@ -193,7 +177,6 @@ class Asset(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  resource_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1AssetResourceSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -208,7 +191,6 @@ class Asset(pulumi.CustomResource):
         :param pulumi.Input[str] display_name: Optional. User friendly display name.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the asset.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1AssetResourceSpecArgs']] resource_spec: Specification of the resource that is referenced by this asset.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -244,7 +226,6 @@ class Asset(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  resource_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1AssetResourceSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -270,7 +251,6 @@ class Asset(pulumi.CustomResource):
             if resource_spec is None and not opts.urn:
                 raise TypeError("Missing required property 'resource_spec'")
             __props__.__dict__["resource_spec"] = resource_spec
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["zone"] = zone
             __props__.__dict__["create_time"] = None
             __props__.__dict__["discovery_status"] = None
@@ -321,7 +301,6 @@ class Asset(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["zone"] = None
         return Asset(resource_name, opts=opts, __props__=__props__)
 
@@ -451,14 +430,6 @@ class Asset(pulumi.CustomResource):
         The time when the asset was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumi_google_native/dataplex/v1/attribute.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/attribute.py
@@ -26,8 +26,7 @@ class AttributeArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  parent_id: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 resource_access_spec: Optional[pulumi.Input['GoogleCloudDataplexV1ResourceAccessSpecArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 resource_access_spec: Optional[pulumi.Input['GoogleCloudDataplexV1ResourceAccessSpecArgs']] = None):
         """
         The set of arguments for constructing a Attribute resource.
         :param pulumi.Input[str] data_attribute_id: Required. DataAttribute identifier. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must be between 1-63 characters. * Must end with a number or a letter. * Must be unique within the DataTaxonomy.
@@ -38,7 +37,6 @@ class AttributeArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the DataAttribute.
         :param pulumi.Input[str] parent_id: Optional. The ID of the parent DataAttribute resource, should belong to the same data taxonomy. Circular dependency in parent chain is not valid. Maximum depth of the hierarchy allowed is 4. a -> b -> c -> d -> e, depth = 4
         :param pulumi.Input['GoogleCloudDataplexV1ResourceAccessSpecArgs'] resource_access_spec: Optional. Specified when applied to a resource (eg: Cloud Storage bucket, BigQuery dataset, BigQuery table).
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "data_attribute_id", data_attribute_id)
         pulumi.set(__self__, "data_taxonomy_id", data_taxonomy_id)
@@ -60,8 +58,6 @@ class AttributeArgs:
             pulumi.set(__self__, "project", project)
         if resource_access_spec is not None:
             pulumi.set(__self__, "resource_access_spec", resource_access_spec)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="dataAttributeId")
@@ -186,18 +182,6 @@ class AttributeArgs:
     def resource_access_spec(self, value: Optional[pulumi.Input['GoogleCloudDataplexV1ResourceAccessSpecArgs']]):
         pulumi.set(self, "resource_access_spec", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Attribute(pulumi.CustomResource):
     @overload
@@ -215,7 +199,6 @@ class Attribute(pulumi.CustomResource):
                  parent_id: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  resource_access_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ResourceAccessSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a DataAttribute resource.
@@ -231,7 +214,6 @@ class Attribute(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the DataAttribute.
         :param pulumi.Input[str] parent_id: Optional. The ID of the parent DataAttribute resource, should belong to the same data taxonomy. Circular dependency in parent chain is not valid. Maximum depth of the hierarchy allowed is 4. a -> b -> c -> d -> e, depth = 4
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ResourceAccessSpecArgs']] resource_access_spec: Optional. Specified when applied to a resource (eg: Cloud Storage bucket, BigQuery dataset, BigQuery table).
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -269,7 +251,6 @@ class Attribute(pulumi.CustomResource):
                  parent_id: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  resource_access_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ResourceAccessSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -294,7 +275,6 @@ class Attribute(pulumi.CustomResource):
             __props__.__dict__["parent_id"] = parent_id
             __props__.__dict__["project"] = project
             __props__.__dict__["resource_access_spec"] = resource_access_spec
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["attribute_count"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["name"] = None
@@ -340,7 +320,6 @@ class Attribute(pulumi.CustomResource):
         __props__.__dict__["resource_access_spec"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Attribute(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -461,12 +440,4 @@ class Attribute(pulumi.CustomResource):
         The time when the DataAttribute was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/content.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/content.py
@@ -25,8 +25,7 @@ class ContentArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  notebook: Optional[pulumi.Input['GoogleCloudDataplexV1ContentNotebookArgs']] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 sql_script: Optional[pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 sql_script: Optional[pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs']] = None):
         """
         The set of arguments for constructing a Content resource.
         :param pulumi.Input[str] data_text: Content data in string format.
@@ -35,7 +34,6 @@ class ContentArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the content.
         :param pulumi.Input['GoogleCloudDataplexV1ContentNotebookArgs'] notebook: Notebook related configurations.
         :param pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs'] sql_script: Sql Script related configurations.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "data_text", data_text)
         pulumi.set(__self__, "lake_id", lake_id)
@@ -52,8 +50,6 @@ class ContentArgs:
             pulumi.set(__self__, "project", project)
         if sql_script is not None:
             pulumi.set(__self__, "sql_script", sql_script)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="dataText")
@@ -154,18 +150,6 @@ class ContentArgs:
     def sql_script(self, value: Optional[pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs']]):
         pulumi.set(self, "sql_script", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Content(pulumi.CustomResource):
     @overload
@@ -181,7 +165,6 @@ class Content(pulumi.CustomResource):
                  path: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  sql_script: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentSqlScriptArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a content.
@@ -195,7 +178,6 @@ class Content(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentNotebookArgs']] notebook: Notebook related configurations.
         :param pulumi.Input[str] path: The path for the Content file, represented as directory structure. Unique within a lake. Limited to alphanumerics, hyphens, underscores, dots and slashes.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentSqlScriptArgs']] sql_script: Sql Script related configurations.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -231,7 +213,6 @@ class Content(pulumi.CustomResource):
                  path: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  sql_script: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentSqlScriptArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -256,7 +237,6 @@ class Content(pulumi.CustomResource):
             __props__.__dict__["path"] = path
             __props__.__dict__["project"] = project
             __props__.__dict__["sql_script"] = sql_script
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["name"] = None
             __props__.__dict__["uid"] = None
@@ -298,7 +278,6 @@ class Content(pulumi.CustomResource):
         __props__.__dict__["sql_script"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Content(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -395,12 +374,4 @@ class Content(pulumi.CustomResource):
         The time when the content was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/contentitem.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/contentitem.py
@@ -25,8 +25,7 @@ class ContentitemArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  notebook: Optional[pulumi.Input['GoogleCloudDataplexV1ContentNotebookArgs']] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 sql_script: Optional[pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 sql_script: Optional[pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs']] = None):
         """
         The set of arguments for constructing a Contentitem resource.
         :param pulumi.Input[str] data_text: Content data in string format.
@@ -35,7 +34,6 @@ class ContentitemArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the content.
         :param pulumi.Input['GoogleCloudDataplexV1ContentNotebookArgs'] notebook: Notebook related configurations.
         :param pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs'] sql_script: Sql Script related configurations.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "data_text", data_text)
         pulumi.set(__self__, "lake_id", lake_id)
@@ -52,8 +50,6 @@ class ContentitemArgs:
             pulumi.set(__self__, "project", project)
         if sql_script is not None:
             pulumi.set(__self__, "sql_script", sql_script)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="dataText")
@@ -154,18 +150,6 @@ class ContentitemArgs:
     def sql_script(self, value: Optional[pulumi.Input['GoogleCloudDataplexV1ContentSqlScriptArgs']]):
         pulumi.set(self, "sql_script", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Contentitem(pulumi.CustomResource):
     @overload
@@ -181,7 +165,6 @@ class Contentitem(pulumi.CustomResource):
                  path: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  sql_script: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentSqlScriptArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a content.
@@ -195,7 +178,6 @@ class Contentitem(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentNotebookArgs']] notebook: Notebook related configurations.
         :param pulumi.Input[str] path: The path for the Content file, represented as directory structure. Unique within a lake. Limited to alphanumerics, hyphens, underscores, dots and slashes.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentSqlScriptArgs']] sql_script: Sql Script related configurations.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -231,7 +213,6 @@ class Contentitem(pulumi.CustomResource):
                  path: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  sql_script: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ContentSqlScriptArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -256,7 +237,6 @@ class Contentitem(pulumi.CustomResource):
             __props__.__dict__["path"] = path
             __props__.__dict__["project"] = project
             __props__.__dict__["sql_script"] = sql_script
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["name"] = None
             __props__.__dict__["uid"] = None
@@ -298,7 +278,6 @@ class Contentitem(pulumi.CustomResource):
         __props__.__dict__["sql_script"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Contentitem(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -395,12 +374,4 @@ class Contentitem(pulumi.CustomResource):
         The time when the content was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/data_attribute_binding.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/data_attribute_binding.py
@@ -25,8 +25,7 @@ class DataAttributeBindingArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  paths: Optional[pulumi.Input[Sequence[pulumi.Input['GoogleCloudDataplexV1DataAttributeBindingPathArgs']]]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 resource: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 resource: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a DataAttributeBinding resource.
         :param pulumi.Input[str] data_attribute_binding_id: Required. DataAttributeBinding identifier. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must be between 1-63 characters. * Must end with a number or a letter. * Must be unique within the Location.
@@ -37,7 +36,6 @@ class DataAttributeBindingArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the DataAttributeBinding.
         :param pulumi.Input[Sequence[pulumi.Input['GoogleCloudDataplexV1DataAttributeBindingPathArgs']]] paths: Optional. The list of paths for items within the associated resource (eg. columns and partitions within a table) along with attribute bindings.
         :param pulumi.Input[str] resource: Optional. Immutable. The resource name of the resource that is associated to attributes. Presently, only entity resource is supported in the form: projects/{project}/locations/{location}/lakes/{lake}/zones/{zone}/entities/{entity_id} Must belong in the same project and region as the attribute binding, and there can only exist one active binding for a resource.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "data_attribute_binding_id", data_attribute_binding_id)
         if attributes is not None:
@@ -58,8 +56,6 @@ class DataAttributeBindingArgs:
             pulumi.set(__self__, "project", project)
         if resource is not None:
             pulumi.set(__self__, "resource", resource)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="dataAttributeBindingId")
@@ -175,18 +171,6 @@ class DataAttributeBindingArgs:
     def resource(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "resource", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class DataAttributeBinding(pulumi.CustomResource):
     @overload
@@ -203,7 +187,6 @@ class DataAttributeBinding(pulumi.CustomResource):
                  paths: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1DataAttributeBindingPathArgs']]]]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  resource: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a DataAttributeBinding resource.
@@ -219,7 +202,6 @@ class DataAttributeBinding(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the DataAttributeBinding.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1DataAttributeBindingPathArgs']]]] paths: Optional. The list of paths for items within the associated resource (eg. columns and partitions within a table) along with attribute bindings.
         :param pulumi.Input[str] resource: Optional. Immutable. The resource name of the resource that is associated to attributes. Presently, only entity resource is supported in the form: projects/{project}/locations/{location}/lakes/{lake}/zones/{zone}/entities/{entity_id} Must belong in the same project and region as the attribute binding, and there can only exist one active binding for a resource.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -256,7 +238,6 @@ class DataAttributeBinding(pulumi.CustomResource):
                  paths: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1DataAttributeBindingPathArgs']]]]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  resource: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -278,7 +259,6 @@ class DataAttributeBinding(pulumi.CustomResource):
             __props__.__dict__["paths"] = paths
             __props__.__dict__["project"] = project
             __props__.__dict__["resource"] = resource
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["name"] = None
             __props__.__dict__["uid"] = None
@@ -321,7 +301,6 @@ class DataAttributeBinding(pulumi.CustomResource):
         __props__.__dict__["resource"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return DataAttributeBinding(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -429,12 +408,4 @@ class DataAttributeBinding(pulumi.CustomResource):
         The time when the DataAttributeBinding was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/data_scan.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/data_scan.py
@@ -26,8 +26,7 @@ class DataScanArgs:
                  execution_spec: Optional[pulumi.Input['GoogleCloudDataplexV1DataScanExecutionSpecArgs']] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a DataScan resource.
         :param pulumi.Input['GoogleCloudDataplexV1DataSourceArgs'] data: The data source for DataScan.
@@ -38,7 +37,6 @@ class DataScanArgs:
         :param pulumi.Input[str] display_name: Optional. User friendly display name. Must be between 1-256 characters.
         :param pulumi.Input['GoogleCloudDataplexV1DataScanExecutionSpecArgs'] execution_spec: Optional. DataScan execution settings.If not specified, the fields in it will use their default values.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the scan.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "data", data)
         pulumi.set(__self__, "data_scan_id", data_scan_id)
@@ -58,8 +56,6 @@ class DataScanArgs:
             pulumi.set(__self__, "location", location)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter
@@ -175,18 +171,6 @@ class DataScanArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class DataScan(pulumi.CustomResource):
     @overload
@@ -203,7 +187,6 @@ class DataScan(pulumi.CustomResource):
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a DataScan resource.
@@ -219,7 +202,6 @@ class DataScan(pulumi.CustomResource):
         :param pulumi.Input[str] display_name: Optional. User friendly display name. Must be between 1-256 characters.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1DataScanExecutionSpecArgs']] execution_spec: Optional. DataScan execution settings.If not specified, the fields in it will use their default values.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the scan.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -256,7 +238,6 @@ class DataScan(pulumi.CustomResource):
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -280,7 +261,6 @@ class DataScan(pulumi.CustomResource):
             __props__.__dict__["labels"] = labels
             __props__.__dict__["location"] = location
             __props__.__dict__["project"] = project
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["data_profile_result"] = None
             __props__.__dict__["data_quality_result"] = None
@@ -333,7 +313,6 @@ class DataScan(pulumi.CustomResource):
         __props__.__dict__["type"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return DataScan(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -481,12 +460,4 @@ class DataScan(pulumi.CustomResource):
         The time when the scan was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/data_taxonomy.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/data_taxonomy.py
@@ -20,8 +20,7 @@ class DataTaxonomyArgs:
                  etag: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a DataTaxonomy resource.
         :param pulumi.Input[str] data_taxonomy_id: Required. DataTaxonomy identifier. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must be between 1-63 characters. * Must end with a number or a letter. * Must be unique within the Project.
@@ -29,7 +28,6 @@ class DataTaxonomyArgs:
         :param pulumi.Input[str] display_name: Optional. User friendly display name.
         :param pulumi.Input[str] etag: This checksum is computed by the server based on the value of other fields, and may be sent on update and delete requests to ensure the client has an up-to-date value before proceeding.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the DataTaxonomy.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "data_taxonomy_id", data_taxonomy_id)
         if description is not None:
@@ -44,8 +42,6 @@ class DataTaxonomyArgs:
             pulumi.set(__self__, "location", location)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="dataTaxonomyId")
@@ -125,18 +121,6 @@ class DataTaxonomyArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class DataTaxonomy(pulumi.CustomResource):
     @overload
@@ -150,7 +134,6 @@ class DataTaxonomy(pulumi.CustomResource):
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a DataTaxonomy resource.
@@ -163,7 +146,6 @@ class DataTaxonomy(pulumi.CustomResource):
         :param pulumi.Input[str] display_name: Optional. User friendly display name.
         :param pulumi.Input[str] etag: This checksum is computed by the server based on the value of other fields, and may be sent on update and delete requests to ensure the client has an up-to-date value before proceeding.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the DataTaxonomy.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -197,7 +179,6 @@ class DataTaxonomy(pulumi.CustomResource):
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -216,7 +197,6 @@ class DataTaxonomy(pulumi.CustomResource):
             __props__.__dict__["labels"] = labels
             __props__.__dict__["location"] = location
             __props__.__dict__["project"] = project
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["attribute_count"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["name"] = None
@@ -258,7 +238,6 @@ class DataTaxonomy(pulumi.CustomResource):
         __props__.__dict__["project"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return DataTaxonomy(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -350,12 +329,4 @@ class DataTaxonomy(pulumi.CustomResource):
         The time when the DataTaxonomy was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/entity.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/entity.py
@@ -31,7 +31,6 @@ class EntityArgs:
                  etag: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Entity resource.
@@ -46,7 +45,6 @@ class EntityArgs:
         :param pulumi.Input[str] description: Optional. User friendly longer description text. Must be shorter than or equal to 1024 characters.
         :param pulumi.Input[str] display_name: Optional. Display name must be shorter than or equal to 256 characters.
         :param pulumi.Input[str] etag: Optional. The etag associated with the entity, which can be retrieved with a GetEntity request. Required for update and delete requests.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "asset", asset)
         pulumi.set(__self__, "data_path", data_path)
@@ -68,8 +66,6 @@ class EntityArgs:
             pulumi.set(__self__, "location", location)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
         if zone is not None:
             pulumi.set(__self__, "zone", zone)
 
@@ -233,18 +229,6 @@ class EntityArgs:
         pulumi.set(self, "project", value)
 
     @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
-    @property
     @pulumi.getter
     def zone(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "zone")
@@ -273,7 +257,6 @@ class Entity(pulumi.CustomResource):
                  schema: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1SchemaArgs']]] = None,
                  system: Optional[pulumi.Input['EntitySystem']] = None,
                  type: Optional[pulumi.Input['EntityType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -293,7 +276,6 @@ class Entity(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1SchemaArgs']] schema: The description of the data structure and layout. The schema is not included in list responses. It is only included in SCHEMA and FULL entity views of a GetEntity response.
         :param pulumi.Input['EntitySystem'] system: Immutable. Identifies the storage system of the entity data.
         :param pulumi.Input['EntityType'] type: Immutable. The type of entity.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -334,7 +316,6 @@ class Entity(pulumi.CustomResource):
                  schema: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1SchemaArgs']]] = None,
                  system: Optional[pulumi.Input['EntitySystem']] = None,
                  type: Optional[pulumi.Input['EntityType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -375,7 +356,6 @@ class Entity(pulumi.CustomResource):
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["zone"] = zone
             __props__.__dict__["access"] = None
             __props__.__dict__["catalog_entry"] = None
@@ -428,7 +408,6 @@ class Entity(pulumi.CustomResource):
         __props__.__dict__["type"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["zone"] = None
         return Entity(resource_name, opts=opts, __props__=__props__)
 
@@ -582,14 +561,6 @@ class Entity(pulumi.CustomResource):
         The time when the entity was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumi_google_native/dataplex/v1/environment.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/environment.py
@@ -24,8 +24,7 @@ class EnvironmentArgs:
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 session_spec: Optional[pulumi.Input['GoogleCloudDataplexV1EnvironmentSessionSpecArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 session_spec: Optional[pulumi.Input['GoogleCloudDataplexV1EnvironmentSessionSpecArgs']] = None):
         """
         The set of arguments for constructing a Environment resource.
         :param pulumi.Input[str] environment_id: Required. Environment identifier. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must be between 1-63 characters. * Must end with a number or a letter. * Must be unique within the lake.
@@ -34,7 +33,6 @@ class EnvironmentArgs:
         :param pulumi.Input[str] display_name: Optional. User friendly display name.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the environment.
         :param pulumi.Input['GoogleCloudDataplexV1EnvironmentSessionSpecArgs'] session_spec: Optional. Configuration for sessions created for this environment.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "environment_id", environment_id)
         pulumi.set(__self__, "infrastructure_spec", infrastructure_spec)
@@ -51,8 +49,6 @@ class EnvironmentArgs:
             pulumi.set(__self__, "project", project)
         if session_spec is not None:
             pulumi.set(__self__, "session_spec", session_spec)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="environmentId")
@@ -153,18 +149,6 @@ class EnvironmentArgs:
     def session_spec(self, value: Optional[pulumi.Input['GoogleCloudDataplexV1EnvironmentSessionSpecArgs']]):
         pulumi.set(self, "session_spec", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Environment(pulumi.CustomResource):
     @overload
@@ -180,7 +164,6 @@ class Environment(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  session_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1EnvironmentSessionSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create an environment resource.
@@ -194,7 +177,6 @@ class Environment(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1EnvironmentInfrastructureSpecArgs']] infrastructure_spec: Infrastructure specification for the Environment.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the environment.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1EnvironmentSessionSpecArgs']] session_spec: Optional. Configuration for sessions created for this environment.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -230,7 +212,6 @@ class Environment(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  session_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1EnvironmentSessionSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -255,7 +236,6 @@ class Environment(pulumi.CustomResource):
             __props__.__dict__["location"] = location
             __props__.__dict__["project"] = project
             __props__.__dict__["session_spec"] = session_spec
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["endpoints"] = None
             __props__.__dict__["name"] = None
@@ -303,7 +283,6 @@ class Environment(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Environment(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -424,12 +403,4 @@ class Environment(pulumi.CustomResource):
         The time when the environment was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/lake.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/lake.py
@@ -22,8 +22,7 @@ class LakeArgs:
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  metastore: Optional[pulumi.Input['GoogleCloudDataplexV1LakeMetastoreArgs']] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Lake resource.
         :param pulumi.Input[str] lake_id: Required. Lake identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique within the customer project / location.
@@ -31,7 +30,6 @@ class LakeArgs:
         :param pulumi.Input[str] display_name: Optional. User friendly display name.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the lake.
         :param pulumi.Input['GoogleCloudDataplexV1LakeMetastoreArgs'] metastore: Optional. Settings to manage lake and Dataproc Metastore service instance association.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "lake_id", lake_id)
         if description is not None:
@@ -46,8 +44,6 @@ class LakeArgs:
             pulumi.set(__self__, "metastore", metastore)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="lakeId")
@@ -127,18 +123,6 @@ class LakeArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Lake(pulumi.CustomResource):
     @overload
@@ -152,7 +136,6 @@ class Lake(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  metastore: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1LakeMetastoreArgs']]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a lake resource.
@@ -165,7 +148,6 @@ class Lake(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the lake.
         :param pulumi.Input[str] lake_id: Required. Lake identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique within the customer project / location.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1LakeMetastoreArgs']] metastore: Optional. Settings to manage lake and Dataproc Metastore service instance association.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -199,7 +181,6 @@ class Lake(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  metastore: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1LakeMetastoreArgs']]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -218,7 +199,6 @@ class Lake(pulumi.CustomResource):
             __props__.__dict__["location"] = location
             __props__.__dict__["metastore"] = metastore
             __props__.__dict__["project"] = project
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["asset_status"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["metastore_status"] = None
@@ -266,7 +246,6 @@ class Lake(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Lake(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -382,12 +361,4 @@ class Lake(pulumi.CustomResource):
         The time when the lake was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/partition.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/partition.py
@@ -20,14 +20,12 @@ class PartitionArgs:
                  etag: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Partition resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] values: Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
         :param pulumi.Input[str] etag: Optional. The etag for this partition.
         :param pulumi.Input[str] location: Immutable. The location of the entity data within the partition, for example, gs://bucket/path/to/entity/key1=value1/key2=value2. Or projects//datasets//tables/
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "entity_id", entity_id)
         pulumi.set(__self__, "lake_id", lake_id)
@@ -38,8 +36,6 @@ class PartitionArgs:
             pulumi.set(__self__, "location", location)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
         if zone is not None:
             pulumi.set(__self__, "zone", zone)
 
@@ -107,18 +103,6 @@ class PartitionArgs:
         pulumi.set(self, "project", value)
 
     @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
-    @property
     @pulumi.getter
     def zone(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "zone")
@@ -138,7 +122,6 @@ class Partition(pulumi.CustomResource):
                  lake_id: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  values: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  zone: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -150,7 +133,6 @@ class Partition(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] etag: Optional. The etag for this partition.
         :param pulumi.Input[str] location: Immutable. The location of the entity data within the partition, for example, gs://bucket/path/to/entity/key1=value1/key2=value2. Or projects//datasets//tables/
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] values: Immutable. The set of values representing the partition, which correspond to the partition schema defined in the parent entity.
         """
         ...
@@ -183,7 +165,6 @@ class Partition(pulumi.CustomResource):
                  lake_id: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  values: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  zone: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -204,7 +185,6 @@ class Partition(pulumi.CustomResource):
             __props__.__dict__["lake_id"] = lake_id
             __props__.__dict__["location"] = location
             __props__.__dict__["project"] = project
-            __props__.__dict__["validate_only"] = validate_only
             if values is None and not opts.urn:
                 raise TypeError("Missing required property 'values'")
             __props__.__dict__["values"] = values
@@ -240,7 +220,6 @@ class Partition(pulumi.CustomResource):
         __props__.__dict__["location"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["project"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["values"] = None
         __props__.__dict__["zone"] = None
         return Partition(resource_name, opts=opts, __props__=__props__)
@@ -280,14 +259,6 @@ class Partition(pulumi.CustomResource):
     @pulumi.getter
     def project(self) -> pulumi.Output[str]:
         return pulumi.get(self, "project")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumi_google_native/dataplex/v1/task.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/task.py
@@ -27,8 +27,7 @@ class TaskArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  notebook: Optional[pulumi.Input['GoogleCloudDataplexV1TaskNotebookTaskConfigArgs']] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 spark: Optional[pulumi.Input['GoogleCloudDataplexV1TaskSparkTaskConfigArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 spark: Optional[pulumi.Input['GoogleCloudDataplexV1TaskSparkTaskConfigArgs']] = None):
         """
         The set of arguments for constructing a Task resource.
         :param pulumi.Input['GoogleCloudDataplexV1TaskExecutionSpecArgs'] execution_spec: Spec related to how a task is executed.
@@ -39,7 +38,6 @@ class TaskArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User-defined labels for the task.
         :param pulumi.Input['GoogleCloudDataplexV1TaskNotebookTaskConfigArgs'] notebook: Config related to running scheduled Notebooks.
         :param pulumi.Input['GoogleCloudDataplexV1TaskSparkTaskConfigArgs'] spark: Config related to running custom Spark tasks.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "execution_spec", execution_spec)
         pulumi.set(__self__, "lake_id", lake_id)
@@ -59,8 +57,6 @@ class TaskArgs:
             pulumi.set(__self__, "project", project)
         if spark is not None:
             pulumi.set(__self__, "spark", spark)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="executionSpec")
@@ -185,18 +181,6 @@ class TaskArgs:
     def spark(self, value: Optional[pulumi.Input['GoogleCloudDataplexV1TaskSparkTaskConfigArgs']]):
         pulumi.set(self, "spark", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Task(pulumi.CustomResource):
     @overload
@@ -214,7 +198,6 @@ class Task(pulumi.CustomResource):
                  spark: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1TaskSparkTaskConfigArgs']]] = None,
                  task_id: Optional[pulumi.Input[str]] = None,
                  trigger_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1TaskTriggerSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a task resource within a lake.
@@ -230,7 +213,6 @@ class Task(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1TaskSparkTaskConfigArgs']] spark: Config related to running custom Spark tasks.
         :param pulumi.Input[str] task_id: Required. Task identifier.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1TaskTriggerSpecArgs']] trigger_spec: Spec related to how often and when a task should be triggered.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         ...
     @overload
@@ -268,7 +250,6 @@ class Task(pulumi.CustomResource):
                  spark: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1TaskSparkTaskConfigArgs']]] = None,
                  task_id: Optional[pulumi.Input[str]] = None,
                  trigger_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1TaskTriggerSpecArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -297,7 +278,6 @@ class Task(pulumi.CustomResource):
             if trigger_spec is None and not opts.urn:
                 raise TypeError("Missing required property 'trigger_spec'")
             __props__.__dict__["trigger_spec"] = trigger_spec
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["execution_status"] = None
             __props__.__dict__["name"] = None
@@ -345,7 +325,6 @@ class Task(pulumi.CustomResource):
         __props__.__dict__["trigger_spec"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Task(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -474,12 +453,4 @@ class Task(pulumi.CustomResource):
         The time when the task was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/dataplex/v1/zone.py
+++ b/sdk/python/pulumi_google_native/dataplex/v1/zone.py
@@ -26,8 +26,7 @@ class ZoneArgs:
                  display_name: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Zone resource.
         :param pulumi.Input['GoogleCloudDataplexV1ZoneResourceSpecArgs'] resource_spec: Specification of the resources that are referenced by the assets within this zone.
@@ -37,7 +36,6 @@ class ZoneArgs:
         :param pulumi.Input['GoogleCloudDataplexV1ZoneDiscoverySpecArgs'] discovery_spec: Optional. Specification of the discovery feature applied to data in this zone.
         :param pulumi.Input[str] display_name: Optional. User friendly display name.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the zone.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         """
         pulumi.set(__self__, "lake_id", lake_id)
         pulumi.set(__self__, "resource_spec", resource_spec)
@@ -55,8 +53,6 @@ class ZoneArgs:
             pulumi.set(__self__, "location", location)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="lakeId")
@@ -169,18 +165,6 @@ class ZoneArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Zone(pulumi.CustomResource):
     @overload
@@ -196,7 +180,6 @@ class Zone(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  resource_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ZoneResourceSpecArgs']]] = None,
                  type: Optional[pulumi.Input['ZoneType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -211,7 +194,6 @@ class Zone(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User defined labels for the zone.
         :param pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ZoneResourceSpecArgs']] resource_spec: Specification of the resources that are referenced by the assets within this zone.
         :param pulumi.Input['ZoneType'] type: Immutable. The type of the zone.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the request, but do not perform mutations. The default is false.
         :param pulumi.Input[str] zone_id: Required. Zone identifier. This ID will be used to generate names such as database and dataset names when publishing metadata to Hive Metastore and BigQuery. * Must contain only lowercase letters, numbers and hyphens. * Must start with a letter. * Must end with a number or a letter. * Must be between 1-63 characters. * Must be unique across all lakes from all locations in a project. * Must not be one of the reserved IDs (i.e. "default", "global-temp")
         """
         ...
@@ -248,7 +230,6 @@ class Zone(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  resource_spec: Optional[pulumi.Input[pulumi.InputType['GoogleCloudDataplexV1ZoneResourceSpecArgs']]] = None,
                  type: Optional[pulumi.Input['ZoneType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  zone_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -274,7 +255,6 @@ class Zone(pulumi.CustomResource):
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             if zone_id is None and not opts.urn:
                 raise TypeError("Missing required property 'zone_id'")
             __props__.__dict__["zone_id"] = zone_id
@@ -323,7 +303,6 @@ class Zone(pulumi.CustomResource):
         __props__.__dict__["type"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["zone_id"] = None
         return Zone(resource_name, opts=opts, __props__=__props__)
 
@@ -437,14 +416,6 @@ class Zone(pulumi.CustomResource):
         The time when the zone was last updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the request, but do not perform mutations. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="zoneId")

--- a/sdk/python/pulumi_google_native/datastream/v1/connection_profile.py
+++ b/sdk/python/pulumi_google_native/datastream/v1/connection_profile.py
@@ -30,8 +30,7 @@ class ConnectionProfileArgs:
                  private_connectivity: Optional[pulumi.Input['PrivateConnectivityArgs']] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 static_service_ip_connectivity: Optional[pulumi.Input['StaticServiceIpConnectivityArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 static_service_ip_connectivity: Optional[pulumi.Input['StaticServiceIpConnectivityArgs']] = None):
         """
         The set of arguments for constructing a ConnectionProfile resource.
         :param pulumi.Input[str] connection_profile_id: Required. The connection profile identifier.
@@ -47,7 +46,6 @@ class ConnectionProfileArgs:
         :param pulumi.Input['PrivateConnectivityArgs'] private_connectivity: Private connectivity.
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['StaticServiceIpConnectivityArgs'] static_service_ip_connectivity: Static Service IP connectivity.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the connection profile, but don't create any resources. The default is false.
         """
         pulumi.set(__self__, "connection_profile_id", connection_profile_id)
         pulumi.set(__self__, "display_name", display_name)
@@ -77,8 +75,6 @@ class ConnectionProfileArgs:
             pulumi.set(__self__, "request_id", request_id)
         if static_service_ip_connectivity is not None:
             pulumi.set(__self__, "static_service_ip_connectivity", static_service_ip_connectivity)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="connectionProfileId")
@@ -254,18 +250,6 @@ class ConnectionProfileArgs:
     def static_service_ip_connectivity(self, value: Optional[pulumi.Input['StaticServiceIpConnectivityArgs']]):
         pulumi.set(self, "static_service_ip_connectivity", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the connection profile, but don't create any resources. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class ConnectionProfile(pulumi.CustomResource):
     @overload
@@ -287,7 +271,6 @@ class ConnectionProfile(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  static_service_ip_connectivity: Optional[pulumi.Input[pulumi.InputType['StaticServiceIpConnectivityArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Use this method to create a connection profile in a project and location.
@@ -308,7 +291,6 @@ class ConnectionProfile(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['PrivateConnectivityArgs']] private_connectivity: Private connectivity.
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input[pulumi.InputType['StaticServiceIpConnectivityArgs']] static_service_ip_connectivity: Static Service IP connectivity.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the connection profile, but don't create any resources. The default is false.
         """
         ...
     @overload
@@ -350,7 +332,6 @@ class ConnectionProfile(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  static_service_ip_connectivity: Optional[pulumi.Input[pulumi.InputType['StaticServiceIpConnectivityArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -379,7 +360,6 @@ class ConnectionProfile(pulumi.CustomResource):
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["static_service_ip_connectivity"] = static_service_ip_connectivity
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["name"] = None
             __props__.__dict__["update_time"] = None
@@ -425,7 +405,6 @@ class ConnectionProfile(pulumi.CustomResource):
         __props__.__dict__["request_id"] = None
         __props__.__dict__["static_service_ip_connectivity"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return ConnectionProfile(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -565,12 +544,4 @@ class ConnectionProfile(pulumi.CustomResource):
         The update time of the resource.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the connection profile, but don't create any resources. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/datastream/v1/stream.py
+++ b/sdk/python/pulumi_google_native/datastream/v1/stream.py
@@ -29,8 +29,7 @@ class StreamArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 state: Optional[pulumi.Input['StreamState']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 state: Optional[pulumi.Input['StreamState']] = None):
         """
         The set of arguments for constructing a Stream resource.
         :param pulumi.Input['DestinationConfigArgs'] destination_config: Destination connection profile configuration.
@@ -44,7 +43,6 @@ class StreamArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels.
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['StreamState'] state: The state of the stream.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the stream, but don't create any resources. The default is false.
         """
         pulumi.set(__self__, "destination_config", destination_config)
         pulumi.set(__self__, "display_name", display_name)
@@ -68,8 +66,6 @@ class StreamArgs:
             pulumi.set(__self__, "request_id", request_id)
         if state is not None:
             pulumi.set(__self__, "state", state)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="destinationConfig")
@@ -221,18 +217,6 @@ class StreamArgs:
     def state(self, value: Optional[pulumi.Input['StreamState']]):
         pulumi.set(self, "state", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the stream, but don't create any resources. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Stream(pulumi.CustomResource):
     @overload
@@ -252,7 +236,6 @@ class Stream(pulumi.CustomResource):
                  source_config: Optional[pulumi.Input[pulumi.InputType['SourceConfigArgs']]] = None,
                  state: Optional[pulumi.Input['StreamState']] = None,
                  stream_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Use this method to create a stream.
@@ -271,7 +254,6 @@ class Stream(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['SourceConfigArgs']] source_config: Source connection profile configuration.
         :param pulumi.Input['StreamState'] state: The state of the stream.
         :param pulumi.Input[str] stream_id: Required. The stream identifier.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the stream, but don't create any resources. The default is false.
         """
         ...
     @overload
@@ -311,7 +293,6 @@ class Stream(pulumi.CustomResource):
                  source_config: Optional[pulumi.Input[pulumi.InputType['SourceConfigArgs']]] = None,
                  state: Optional[pulumi.Input['StreamState']] = None,
                  stream_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -342,7 +323,6 @@ class Stream(pulumi.CustomResource):
             if stream_id is None and not opts.urn:
                 raise TypeError("Missing required property 'stream_id'")
             __props__.__dict__["stream_id"] = stream_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["errors"] = None
             __props__.__dict__["name"] = None
@@ -388,7 +368,6 @@ class Stream(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["stream_id"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Stream(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -520,12 +499,4 @@ class Stream(pulumi.CustomResource):
         The last update time of the stream.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the stream, but don't create any resources. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/datastream/v1alpha1/stream.py
+++ b/sdk/python/pulumi_google_native/datastream/v1alpha1/stream.py
@@ -29,8 +29,7 @@ class StreamArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 state: Optional[pulumi.Input['StreamState']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 state: Optional[pulumi.Input['StreamState']] = None):
         """
         The set of arguments for constructing a Stream resource.
         :param pulumi.Input['DestinationConfigArgs'] destination_config: Destination connection profile configuration.
@@ -44,7 +43,6 @@ class StreamArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Labels.
         :param pulumi.Input[str] request_id: Optional. A request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['StreamState'] state: The state of the stream.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the stream, but do not create any resources. The default is false.
         """
         pulumi.set(__self__, "destination_config", destination_config)
         pulumi.set(__self__, "display_name", display_name)
@@ -68,8 +66,6 @@ class StreamArgs:
             pulumi.set(__self__, "request_id", request_id)
         if state is not None:
             pulumi.set(__self__, "state", state)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="destinationConfig")
@@ -221,18 +217,6 @@ class StreamArgs:
     def state(self, value: Optional[pulumi.Input['StreamState']]):
         pulumi.set(self, "state", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. Only validate the stream, but do not create any resources. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Stream(pulumi.CustomResource):
     @overload
@@ -252,7 +236,6 @@ class Stream(pulumi.CustomResource):
                  source_config: Optional[pulumi.Input[pulumi.InputType['SourceConfigArgs']]] = None,
                  state: Optional[pulumi.Input['StreamState']] = None,
                  stream_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Use this method to create a stream.
@@ -271,7 +254,6 @@ class Stream(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['SourceConfigArgs']] source_config: Source connection profile configuration.
         :param pulumi.Input['StreamState'] state: The state of the stream.
         :param pulumi.Input[str] stream_id: Required. The stream identifier.
-        :param pulumi.Input[bool] validate_only: Optional. Only validate the stream, but do not create any resources. The default is false.
         """
         ...
     @overload
@@ -311,7 +293,6 @@ class Stream(pulumi.CustomResource):
                  source_config: Optional[pulumi.Input[pulumi.InputType['SourceConfigArgs']]] = None,
                  state: Optional[pulumi.Input['StreamState']] = None,
                  stream_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -342,7 +323,6 @@ class Stream(pulumi.CustomResource):
             if stream_id is None and not opts.urn:
                 raise TypeError("Missing required property 'stream_id'")
             __props__.__dict__["stream_id"] = stream_id
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["errors"] = None
             __props__.__dict__["name"] = None
@@ -388,7 +368,6 @@ class Stream(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["stream_id"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Stream(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -520,12 +499,4 @@ class Stream(pulumi.CustomResource):
         The last update time of the stream.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. Only validate the stream, but do not create any resources. The default is false.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/eventarc/v1/channel.py
+++ b/sdk/python/pulumi_google_native/eventarc/v1/channel.py
@@ -15,7 +15,6 @@ __all__ = ['ChannelArgs', 'Channel']
 class ChannelArgs:
     def __init__(__self__, *,
                  channel_id: pulumi.Input[str],
-                 validate_only: pulumi.Input[bool],
                  crypto_key_name: Optional[pulumi.Input[str]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
@@ -24,13 +23,11 @@ class ChannelArgs:
         """
         The set of arguments for constructing a Channel resource.
         :param pulumi.Input[str] channel_id: Required. The user-provided ID to be assigned to the channel.
-        :param pulumi.Input[bool] validate_only: Required. If set, validate the request and preview the review, but do not post it.
         :param pulumi.Input[str] crypto_key_name: Resource name of a KMS crypto key (managed by the user) used to encrypt/decrypt their event data. It must match the pattern `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
         :param pulumi.Input[str] name: The resource name of the channel. Must be unique within the location on the project and must be in `projects/{project}/locations/{location}/channels/{channel_id}` format.
         :param pulumi.Input[str] provider: The name of the event provider (e.g. Eventarc SaaS partner) associated with the channel. This provider will be granted permissions to publish events to the channel. Format: `projects/{project}/locations/{location}/providers/{provider_id}`.
         """
         pulumi.set(__self__, "channel_id", channel_id)
-        pulumi.set(__self__, "validate_only", validate_only)
         if crypto_key_name is not None:
             pulumi.set(__self__, "crypto_key_name", crypto_key_name)
         if location is not None:
@@ -53,18 +50,6 @@ class ChannelArgs:
     @channel_id.setter
     def channel_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "channel_id", value)
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Input[bool]:
-        """
-        Required. If set, validate the request and preview the review, but do not post it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: pulumi.Input[bool]):
-        pulumi.set(self, "validate_only", value)
 
     @property
     @pulumi.getter(name="cryptoKeyName")
@@ -132,7 +117,6 @@ class Channel(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  provider: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a new channel in a particular project and location.
@@ -143,7 +127,6 @@ class Channel(pulumi.CustomResource):
         :param pulumi.Input[str] crypto_key_name: Resource name of a KMS crypto key (managed by the user) used to encrypt/decrypt their event data. It must match the pattern `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
         :param pulumi.Input[str] name: The resource name of the channel. Must be unique within the location on the project and must be in `projects/{project}/locations/{location}/channels/{channel_id}` format.
         :param pulumi.Input[str] provider: The name of the event provider (e.g. Eventarc SaaS partner) associated with the channel. This provider will be granted permissions to publish events to the channel. Format: `projects/{project}/locations/{location}/providers/{provider_id}`.
-        :param pulumi.Input[bool] validate_only: Required. If set, validate the request and preview the review, but do not post it.
         """
         ...
     @overload
@@ -175,7 +158,6 @@ class Channel(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  provider: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -193,16 +175,13 @@ class Channel(pulumi.CustomResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
             __props__.__dict__["provider"] = provider
-            if validate_only is None and not opts.urn:
-                raise TypeError("Missing required property 'validate_only'")
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["activation_token"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["pubsub_topic"] = None
             __props__.__dict__["state"] = None
             __props__.__dict__["uid"] = None
             __props__.__dict__["update_time"] = None
-        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["channel_id", "location", "project", "validate_only"])
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["channel_id", "location", "project"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(Channel, __self__).__init__(
             'google-native:eventarc/v1:Channel',
@@ -238,7 +217,6 @@ class Channel(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Channel(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -330,12 +308,4 @@ class Channel(pulumi.CustomResource):
         The last-modified time.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[bool]:
-        """
-        Required. If set, validate the request and preview the review, but do not post it.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/eventarc/v1/trigger.py
+++ b/sdk/python/pulumi_google_native/eventarc/v1/trigger.py
@@ -19,7 +19,6 @@ class TriggerArgs:
                  destination: pulumi.Input['DestinationArgs'],
                  event_filters: pulumi.Input[Sequence[pulumi.Input['EventFilterArgs']]],
                  trigger_id: pulumi.Input[str],
-                 validate_only: pulumi.Input[bool],
                  channel: Optional[pulumi.Input[str]] = None,
                  event_data_content_type: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -33,7 +32,6 @@ class TriggerArgs:
         :param pulumi.Input['DestinationArgs'] destination: Destination specifies where the events should be sent to.
         :param pulumi.Input[Sequence[pulumi.Input['EventFilterArgs']]] event_filters: Unordered list. The list of filters that applies to event attributes. Only events that match all the provided filters are sent to the destination.
         :param pulumi.Input[str] trigger_id: Required. The user-provided ID to be assigned to the trigger.
-        :param pulumi.Input[bool] validate_only: Required. If set, validate the request and preview the review, but do not post it.
         :param pulumi.Input[str] channel: Optional. The name of the channel associated with the trigger in `projects/{project}/locations/{location}/channels/{channel}` format. You must provide a channel to receive events from Eventarc SaaS partners.
         :param pulumi.Input[str] event_data_content_type: Optional. EventDataContentType specifies the type of payload in MIME format that is expected from the CloudEvent data field. This is set to `application/json` if the value is not defined.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User labels attached to the triggers that can be used to group resources.
@@ -44,7 +42,6 @@ class TriggerArgs:
         pulumi.set(__self__, "destination", destination)
         pulumi.set(__self__, "event_filters", event_filters)
         pulumi.set(__self__, "trigger_id", trigger_id)
-        pulumi.set(__self__, "validate_only", validate_only)
         if channel is not None:
             pulumi.set(__self__, "channel", channel)
         if event_data_content_type is not None:
@@ -97,18 +94,6 @@ class TriggerArgs:
     @trigger_id.setter
     def trigger_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "trigger_id", value)
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Input[bool]:
-        """
-        Required. If set, validate the request and preview the review, but do not post it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: pulumi.Input[bool]):
-        pulumi.set(self, "validate_only", value)
 
     @property
     @pulumi.getter
@@ -217,7 +202,6 @@ class Trigger(pulumi.CustomResource):
                  service_account: Optional[pulumi.Input[str]] = None,
                  transport: Optional[pulumi.Input[pulumi.InputType['TransportArgs']]] = None,
                  trigger_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a new trigger in a particular project and location.
@@ -233,7 +217,6 @@ class Trigger(pulumi.CustomResource):
         :param pulumi.Input[str] service_account: Optional. The IAM service account email associated with the trigger. The service account represents the identity of the trigger. The principal who calls this API must have the `iam.serviceAccounts.actAs` permission in the service account. See https://cloud.google.com/iam/docs/understanding-service-accounts?hl=en#sa_common for more information. For Cloud Run destinations, this service account is used to generate identity tokens when invoking the service. See https://cloud.google.com/run/docs/triggering/pubsub-push#create-service-account for information on how to invoke authenticated Cloud Run services. To create Audit Log triggers, the service account should also have the `roles/eventarc.eventReceiver` IAM role.
         :param pulumi.Input[pulumi.InputType['TransportArgs']] transport: Optional. To deliver messages, Eventarc might use other Google Cloud products as a transport intermediary. This field contains a reference to that transport intermediary. This information can be used for debugging purposes.
         :param pulumi.Input[str] trigger_id: Required. The user-provided ID to be assigned to the trigger.
-        :param pulumi.Input[bool] validate_only: Required. If set, validate the request and preview the review, but do not post it.
         """
         ...
     @overload
@@ -270,7 +253,6 @@ class Trigger(pulumi.CustomResource):
                  service_account: Optional[pulumi.Input[str]] = None,
                  transport: Optional[pulumi.Input[pulumi.InputType['TransportArgs']]] = None,
                  trigger_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -297,15 +279,12 @@ class Trigger(pulumi.CustomResource):
             if trigger_id is None and not opts.urn:
                 raise TypeError("Missing required property 'trigger_id'")
             __props__.__dict__["trigger_id"] = trigger_id
-            if validate_only is None and not opts.urn:
-                raise TypeError("Missing required property 'validate_only'")
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["conditions"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["etag"] = None
             __props__.__dict__["uid"] = None
             __props__.__dict__["update_time"] = None
-        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["location", "project", "trigger_id", "validate_only"])
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["location", "project", "trigger_id"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(Trigger, __self__).__init__(
             'google-native:eventarc/v1:Trigger',
@@ -345,7 +324,6 @@ class Trigger(pulumi.CustomResource):
         __props__.__dict__["trigger_id"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Trigger(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -469,12 +447,4 @@ class Trigger(pulumi.CustomResource):
         The last-modified time.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[bool]:
-        """
-        Required. If set, validate the request and preview the review, but do not post it.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/eventarc/v1beta1/trigger.py
+++ b/sdk/python/pulumi_google_native/eventarc/v1beta1/trigger.py
@@ -19,7 +19,6 @@ class TriggerArgs:
                  destination: pulumi.Input['DestinationArgs'],
                  matching_criteria: pulumi.Input[Sequence[pulumi.Input['MatchingCriteriaArgs']]],
                  trigger_id: pulumi.Input[str],
-                 validate_only: pulumi.Input[bool],
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
@@ -30,7 +29,6 @@ class TriggerArgs:
         :param pulumi.Input['DestinationArgs'] destination: Destination specifies where the events should be sent to.
         :param pulumi.Input[Sequence[pulumi.Input['MatchingCriteriaArgs']]] matching_criteria: Unordered list. The criteria by which events are filtered. Only events that match with this criteria will be sent to the destination.
         :param pulumi.Input[str] trigger_id: Required. The user-provided ID to be assigned to the trigger.
-        :param pulumi.Input[bool] validate_only: Required. If set, validate the request and preview the review, but do not actually post it.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Optional. User labels attached to the triggers that can be used to group resources.
         :param pulumi.Input[str] name: The resource name of the trigger. Must be unique within the location on the project and must in `projects/{project}/locations/{location}/triggers/{trigger}` format.
         :param pulumi.Input[str] service_account: Optional. The IAM service account email associated with the trigger. The service account represents the identity of the trigger. The principal who calls this API must have `iam.serviceAccounts.actAs` permission in the service account. See https://cloud.google.com/iam/docs/understanding-service-accounts?hl=en#sa_common for more information. For Cloud Run destinations, this service account is used to generate identity tokens when invoking the service. See https://cloud.google.com/run/docs/triggering/pubsub-push#create-service-account for information on how to invoke authenticated Cloud Run services. In order to create Audit Log triggers, the service account should also have 'eventarc.events.receiveAuditLogV1Written' permission.
@@ -38,7 +36,6 @@ class TriggerArgs:
         pulumi.set(__self__, "destination", destination)
         pulumi.set(__self__, "matching_criteria", matching_criteria)
         pulumi.set(__self__, "trigger_id", trigger_id)
-        pulumi.set(__self__, "validate_only", validate_only)
         if labels is not None:
             pulumi.set(__self__, "labels", labels)
         if location is not None:
@@ -85,18 +82,6 @@ class TriggerArgs:
     @trigger_id.setter
     def trigger_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "trigger_id", value)
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Input[bool]:
-        """
-        Required. If set, validate the request and preview the review, but do not actually post it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: pulumi.Input[bool]):
-        pulumi.set(self, "validate_only", value)
 
     @property
     @pulumi.getter
@@ -166,7 +151,6 @@ class Trigger(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  service_account: Optional[pulumi.Input[str]] = None,
                  trigger_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a new trigger in a particular project and location.
@@ -179,7 +163,6 @@ class Trigger(pulumi.CustomResource):
         :param pulumi.Input[str] name: The resource name of the trigger. Must be unique within the location on the project and must in `projects/{project}/locations/{location}/triggers/{trigger}` format.
         :param pulumi.Input[str] service_account: Optional. The IAM service account email associated with the trigger. The service account represents the identity of the trigger. The principal who calls this API must have `iam.serviceAccounts.actAs` permission in the service account. See https://cloud.google.com/iam/docs/understanding-service-accounts?hl=en#sa_common for more information. For Cloud Run destinations, this service account is used to generate identity tokens when invoking the service. See https://cloud.google.com/run/docs/triggering/pubsub-push#create-service-account for information on how to invoke authenticated Cloud Run services. In order to create Audit Log triggers, the service account should also have 'eventarc.events.receiveAuditLogV1Written' permission.
         :param pulumi.Input[str] trigger_id: Required. The user-provided ID to be assigned to the trigger.
-        :param pulumi.Input[bool] validate_only: Required. If set, validate the request and preview the review, but do not actually post it.
         """
         ...
     @overload
@@ -213,7 +196,6 @@ class Trigger(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  service_account: Optional[pulumi.Input[str]] = None,
                  trigger_id: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -237,14 +219,11 @@ class Trigger(pulumi.CustomResource):
             if trigger_id is None and not opts.urn:
                 raise TypeError("Missing required property 'trigger_id'")
             __props__.__dict__["trigger_id"] = trigger_id
-            if validate_only is None and not opts.urn:
-                raise TypeError("Missing required property 'validate_only'")
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["create_time"] = None
             __props__.__dict__["etag"] = None
             __props__.__dict__["transport"] = None
             __props__.__dict__["update_time"] = None
-        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["location", "project", "trigger_id", "validate_only"])
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["location", "project", "trigger_id"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(Trigger, __self__).__init__(
             'google-native:eventarc/v1beta1:Trigger',
@@ -280,7 +259,6 @@ class Trigger(pulumi.CustomResource):
         __props__.__dict__["transport"] = None
         __props__.__dict__["trigger_id"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Trigger(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -372,12 +350,4 @@ class Trigger(pulumi.CustomResource):
         The last-modified time.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[bool]:
-        """
-        Required. If set, validate the request and preview the review, but do not actually post it.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/firebasedatabase/v1beta/instance.py
+++ b/sdk/python/pulumi_google_native/firebasedatabase/v1beta/instance.py
@@ -19,14 +19,12 @@ class InstanceArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 type: Optional[pulumi.Input['InstanceType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 type: Optional[pulumi.Input['InstanceType']] = None):
         """
         The set of arguments for constructing a Instance resource.
         :param pulumi.Input[str] database_id: The globally unique identifier of the database instance.
         :param pulumi.Input[str] name: The fully qualified resource name of the database instance, in the form: `projects/{project-number}/locations/{location-id}/instances/{database-id}`.
         :param pulumi.Input['InstanceType'] type: Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
-        :param pulumi.Input[bool] validate_only: When set to true, the request will be validated but not submitted.
         """
         if database_id is not None:
             pulumi.set(__self__, "database_id", database_id)
@@ -38,8 +36,6 @@ class InstanceArgs:
             pulumi.set(__self__, "project", project)
         if type is not None:
             pulumi.set(__self__, "type", type)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="databaseId")
@@ -95,18 +91,6 @@ class InstanceArgs:
     def type(self, value: Optional[pulumi.Input['InstanceType']]):
         pulumi.set(self, "type", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        When set to true, the request will be validated but not submitted.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Instance(pulumi.CustomResource):
     @overload
@@ -118,7 +102,6 @@ class Instance(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['InstanceType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Requests that a new DatabaseInstance be created. The state of a successfully created DatabaseInstance is ACTIVE. Only available for projects on the Blaze plan. Projects can be upgraded using the Cloud Billing API https://cloud.google.com/billing/reference/rest/v1/projects/updateBillingInfo. Note that it might take a few minutes for billing enablement state to propagate to Firebase systems.
@@ -128,7 +111,6 @@ class Instance(pulumi.CustomResource):
         :param pulumi.Input[str] database_id: The globally unique identifier of the database instance.
         :param pulumi.Input[str] name: The fully qualified resource name of the database instance, in the form: `projects/{project-number}/locations/{location-id}/instances/{database-id}`.
         :param pulumi.Input['InstanceType'] type: Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
-        :param pulumi.Input[bool] validate_only: When set to true, the request will be validated but not submitted.
         """
         ...
     @overload
@@ -159,7 +141,6 @@ class Instance(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input['InstanceType']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -174,7 +155,6 @@ class Instance(pulumi.CustomResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
             __props__.__dict__["type"] = type
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["database_url"] = None
             __props__.__dict__["state"] = None
         replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["location", "project"])
@@ -208,7 +188,6 @@ class Instance(pulumi.CustomResource):
         __props__.__dict__["project"] = None
         __props__.__dict__["state"] = None
         __props__.__dict__["type"] = None
-        __props__.__dict__["validate_only"] = None
         return Instance(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -260,12 +239,4 @@ class Instance(pulumi.CustomResource):
         Immutable. The database instance type. On creation only USER_DATABASE is allowed, which is also the default when omitted.
         """
         return pulumi.get(self, "type")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        When set to true, the request will be validated but not submitted.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/monitoring/v1/dashboard.py
+++ b/sdk/python/pulumi_google_native/monitoring/v1/dashboard.py
@@ -26,8 +26,7 @@ class DashboardArgs:
                  mosaic_layout: Optional[pulumi.Input['MosaicLayoutArgs']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 row_layout: Optional[pulumi.Input['RowLayoutArgs']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 row_layout: Optional[pulumi.Input['RowLayoutArgs']] = None):
         """
         The set of arguments for constructing a Dashboard resource.
         :param pulumi.Input[str] display_name: The mutable, human-readable name.
@@ -39,7 +38,6 @@ class DashboardArgs:
         :param pulumi.Input['MosaicLayoutArgs'] mosaic_layout: The content is arranged as a grid of tiles, with each content widget occupying one or more grid blocks.
         :param pulumi.Input[str] name: Immutable. The resource name of the dashboard.
         :param pulumi.Input['RowLayoutArgs'] row_layout: The content is divided into equally spaced rows and the widgets are arranged horizontally.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually save it.
         """
         pulumi.set(__self__, "display_name", display_name)
         if column_layout is not None:
@@ -60,8 +58,6 @@ class DashboardArgs:
             pulumi.set(__self__, "project", project)
         if row_layout is not None:
             pulumi.set(__self__, "row_layout", row_layout)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="displayName")
@@ -180,18 +176,6 @@ class DashboardArgs:
     def row_layout(self, value: Optional[pulumi.Input['RowLayoutArgs']]):
         pulumi.set(self, "row_layout", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually save it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Dashboard(pulumi.CustomResource):
     @overload
@@ -208,7 +192,6 @@ class Dashboard(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  row_layout: Optional[pulumi.Input[pulumi.InputType['RowLayoutArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new custom dashboard. For examples on how you can use this API to create dashboards, see Managing dashboards by API (https://cloud.google.com/monitoring/dashboards/api-dashboard). This method requires the monitoring.dashboards.create permission on the specified project. For more information about permissions, see Cloud Identity and Access Management (https://cloud.google.com/iam).
@@ -224,7 +207,6 @@ class Dashboard(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['MosaicLayoutArgs']] mosaic_layout: The content is arranged as a grid of tiles, with each content widget occupying one or more grid blocks.
         :param pulumi.Input[str] name: Immutable. The resource name of the dashboard.
         :param pulumi.Input[pulumi.InputType['RowLayoutArgs']] row_layout: The content is divided into equally spaced rows and the widgets are arranged horizontally.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually save it.
         """
         ...
     @overload
@@ -260,7 +242,6 @@ class Dashboard(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  row_layout: Optional[pulumi.Input[pulumi.InputType['RowLayoutArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -282,7 +263,6 @@ class Dashboard(pulumi.CustomResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
             __props__.__dict__["row_layout"] = row_layout
-            __props__.__dict__["validate_only"] = validate_only
         replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["project"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(Dashboard, __self__).__init__(
@@ -317,7 +297,6 @@ class Dashboard(pulumi.CustomResource):
         __props__.__dict__["name"] = None
         __props__.__dict__["project"] = None
         __props__.__dict__["row_layout"] = None
-        __props__.__dict__["validate_only"] = None
         return Dashboard(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -396,12 +375,4 @@ class Dashboard(pulumi.CustomResource):
         The content is divided into equally spaced rows and the widgets are arranged horizontally.
         """
         return pulumi.get(self, "row_layout")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually save it.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/monitoring/v3/group.py
+++ b/sdk/python/pulumi_google_native/monitoring/v3/group.py
@@ -18,15 +18,13 @@ class GroupArgs:
                  filter: Optional[pulumi.Input[str]] = None,
                  is_cluster: Optional[pulumi.Input[bool]] = None,
                  parent_name: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Group resource.
         :param pulumi.Input[str] display_name: A user-assigned name for this group, used only for display purposes.
         :param pulumi.Input[str] filter: The filter used to determine which monitored resources belong to this group.
         :param pulumi.Input[bool] is_cluster: If true, the members of this group are considered to be a cluster. The system can perform additional analysis on groups that are clusters.
         :param pulumi.Input[str] parent_name: The name of the group's parent, if it has one. The format is: projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID] For groups with no parent, parent_name is the empty string, "".
-        :param pulumi.Input[bool] validate_only: If true, validate this request but do not create the group.
         """
         if display_name is not None:
             pulumi.set(__self__, "display_name", display_name)
@@ -38,8 +36,6 @@ class GroupArgs:
             pulumi.set(__self__, "parent_name", parent_name)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="displayName")
@@ -98,18 +94,6 @@ class GroupArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If true, validate this request but do not create the group.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Group(pulumi.CustomResource):
     @overload
@@ -121,7 +105,6 @@ class Group(pulumi.CustomResource):
                  is_cluster: Optional[pulumi.Input[bool]] = None,
                  parent_name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new group.
@@ -133,7 +116,6 @@ class Group(pulumi.CustomResource):
         :param pulumi.Input[str] filter: The filter used to determine which monitored resources belong to this group.
         :param pulumi.Input[bool] is_cluster: If true, the members of this group are considered to be a cluster. The system can perform additional analysis on groups that are clusters.
         :param pulumi.Input[str] parent_name: The name of the group's parent, if it has one. The format is: projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID] For groups with no parent, parent_name is the empty string, "".
-        :param pulumi.Input[bool] validate_only: If true, validate this request but do not create the group.
         """
         ...
     @overload
@@ -165,7 +147,6 @@ class Group(pulumi.CustomResource):
                  is_cluster: Optional[pulumi.Input[bool]] = None,
                  parent_name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -180,7 +161,6 @@ class Group(pulumi.CustomResource):
             __props__.__dict__["is_cluster"] = is_cluster
             __props__.__dict__["parent_name"] = parent_name
             __props__.__dict__["project"] = project
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["name"] = None
         replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["project"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
@@ -212,7 +192,6 @@ class Group(pulumi.CustomResource):
         __props__.__dict__["name"] = None
         __props__.__dict__["parent_name"] = None
         __props__.__dict__["project"] = None
-        __props__.__dict__["validate_only"] = None
         return Group(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -259,12 +238,4 @@ class Group(pulumi.CustomResource):
     @pulumi.getter
     def project(self) -> pulumi.Output[str]:
         return pulumi.get(self, "project")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If true, validate this request but do not create the group.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/privateca/v1/certificate.py
+++ b/sdk/python/pulumi_google_native/privateca/v1/certificate.py
@@ -28,8 +28,7 @@ class CertificateArgs:
                  pem_csr: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
-                 subject_mode: Optional[pulumi.Input['CertificateSubjectMode']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 subject_mode: Optional[pulumi.Input['CertificateSubjectMode']] = None):
         """
         The set of arguments for constructing a Certificate resource.
         :param pulumi.Input[str] lifetime: Immutable. The desired lifetime of a certificate. Used to create the "not_before_time" and "not_after_time" fields inside an X.509 certificate. Note that the lifetime may be truncated if it would extend past the life of any certificate authority in the issuing chain.
@@ -41,7 +40,6 @@ class CertificateArgs:
         :param pulumi.Input[str] pem_csr: Immutable. A pem-encoded X.509 certificate signing request (CSR).
         :param pulumi.Input[str] request_id: Optional. An ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['CertificateSubjectMode'] subject_mode: Immutable. Specifies how the Certificate's identity fields are to be decided. If this is omitted, the `DEFAULT` subject mode will be used.
-        :param pulumi.Input[bool] validate_only: Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
         """
         pulumi.set(__self__, "ca_pool_id", ca_pool_id)
         pulumi.set(__self__, "lifetime", lifetime)
@@ -65,8 +63,6 @@ class CertificateArgs:
             pulumi.set(__self__, "request_id", request_id)
         if subject_mode is not None:
             pulumi.set(__self__, "subject_mode", subject_mode)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="caPoolId")
@@ -203,18 +199,6 @@ class CertificateArgs:
     def subject_mode(self, value: Optional[pulumi.Input['CertificateSubjectMode']]):
         pulumi.set(self, "subject_mode", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Certificate(pulumi.CustomResource):
     @overload
@@ -233,7 +217,6 @@ class Certificate(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  subject_mode: Optional[pulumi.Input['CertificateSubjectMode']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Create a new Certificate in a given Project, Location from a particular CaPool.
@@ -252,7 +235,6 @@ class Certificate(pulumi.CustomResource):
         :param pulumi.Input[str] pem_csr: Immutable. A pem-encoded X.509 certificate signing request (CSR).
         :param pulumi.Input[str] request_id: Optional. An ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. The server will guarantee that for at least 60 minutes since the first request. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
         :param pulumi.Input['CertificateSubjectMode'] subject_mode: Immutable. Specifies how the Certificate's identity fields are to be decided. If this is omitted, the `DEFAULT` subject mode will be used.
-        :param pulumi.Input[bool] validate_only: Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
         """
         ...
     @overload
@@ -293,7 +275,6 @@ class Certificate(pulumi.CustomResource):
                  project: Optional[pulumi.Input[str]] = None,
                  request_id: Optional[pulumi.Input[str]] = None,
                  subject_mode: Optional[pulumi.Input['CertificateSubjectMode']] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -319,7 +300,6 @@ class Certificate(pulumi.CustomResource):
             __props__.__dict__["project"] = project
             __props__.__dict__["request_id"] = request_id
             __props__.__dict__["subject_mode"] = subject_mode
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["certificate_description"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["issuer_certificate_authority"] = None
@@ -372,7 +352,6 @@ class Certificate(pulumi.CustomResource):
         __props__.__dict__["revocation_details"] = None
         __props__.__dict__["subject_mode"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Certificate(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -525,12 +504,4 @@ class Certificate(pulumi.CustomResource):
         The time at which this Certificate was updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Optional. If this is true, no Certificate resource will be persisted regardless of the CaPool's tier, and the returned Certificate will not contain the pem_certificate field.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/run/v2/job.py
+++ b/sdk/python/pulumi_google_native/run/v2/job.py
@@ -27,8 +27,7 @@ class JobArgs:
                  launch_stage: Optional[pulumi.Input['JobLaunchStage']] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Job resource.
         :param pulumi.Input[str] job_id: Required. The unique identifier for the Job. The name of the job becomes {parent}/jobs/{job_id}.
@@ -40,7 +39,6 @@ class JobArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: KRM-style labels for the resource. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component, environment, state, etc. For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels Cloud Run API v2 does not support labels with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected. All system labels in v1 now have a corresponding field in v2 Job.
         :param pulumi.Input['JobLaunchStage'] launch_stage: The launch stage as defined by [Google Cloud Platform Launch Stages](https://cloud.google.com/terms/launch-stages). Cloud Run supports `ALPHA`, `BETA`, and `GA`. If no value is specified, GA is assumed. Set the launch stage to a preview stage on input to allow use of preview features in that stage. On read (or output), describes whether the resource uses preview features. For example, if ALPHA is provided as input, but only BETA and GA-level features are used, this field will be BETA on output.
         :param pulumi.Input[str] name: The fully qualified name of this Job. Format: projects/{project}/locations/{location}/jobs/{job}
-        :param pulumi.Input[bool] validate_only: Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
         """
         pulumi.set(__self__, "job_id", job_id)
         pulumi.set(__self__, "template", template)
@@ -62,8 +60,6 @@ class JobArgs:
             pulumi.set(__self__, "name", name)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="jobId")
@@ -191,18 +187,6 @@ class JobArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Job(pulumi.CustomResource):
     @overload
@@ -220,7 +204,6 @@ class Job(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  template: Optional[pulumi.Input[pulumi.InputType['GoogleCloudRunV2ExecutionTemplateArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a Job.
@@ -236,7 +219,6 @@ class Job(pulumi.CustomResource):
         :param pulumi.Input['JobLaunchStage'] launch_stage: The launch stage as defined by [Google Cloud Platform Launch Stages](https://cloud.google.com/terms/launch-stages). Cloud Run supports `ALPHA`, `BETA`, and `GA`. If no value is specified, GA is assumed. Set the launch stage to a preview stage on input to allow use of preview features in that stage. On read (or output), describes whether the resource uses preview features. For example, if ALPHA is provided as input, but only BETA and GA-level features are used, this field will be BETA on output.
         :param pulumi.Input[str] name: The fully qualified name of this Job. Format: projects/{project}/locations/{location}/jobs/{job}
         :param pulumi.Input[pulumi.InputType['GoogleCloudRunV2ExecutionTemplateArgs']] template: The template used to create executions for this Job.
-        :param pulumi.Input[bool] validate_only: Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
         """
         ...
     @overload
@@ -273,7 +255,6 @@ class Job(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  template: Optional[pulumi.Input[pulumi.InputType['GoogleCloudRunV2ExecutionTemplateArgs']]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -298,7 +279,6 @@ class Job(pulumi.CustomResource):
             if template is None and not opts.urn:
                 raise TypeError("Missing required property 'template'")
             __props__.__dict__["template"] = template
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["conditions"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["creator"] = None
@@ -366,7 +346,6 @@ class Job(pulumi.CustomResource):
         __props__.__dict__["terminal_condition"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         return Job(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -578,12 +557,4 @@ class Job(pulumi.CustomResource):
         The last-modified time.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/run/v2/service.py
+++ b/sdk/python/pulumi_google_native/run/v2/service.py
@@ -30,8 +30,7 @@ class ServiceArgs:
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 traffic: Optional[pulumi.Input[Sequence[pulumi.Input['GoogleCloudRunV2TrafficTargetArgs']]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 traffic: Optional[pulumi.Input[Sequence[pulumi.Input['GoogleCloudRunV2TrafficTargetArgs']]]] = None):
         """
         The set of arguments for constructing a Service resource.
         :param pulumi.Input[str] service_id: Required. The unique identifier for the Service. It must begin with letter, and cannot end with hyphen; must contain fewer than 50 characters. The name of the service becomes {parent}/services/{service_id}.
@@ -46,7 +45,6 @@ class ServiceArgs:
         :param pulumi.Input['ServiceLaunchStage'] launch_stage: The launch stage as defined by [Google Cloud Platform Launch Stages](https://cloud.google.com/terms/launch-stages). Cloud Run supports `ALPHA`, `BETA`, and `GA`. If no value is specified, GA is assumed. Set the launch stage to a preview stage on input to allow use of preview features in that stage. On read (or output), describes whether the resource uses preview features. For example, if ALPHA is provided as input, but only BETA and GA-level features are used, this field will be BETA on output.
         :param pulumi.Input[str] name: The fully qualified name of this Service. In CreateServiceRequest, this field is ignored, and instead composed from CreateServiceRequest.parent and CreateServiceRequest.service_id. Format: projects/{project}/locations/{location}/services/{service_id}
         :param pulumi.Input[Sequence[pulumi.Input['GoogleCloudRunV2TrafficTargetArgs']]] traffic: Specifies how to distribute traffic over a collection of Revisions belonging to the Service. If traffic is empty or not provided, defaults to 100% traffic to the latest `Ready` Revision.
-        :param pulumi.Input[bool] validate_only: Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
         """
         pulumi.set(__self__, "service_id", service_id)
         pulumi.set(__self__, "template", template)
@@ -74,8 +72,6 @@ class ServiceArgs:
             pulumi.set(__self__, "project", project)
         if traffic is not None:
             pulumi.set(__self__, "traffic", traffic)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="serviceId")
@@ -239,18 +235,6 @@ class ServiceArgs:
     def traffic(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['GoogleCloudRunV2TrafficTargetArgs']]]]):
         pulumi.set(self, "traffic", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Service(pulumi.CustomResource):
     @overload
@@ -271,7 +255,6 @@ class Service(pulumi.CustomResource):
                  service_id: Optional[pulumi.Input[str]] = None,
                  template: Optional[pulumi.Input[pulumi.InputType['GoogleCloudRunV2RevisionTemplateArgs']]] = None,
                  traffic: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['GoogleCloudRunV2TrafficTargetArgs']]]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
         Creates a new Service in a given project and location.
@@ -290,7 +273,6 @@ class Service(pulumi.CustomResource):
         :param pulumi.Input[str] service_id: Required. The unique identifier for the Service. It must begin with letter, and cannot end with hyphen; must contain fewer than 50 characters. The name of the service becomes {parent}/services/{service_id}.
         :param pulumi.Input[pulumi.InputType['GoogleCloudRunV2RevisionTemplateArgs']] template: The template used to create revisions for this Service.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['GoogleCloudRunV2TrafficTargetArgs']]]] traffic: Specifies how to distribute traffic over a collection of Revisions belonging to the Service. If traffic is empty or not provided, defaults to 100% traffic to the latest `Ready` Revision.
-        :param pulumi.Input[bool] validate_only: Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
         """
         ...
     @overload
@@ -330,7 +312,6 @@ class Service(pulumi.CustomResource):
                  service_id: Optional[pulumi.Input[str]] = None,
                  template: Optional[pulumi.Input[pulumi.InputType['GoogleCloudRunV2RevisionTemplateArgs']]] = None,
                  traffic: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['GoogleCloudRunV2TrafficTargetArgs']]]]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -358,7 +339,6 @@ class Service(pulumi.CustomResource):
                 raise TypeError("Missing required property 'template'")
             __props__.__dict__["template"] = template
             __props__.__dict__["traffic"] = traffic
-            __props__.__dict__["validate_only"] = validate_only
             __props__.__dict__["conditions"] = None
             __props__.__dict__["create_time"] = None
             __props__.__dict__["creator"] = None
@@ -433,7 +413,6 @@ class Service(pulumi.CustomResource):
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
         __props__.__dict__["uri"] = None
-        __props__.__dict__["validate_only"] = None
         return Service(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -685,12 +664,4 @@ class Service(pulumi.CustomResource):
         The main URI in which this Service is serving traffic.
         """
         return pulumi.get(self, "uri")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        Indicates that the request should be validated and default values populated, without persisting the request or creating any resources.
-        """
-        return pulumi.get(self, "validate_only")
 

--- a/sdk/python/pulumi_google_native/workstations/v1beta/workstation.py
+++ b/sdk/python/pulumi_google_native/workstations/v1beta/workstation.py
@@ -23,8 +23,7 @@ class WorkstationArgs:
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
-                 project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Workstation resource.
         :param pulumi.Input[str] workstation_id: Required. ID to use for the workstation.
@@ -33,7 +32,6 @@ class WorkstationArgs:
         :param pulumi.Input[str] etag: Checksum computed by the server. May be sent on update and delete requests to ensure that the client has an up-to-date value before proceeding.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Client-specified labels that are applied to the resource and that are also propagated to the underlying Compute Engine resources.
         :param pulumi.Input[str] name: Full name of this resource.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually apply it.
         """
         pulumi.set(__self__, "workstation_cluster_id", workstation_cluster_id)
         pulumi.set(__self__, "workstation_config_id", workstation_config_id)
@@ -52,8 +50,6 @@ class WorkstationArgs:
             pulumi.set(__self__, "name", name)
         if project is not None:
             pulumi.set(__self__, "project", project)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="workstationClusterId")
@@ -163,18 +159,6 @@ class WorkstationArgs:
     def project(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "project", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually apply it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class Workstation(pulumi.CustomResource):
     @overload
@@ -188,7 +172,6 @@ class Workstation(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  workstation_cluster_id: Optional[pulumi.Input[str]] = None,
                  workstation_config_id: Optional[pulumi.Input[str]] = None,
                  workstation_id: Optional[pulumi.Input[str]] = None,
@@ -203,7 +186,6 @@ class Workstation(pulumi.CustomResource):
         :param pulumi.Input[str] etag: Checksum computed by the server. May be sent on update and delete requests to ensure that the client has an up-to-date value before proceeding.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Client-specified labels that are applied to the resource and that are also propagated to the underlying Compute Engine resources.
         :param pulumi.Input[str] name: Full name of this resource.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually apply it.
         :param pulumi.Input[str] workstation_id: Required. ID to use for the workstation.
         """
         ...
@@ -237,7 +219,6 @@ class Workstation(pulumi.CustomResource):
                  location: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  workstation_cluster_id: Optional[pulumi.Input[str]] = None,
                  workstation_config_id: Optional[pulumi.Input[str]] = None,
                  workstation_id: Optional[pulumi.Input[str]] = None,
@@ -257,7 +238,6 @@ class Workstation(pulumi.CustomResource):
             __props__.__dict__["location"] = location
             __props__.__dict__["name"] = name
             __props__.__dict__["project"] = project
-            __props__.__dict__["validate_only"] = validate_only
             if workstation_cluster_id is None and not opts.urn:
                 raise TypeError("Missing required property 'workstation_cluster_id'")
             __props__.__dict__["workstation_cluster_id"] = workstation_cluster_id
@@ -312,7 +292,6 @@ class Workstation(pulumi.CustomResource):
         __props__.__dict__["state"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["workstation_cluster_id"] = None
         __props__.__dict__["workstation_config_id"] = None
         __props__.__dict__["workstation_id"] = None
@@ -423,14 +402,6 @@ class Workstation(pulumi.CustomResource):
         Time when this resource was most recently updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually apply it.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="workstationClusterId")

--- a/sdk/python/pulumi_google_native/workstations/v1beta/workstation_cluster.py
+++ b/sdk/python/pulumi_google_native/workstations/v1beta/workstation_cluster.py
@@ -26,8 +26,7 @@ class WorkstationClusterArgs:
                  network: Optional[pulumi.Input[str]] = None,
                  private_cluster_config: Optional[pulumi.Input['PrivateClusterConfigArgs']] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 subnetwork: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 subnetwork: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a WorkstationCluster resource.
         :param pulumi.Input[str] workstation_cluster_id: Required. ID to use for the workstation cluster.
@@ -39,7 +38,6 @@ class WorkstationClusterArgs:
         :param pulumi.Input[str] network: Immutable. Name of the Compute Engine network in which instances associated with this cluster will be created.
         :param pulumi.Input['PrivateClusterConfigArgs'] private_cluster_config: Configuration for private cluster.
         :param pulumi.Input[str] subnetwork: Immutable. Name of the Compute Engine subnetwork in which instances associated with this cluster will be created. Must be part of the subnetwork specified for this cluster.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually apply it.
         """
         pulumi.set(__self__, "workstation_cluster_id", workstation_cluster_id)
         if annotations is not None:
@@ -62,8 +60,6 @@ class WorkstationClusterArgs:
             pulumi.set(__self__, "project", project)
         if subnetwork is not None:
             pulumi.set(__self__, "subnetwork", subnetwork)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="workstationClusterId")
@@ -191,18 +187,6 @@ class WorkstationClusterArgs:
     def subnetwork(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "subnetwork", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually apply it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class WorkstationCluster(pulumi.CustomResource):
     @overload
@@ -219,7 +203,6 @@ class WorkstationCluster(pulumi.CustomResource):
                  private_cluster_config: Optional[pulumi.Input[pulumi.InputType['PrivateClusterConfigArgs']]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  subnetwork: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  workstation_cluster_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -235,7 +218,6 @@ class WorkstationCluster(pulumi.CustomResource):
         :param pulumi.Input[str] network: Immutable. Name of the Compute Engine network in which instances associated with this cluster will be created.
         :param pulumi.Input[pulumi.InputType['PrivateClusterConfigArgs']] private_cluster_config: Configuration for private cluster.
         :param pulumi.Input[str] subnetwork: Immutable. Name of the Compute Engine subnetwork in which instances associated with this cluster will be created. Must be part of the subnetwork specified for this cluster.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually apply it.
         :param pulumi.Input[str] workstation_cluster_id: Required. ID to use for the workstation cluster.
         """
         ...
@@ -272,7 +254,6 @@ class WorkstationCluster(pulumi.CustomResource):
                  private_cluster_config: Optional[pulumi.Input[pulumi.InputType['PrivateClusterConfigArgs']]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  subnetwork: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  workstation_cluster_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -293,7 +274,6 @@ class WorkstationCluster(pulumi.CustomResource):
             __props__.__dict__["private_cluster_config"] = private_cluster_config
             __props__.__dict__["project"] = project
             __props__.__dict__["subnetwork"] = subnetwork
-            __props__.__dict__["validate_only"] = validate_only
             if workstation_cluster_id is None and not opts.urn:
                 raise TypeError("Missing required property 'workstation_cluster_id'")
             __props__.__dict__["workstation_cluster_id"] = workstation_cluster_id
@@ -345,7 +325,6 @@ class WorkstationCluster(pulumi.CustomResource):
         __props__.__dict__["subnetwork"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["workstation_cluster_id"] = None
         return WorkstationCluster(resource_name, opts=opts, __props__=__props__)
 
@@ -478,14 +457,6 @@ class WorkstationCluster(pulumi.CustomResource):
         Time when this resource was most recently updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually apply it.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="workstationClusterId")

--- a/sdk/python/pulumi_google_native/workstations/v1beta/workstation_config.py
+++ b/sdk/python/pulumi_google_native/workstations/v1beta/workstation_config.py
@@ -31,8 +31,7 @@ class WorkstationConfigArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  persistent_directories: Optional[pulumi.Input[Sequence[pulumi.Input['PersistentDirectoryArgs']]]] = None,
                  project: Optional[pulumi.Input[str]] = None,
-                 running_timeout: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None):
+                 running_timeout: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a WorkstationConfig resource.
         :param pulumi.Input[str] workstation_config_id: Required. ID to use for the config.
@@ -47,7 +46,6 @@ class WorkstationConfigArgs:
         :param pulumi.Input[str] name: Full name of this resource.
         :param pulumi.Input[Sequence[pulumi.Input['PersistentDirectoryArgs']]] persistent_directories: Directories to persist across workstation sessions.
         :param pulumi.Input[str] running_timeout: How long to wait before automatically stopping a workstation after it started. A value of 0 indicates that workstations using this configuration should never time out. Must be greater than 0 and less than 24 hours if encryption_key is set. Defaults to 12 hours.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually apply it.
         """
         pulumi.set(__self__, "workstation_cluster_id", workstation_cluster_id)
         pulumi.set(__self__, "workstation_config_id", workstation_config_id)
@@ -77,8 +75,6 @@ class WorkstationConfigArgs:
             pulumi.set(__self__, "project", project)
         if running_timeout is not None:
             pulumi.set(__self__, "running_timeout", running_timeout)
-        if validate_only is not None:
-            pulumi.set(__self__, "validate_only", validate_only)
 
     @property
     @pulumi.getter(name="workstationClusterId")
@@ -251,18 +247,6 @@ class WorkstationConfigArgs:
     def running_timeout(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "running_timeout", value)
 
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> Optional[pulumi.Input[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually apply it.
-        """
-        return pulumi.get(self, "validate_only")
-
-    @validate_only.setter
-    def validate_only(self, value: Optional[pulumi.Input[bool]]):
-        pulumi.set(self, "validate_only", value)
-
 
 class WorkstationConfig(pulumi.CustomResource):
     @overload
@@ -282,7 +266,6 @@ class WorkstationConfig(pulumi.CustomResource):
                  persistent_directories: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentDirectoryArgs']]]]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  running_timeout: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  workstation_cluster_id: Optional[pulumi.Input[str]] = None,
                  workstation_config_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -302,7 +285,6 @@ class WorkstationConfig(pulumi.CustomResource):
         :param pulumi.Input[str] name: Full name of this resource.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentDirectoryArgs']]]] persistent_directories: Directories to persist across workstation sessions.
         :param pulumi.Input[str] running_timeout: How long to wait before automatically stopping a workstation after it started. A value of 0 indicates that workstations using this configuration should never time out. Must be greater than 0 and less than 24 hours if encryption_key is set. Defaults to 12 hours.
-        :param pulumi.Input[bool] validate_only: If set, validate the request and preview the review, but do not actually apply it.
         :param pulumi.Input[str] workstation_config_id: Required. ID to use for the config.
         """
         ...
@@ -342,7 +324,6 @@ class WorkstationConfig(pulumi.CustomResource):
                  persistent_directories: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentDirectoryArgs']]]]] = None,
                  project: Optional[pulumi.Input[str]] = None,
                  running_timeout: Optional[pulumi.Input[str]] = None,
-                 validate_only: Optional[pulumi.Input[bool]] = None,
                  workstation_cluster_id: Optional[pulumi.Input[str]] = None,
                  workstation_config_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -367,7 +348,6 @@ class WorkstationConfig(pulumi.CustomResource):
             __props__.__dict__["persistent_directories"] = persistent_directories
             __props__.__dict__["project"] = project
             __props__.__dict__["running_timeout"] = running_timeout
-            __props__.__dict__["validate_only"] = validate_only
             if workstation_cluster_id is None and not opts.urn:
                 raise TypeError("Missing required property 'workstation_cluster_id'")
             __props__.__dict__["workstation_cluster_id"] = workstation_cluster_id
@@ -425,7 +405,6 @@ class WorkstationConfig(pulumi.CustomResource):
         __props__.__dict__["running_timeout"] = None
         __props__.__dict__["uid"] = None
         __props__.__dict__["update_time"] = None
-        __props__.__dict__["validate_only"] = None
         __props__.__dict__["workstation_cluster_id"] = None
         __props__.__dict__["workstation_config_id"] = None
         return WorkstationConfig(resource_name, opts=opts, __props__=__props__)
@@ -583,14 +562,6 @@ class WorkstationConfig(pulumi.CustomResource):
         Time when this resource was most recently updated.
         """
         return pulumi.get(self, "update_time")
-
-    @property
-    @pulumi.getter(name="validateOnly")
-    def validate_only(self) -> pulumi.Output[Optional[bool]]:
-        """
-        If set, validate the request and preview the review, but do not actually apply it.
-        """
-        return pulumi.get(self, "validate_only")
 
     @property
     @pulumi.getter(name="workstationClusterId")


### PR DESCRIPTION
Previously, `validateOnly` was a property of the `eventarc.Trigger` resource (and some others). However, this property is an API implementation detail: API client may specify it to get a "dry run" without the actual action. See https://google.aip.dev/163#guidance

This PR ignores all query parameters with this specific name while building SDKs and resource URLs. As a result, we will never set it and it will stay `false` by default.

Fix https://github.com/pulumi/pulumi-google-native/issues/865