### PR TITLE
Mark pulumi-google-native as unmaintained in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 # Native Google Cloud Pulumi Provider (developer preview)
 
+> **This provider is unmaintained.** New and existing users should prefer the [Google Cloud Classic Provider (`pulumi-gcp`)](https://github.com/pulumi/pulumi-gcp), which is actively maintained and covers the Google Cloud surface area. No further releases or fixes are planned for `pulumi-google-native`.
+
 The native Google Cloud Provider for Pulumi lets you provision Google Cloud resources in your cloud programs.
 
 This provider uses the Google Cloud REST API directly and therefore provides full access to Google Cloud.
-
-> **Warning:** Google Cloud Native is available in developer preview. While upstream changes continue to be delivered, active development is paused. Breaking changes may be introduced in minor version releases.
 
 To use this package, [install the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
 


### PR DESCRIPTION
## Summary
- Replaces the existing "developer preview / active development is paused" warning with an explicit unmaintained notice at the top of the README.
- Points users at `pulumi-gcp` as the recommended alternative and notes that no further releases or fixes are planned.

## Test plan
- [ ] Verify the rendered README on GitHub shows the notice above the project description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)