### PR TITLE
Add codecov to this repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,10 @@ jobs:
         path: ${{ github.workspace }}/bin/provider.tar.gz
     - name: Test Provider Library
       run: make test_provider
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -129,6 +129,10 @@ jobs:
         path: ${{ github.workspace }}/bin/provider.tar.gz
     - name: Test Provider Library
       run: make test_provider
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn.lock
 package-lock.json
 
 **/metadata.go
+provider/coverage.txt
 provider/cmd/**/schema.go
 **/version.txt
 **/nuget

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION         := $(shell pulumictl get version)
 PROVIDER_PKGS   := $(shell cd ./provider && go list ./...)
 WORKING_DIR     := $(shell pwd)
 
-JAVA_GEN 		 := pulumi-java-gen
+JAVA_GEN		 := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 
 VERSION_FLAGS   := -ldflags "-X github.com/pulumi/pulumi-${PACK}/provider/pkg/version.Version=${VERSION}"
@@ -39,7 +39,7 @@ debug_provider::
 	(cd provider && go install -gcflags="all=-N -l" $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(PROVIDER))
 
 test_provider::
-	(cd provider && go test -v $(PROVIDER_PKGS))
+	(cd provider && go test -v -coverprofile="coverage.txt" $(PROVIDER_PKGS))
 
 lint_provider:: provider # lint the provider code
 	cd provider && GOGC=20 golangci-lint run -c ../.golangci.yml

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ debug_provider::
 	(cd provider && go install -gcflags="all=-N -l" $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(PROVIDER))
 
 test_provider::
-	(cd provider && go test -v -coverprofile="coverage.txt" $(PROVIDER_PKGS))
+	(cd provider && go test -v -coverprofile="coverage.txt" -coverpkg=./... $(PROVIDER_PKGS))
 
 lint_provider:: provider # lint the provider code
 	cd provider && GOGC=20 golangci-lint run -c ../.golangci.yml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Modifies `make test_provider` to collect coverage profile files and adds a ci action to push them to codecov.

An example of the codecov analysis can be see in the comment below and at https://app.codecov.io/gh/pulumi/pulumi-google-native/commit/e2e535ad17dd7eee6a5509a3495a0a6dad2ca7b3