### PR TITLE
Update Go to 1.21, Go and .NET versions in CI

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.x"
+        go-version: "1.21.x"
 
     - name: Install Pulumi CLI
       uses: pulumi/setup-pulumi@v2
@@ -31,12 +31,8 @@ runs:
     - name: Setup DotNet
       if: inputs.skip_dotnet_and_java != 'true'
       uses: actions/setup-dotnet@v3
-      # Codegen emits 3.1 projects but we want to start using 6.0 
-      # Once codegen is updated, 3.1 can be removed.
       with:
-        dotnet-version: |
-          3.1.301
-          6.0.x
+        dotnet-version: 6.0.x
 
     - name: Setup Java
       if: inputs.skip_dotnet_and_java != 'true'

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-google-native/provider
 
-go 1.19
+go 1.21
 
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible


### PR DESCRIPTION
Unblock https://github.com/pulumi/pulumi-google-native/actions/runs/7030180233/job/19129224137