### PR TITLE
fix: Disable autonaming for iam/v1:OrganizationRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bug fixes:
   [#890](https://github.com/pulumi/pulumi-google-native/pull/890)
 - Fix issues when diffing config property keys with special characters
   [#911](https://github.com/pulumi/pulumi-google-native/pull/911)
+- Disable autonaming for `google-native:iam:v1/OrganizationRole` 
+  [#905](https://github.com/pulumi/pulumi-google-native/pull/905)
 
 ## v0.30.0 (2023-04-14)
 Upstream breaking changes:

--- a/provider/pkg/gen/overrides.go
+++ b/provider/pkg/gen/overrides.go
@@ -186,6 +186,7 @@ var autonameExcludes = codegen.NewStringSet(
 	"google-native:monitoring/v3:UptimeCheckConfig",
 	"google-native:vpcaccess/v1:Connector",
 	"google-native:iam/v1:Role",
+	"google-native:iam/v1:OrganizationRole",
 	"google-native:run/v2:Service")
 
 // metadataOverrides is a map of values static overlays to merge into the metadata for


### PR DESCRIPTION
- Same issue as #209 which was fixed in #646
